### PR TITLE
Add trivial initial search endpoint

### DIFF
--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -1,0 +1,5 @@
+class SearchesController < ApplicationController
+  def show
+    render json: {}
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  resource :search, only: [:show]
+
   # Healthchecks
   get "/healthcheck/live", to: proc { [200, {}, %w[OK]] }
   get "/healthcheck/ready", to: GovukHealthcheck.rack_response

--- a/spec/requests/search_request_spec.rb
+++ b/spec/requests/search_request_spec.rb
@@ -1,0 +1,10 @@
+RSpec.describe "Making a search request" do
+  describe "GET /search.json" do
+    it "returns HTTP 200 and an empty JSON object" do
+      get "/search.json"
+
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body)).to eq({})
+    end
+  end
+end


### PR DESCRIPTION
- Add route and action for `/search.json` to return empty JSON object