### PR TITLE
Return "minimal viable" search response

### DIFF
--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -1,5 +1,9 @@
 class SearchesController < ApplicationController
   def show
-    render json: {}
+    render json: {
+      results: [],
+      total: 0,
+      start: 0,
+    }
   end
 end

--- a/docs/openapi/specification.yml
+++ b/docs/openapi/specification.yml
@@ -1,0 +1,36 @@
+openapi: '3.0.0'
+info:
+  title: GOV.UK Search API
+  version: 2.0.0-alpha
+
+paths:
+  /search:
+    get:
+      summary: Perform a search
+      description: Returns search results
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SearchResponse'
+
+components:
+  schemas:
+    SearchResponse:
+      type: object
+      properties:
+        results:
+          type: array
+          items:
+            type: string
+          default: []
+          maxItems: 0
+          description: 'The array of search results. Currently always empty (not yet implemented).'
+        total:
+          type: integer
+          description: 'The total number of items that match the search criteria.'
+        start:
+          type: integer
+          description: 'The starting index for the returned search results.'

--- a/spec/requests/search_request_spec.rb
+++ b/spec/requests/search_request_spec.rb
@@ -1,10 +1,14 @@
 RSpec.describe "Making a search request" do
   describe "GET /search.json" do
-    it "returns HTTP 200 and an empty JSON object" do
+    it "successfully returns a minimally acceptable zero results response for finder-frontend" do
       get "/search.json"
 
       expect(response).to have_http_status(:ok)
-      expect(JSON.parse(response.body)).to eq({})
+      expect(JSON.parse(response.body)).to eq({
+        "results" => [],
+        "total" => 0,
+        "start" => 0,
+      })
     end
   end
 end


### PR DESCRIPTION
Finder Frontend expects at a minimum a response containing an array of results, a total result count, and a start index. This adds a hardcoded zero results response for any query that is just enough to be able to be displayed by it.

- Add necessary fields to search endpoint response
- Add basic OpenAPI schema to docs