### PR TITLE
Improve CI Github Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,5 @@
+name: CI
+
 on:
   push:
     branches:
@@ -9,8 +11,18 @@ on:
         description: 'The branch, tag or SHA to checkout'
         default: main
         type: string
+
 jobs:
-  test:
+  lint-ruby:
+    name: Lint Ruby
+    uses: alphagov/govuk-infrastructure/.github/workflows/rubocop.yml@main
+
+  security-analysis:
+    name: Security Analysis
+    uses: alphagov/govuk-infrastructure/.github/workflows/brakeman.yml@main
+
+  test-ruby:
+    name: Test Ruby
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -20,4 +32,3 @@ jobs:
         with:
           bundler-cache: true
       - run: bin/rake
-      - run: bundle exec brakeman

--- a/Rakefile
+++ b/Rakefile
@@ -5,4 +5,4 @@ require_relative "config/application"
 
 Rails.application.load_tasks
 
-task default: %i[spec rubocop]
+task default: %i[spec]

--- a/lib/tasks/rubocop.rake
+++ b/lib/tasks/rubocop.rake
@@ -1,3 +1,0 @@
-require "rubocop/rake_task"
-
-RuboCop::RakeTask.new


### PR DESCRIPTION
- Give it the expected name ("CI") that downstream workflows expect
- Change default Rake task to only run specs (and remove custom Rubocop Rake task)
- Use `govuk-infrastructure` upstream workflows to run linting and Brakeman