### PR TITLE
Create basic `Document` domain model as "schema MVP"

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -1,0 +1,17 @@
+# Domain model for a single piece of content on GOV.UK that can be stored in, and retrieved from, a
+# search engine
+#
+# @attr_reader [String] content_id A unique UUID for this document across all GOV.UK content
+# @attr_reader [String, nil] title The title of the document
+Document = Data.define(:content_id, :title) do
+  # Creates a document from a message hash from the "published documents" message queue.
+  #
+  # @param message_hash [Hash] The message hash to create the document from.
+  # @return [Document] The newly created Document instance.
+  def self.from_message_hash(message_hash)
+    new(
+      content_id: message_hash.fetch("content_id"),
+      title: message_hash["title"],
+    )
+  end
+end

--- a/app/queue_consumers/published_documents_queue_consumer.rb
+++ b/app/queue_consumers/published_documents_queue_consumer.rb
@@ -1,6 +1,7 @@
 class PublishedDocumentsQueueConsumer
   def process(message)
-    Rails.logger.info(message.payload)
+    document = Document.from_message_hash(message.payload)
+    Rails.logger.info("Received message: #{document.content_id} ('#{document.title}')")
     message.ack
   end
 end

--- a/spec/fixtures/files/message_queue/message.json
+++ b/spec/fixtures/files/message_queue/message.json
@@ -1,0 +1,572 @@
+{
+  "title": "Ebola medal for over 3000 heroes",
+  "public_updated_at": "2015-06-11T11:14:00Z",
+  "publishing_app": "whitehall",
+  "rendering_app": "government-frontend",
+  "update_type": "republish",
+  "phase": "live",
+  "analytics_identifier": null,
+  "document_type": "press_release",
+  "schema_name": "news_article",
+  "first_published_at": "2015-06-11T11:14:00Z",
+  "base_path": "/government/news/ebola-medal-for-over-3000-heroes",
+  "description": "A new medal has been created to recognise the bravery and hard work of people who have helped to stop the spread of Ebola.",
+  "details": {
+    "body": "<div class=\"govspeak\"><p>The government has today (11 June 2015) set out the details of a new medal that will recognise the bravery and hard work of thousands of people who helped to tackle Ebola in West Africa.</p>\n\n<p>The medal is expected to go to over 3,000 people who travelled from the UK to work in high risk areas to stop the spread of the disease.</p>\n\n<p>This is the first time a medal has been created specifically to recognise those who have tackled a humanitarian crisis and is in recognition of the highly dangerous environment that workers were required to enter.</p>\n\n<p>The medal has been designed by John Bergdahl, who has been an engraver for over 40 years and recently designed a new coin set to celebrate the birth of Prince George. Mr Bergdahl’s design was chosen following a competition run by the Royal Mint Advisory Committee. It shows a flame on a background depicting the Ebola virus – above this are the words “For Service” and below  “Ebola Epidemic West Africa”.</p>\n\n<p>The obverse bears a portrait of Her Majesty The Queen designed by Ian Rank-Broadley.</p>\n\n<p>The medal will be awarded to military and civilian personnel who have been tackling Ebola on behalf of the UK in West Africa such as people from our armed forces, doctors and nurses from the <abbr title=\"National Health Service\">NHS</abbr>, laboratory specialists and members of the civil service and non-governmental organisations. Eligibility is set out in detail in a <a href=\"https://www.gov.uk/government/publications/ebola-medal-for-service-in-west-africa\" class=\"govuk-link\">command paper</a> published today.</p>\n\n<p>The first awards of the medal will be made as early as this summer and will be ongoing thereafter. The Prime Minister will also host a summer reception to congratulate in person some of the recipients.</p>\n\n<p>The Prime Minister, David Cameron, said:</p>\n\n<blockquote>\n  <p>The Ebola outbreak was one of the most devastating epidemics of our generation but we managed to stop its spread thanks to the hard work of British people who travelled to West Africa.</p>\n\n  <p class=\"last-child\">As a result of their efforts, many lives were saved and the outbreak contained.</p>\n</blockquote>\n\n<blockquote>\n  <p class=\"last-child\">This medal is about paying tribute to those people. They put themselves at considerable personal risk and we owe them a debt of gratitude.</p>\n</blockquote>\n\n<h2 id=\"notes-to-editors\">Notes to editors</h2>\n\n<p>All those eligible should receive their medal during the course of this year, other than those who need to self-nominate. Read <a href=\"https://www.gov.uk/government/publications/ebola-medal\" class=\"govuk-link\">more information on self-nomination</a>.</p>\n\n<h3 id=\"about-the-medal\">About the medal</h3>\n\n<p>The Committee on the Grant of Honours, Decorations and Medals recommended specific eligibility criteria to Her Majesty The Queen, who graciously approved them.</p>\n\n<p>Eligible personnel, including civil servants, the military, UK Med, Public Health England, Stabilisation Unit, Conflict Humanitarian and Security Department (CHASE) Operations Team, UK nationals who worked for DFID-funded NGOs supporting government efforts who served at least 21 days of continuous service (or 30 days of accumulated service) within the geographical territories of Sierra Leone, Liberia, Guinea and their territorial waters, would automatically receive the medal.</p>\n\n<p>The medal will be sent to most people automatically, but a few people who have not gone as part of the UK government effort will need to <a href=\"https://www.gov.uk/government/publications/ebola-medal\" class=\"govuk-link\">nominate themselves</a>.</p>\n\n<p>This new medal has been introduced following approval by Her Majesty The Queen and the Honours and Decorations Committee. The medal will be manufactured in the UK by Worcestershire Medal Service and will be awarded to those eligible continuously from the summer.</p>\n\n<p>Read the PM’s <a rel=\"external\" href=\"http://www.parliament.uk/business/publications/written-questions-answers-statements/written-statement/Commons/2015-06-11/HCWS28\" class=\"govuk-link\">written ministerial statement on the Ebola Medal</a>.</p>\n\n<h3 id=\"about-uk-government-response-to-ebola\">About UK government response to Ebola</h3>\n\n<p>£427 million has been committed to the effort by UK government. Our contribution has included supporting more than half of all the beds available for Ebola patients in Sierra Leone, funded over 100 burial teams, trained 4,000 frontline staff, provided three labs to test one third of all samples collected nationally and delivered over one million <abbr title=\"personal protective equipment\">PPE</abbr> suits and 150 vehicles.</p>\n\n<div class=\"call-to-action\">\n<p>Find our more about the <a href=\"https://www.gov.uk/government/topical-events/ebola-virus-government-response\" class=\"govuk-link\">UK government’s response to Ebola</a>.</p>\n</div>\n\n</div>",
+    "tags": {
+      "topics": [],
+      "browse_pages": []
+    },
+    "image": {
+      "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/default_news_organisation_image_data/file/2/s300_number10.jpg",
+      "caption": null,
+      "alt_text": "",
+      "high_resolution_url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/default_news_organisation_image_data/file/2/s960_number10.jpg"
+    },
+    "political": true,
+    "attachments": [],
+    "change_history": [
+      {
+        "note": "First published.",
+        "public_timestamp": "2015-06-11T12:14:00.000+01:00"
+      }
+    ],
+    "first_public_at": "2015-06-11T12:14:00.000+01:00",
+    "emphasised_organisations": [
+      "705dbea4-8bd7-422e-ba9c-254557f77f81",
+      "96ae61d6-c2a1-48cb-8e67-da9d105ae381"
+    ]
+  },
+  "routes": [
+    {
+      "path": "/government/news/ebola-medal-for-over-3000-heroes",
+      "type": "exact"
+    }
+  ],
+  "redirects": [],
+  "content_id": "f75d26a3-25a4-4c31-beea-a77cada4ce12",
+  "locale": "en",
+  "expanded_links": {
+    "government": [
+      {
+        "content_id": "d4fbc1b9-d47d-4386-af04-ac909f868f92",
+        "title": "2015 Conservative government",
+        "locale": "en",
+        "api_path": "/api/content/government/2015-conservative-government",
+        "base_path": "/government/2015-conservative-government",
+        "document_type": "government",
+        "details": {
+          "started_on": "2015-05-08T00:00:00+00:00",
+          "ended_on": null,
+          "current": true
+        },
+        "links": {}
+      }
+    ],
+    "organisations": [
+      {
+        "content_id": "96ae61d6-c2a1-48cb-8e67-da9d105ae381",
+        "title": "Cabinet Office",
+        "locale": "en",
+        "analytics_identifier": "D2",
+        "api_path": "/api/content/government/organisations/cabinet-office",
+        "base_path": "/government/organisations/cabinet-office",
+        "document_type": "organisation",
+        "schema_name": "organisation",
+        "withdrawn": false,
+        "details": {
+          "acronym": "",
+          "logo": {
+            "crest": "single-identity",
+            "formatted_title": "Cabinet Office"
+          },
+          "brand": "cabinet-office",
+          "default_news_image": {
+            "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/default_news_organisation_image_data/file/148/s300_cabinet-office.jpg",
+            "high_resolution_url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/default_news_organisation_image_data/file/148/s960_cabinet-office.jpg"
+          },
+          "organisation_govuk_status": {
+            "url": null,
+            "status": "live",
+            "updated_at": null
+          }
+        },
+        "links": {}
+      },
+      {
+        "content_id": "db994552-7644-404d-a770-a2fe659c661f",
+        "title": "Department for International Development",
+        "locale": "en",
+        "analytics_identifier": "D8",
+        "api_path": "/api/content/government/organisations/department-for-international-development",
+        "base_path": "/government/organisations/department-for-international-development",
+        "document_type": "organisation",
+        "schema_name": "organisation",
+        "withdrawn": false,
+        "details": {
+          "acronym": "DFID",
+          "logo": {
+            "crest": "single-identity",
+            "formatted_title": "Department<br/>for International <br/>Development"
+          },
+          "brand": "department-for-international-development",
+          "default_news_image": {
+            "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/default_news_organisation_image_data/file/27/s300_DFID-default-image-v2.jpg",
+            "high_resolution_url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/default_news_organisation_image_data/file/27/s960_DFID-default-image-v2.jpg"
+          },
+          "organisation_govuk_status": {
+            "url": "http://www.dfid.gov.uk/",
+            "status": "replaced",
+            "updated_at": "2020-09-02T00:00:00.000+01:00"
+          }
+        },
+        "links": {}
+      },
+      {
+        "content_id": "1343f283-19e9-4fbb-86b1-58c7549d874b",
+        "title": "Public Health England",
+        "locale": "en",
+        "analytics_identifier": "EA480",
+        "api_path": "/api/content/government/organisations/public-health-england",
+        "base_path": "/government/organisations/public-health-england",
+        "document_type": "organisation",
+        "schema_name": "organisation",
+        "withdrawn": false,
+        "details": {
+          "acronym": "PHE",
+          "logo": {
+            "crest": "single-identity",
+            "formatted_title": "Public Health <br/>England"
+          },
+          "brand": "department-of-health",
+          "default_news_image": {
+            "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/default_news_organisation_image_data/file/36/s300_sign5.jpg",
+            "high_resolution_url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/default_news_organisation_image_data/file/36/s960_sign5.jpg"
+          },
+          "organisation_govuk_status": {
+            "url": "https://www.gov.uk/phe",
+            "status": "split",
+            "updated_at": "2021-10-01T00:00:00.000+01:00"
+          }
+        },
+        "links": {}
+      },
+      {
+        "content_id": "705dbea4-8bd7-422e-ba9c-254557f77f81",
+        "title": "Prime Minister's Office, 10 Downing Street",
+        "locale": "en",
+        "analytics_identifier": "OT532",
+        "api_path": "/api/content/government/organisations/prime-ministers-office-10-downing-street",
+        "base_path": "/government/organisations/prime-ministers-office-10-downing-street",
+        "document_type": "organisation",
+        "schema_name": "organisation",
+        "withdrawn": false,
+        "details": {
+          "acronym": "Number 10",
+          "logo": {
+            "crest": "eo",
+            "formatted_title": "Prime Minister&#39;s Office, 10 Downing Street"
+          },
+          "brand": "cabinet-office",
+          "default_news_image": {
+            "url": "https://assets.integration.publishing.service.gov.uk/government/uploads/system/uploads/default_news_organisation_image_data/file/2/s300_number10.jpg",
+            "high_resolution_url": "https://assets.integration.publishing.service.gov.uk/government/uploads/system/uploads/default_news_organisation_image_data/file/2/s960_number10.jpg"
+          },
+          "organisation_govuk_status": {
+            "url": null,
+            "status": "live",
+            "updated_at": null
+          }
+        },
+        "links": {}
+      }
+    ],
+    "original_primary_publishing_organisation": [
+      {
+        "content_id": "705dbea4-8bd7-422e-ba9c-254557f77f81",
+        "title": "Prime Minister's Office, 10 Downing Street",
+        "locale": "en",
+        "analytics_identifier": "OT532",
+        "api_path": "/api/content/government/organisations/prime-ministers-office-10-downing-street",
+        "base_path": "/government/organisations/prime-ministers-office-10-downing-street",
+        "document_type": "organisation",
+        "schema_name": "organisation",
+        "withdrawn": false,
+        "details": {
+          "acronym": "Number 10",
+          "logo": {
+            "crest": "eo",
+            "formatted_title": "Prime Minister&#39;s Office, 10 Downing Street"
+          },
+          "brand": "cabinet-office",
+          "default_news_image": {
+            "url": "https://assets.integration.publishing.service.gov.uk/government/uploads/system/uploads/default_news_organisation_image_data/file/2/s300_number10.jpg",
+            "high_resolution_url": "https://assets.integration.publishing.service.gov.uk/government/uploads/system/uploads/default_news_organisation_image_data/file/2/s960_number10.jpg"
+          },
+          "organisation_govuk_status": {
+            "url": null,
+            "status": "live",
+            "updated_at": null
+          }
+        },
+        "links": {}
+      }
+    ],
+    "people": [
+      {
+        "content_id": "8529186b-c0f1-11e4-8223-005056011aef",
+        "title": "The Rt Hon David Cameron",
+        "locale": "en",
+        "analytics_identifier": null,
+        "api_path": "/api/content/government/people/david-cameron",
+        "base_path": "/government/people/david-cameron",
+        "document_type": "person",
+        "public_updated_at": "2019-11-07T15:02:24Z",
+        "schema_name": "person",
+        "withdrawn": false,
+        "links": {}
+      }
+    ],
+    "primary_publishing_organisation": [
+      {
+        "content_id": "705dbea4-8bd7-422e-ba9c-254557f77f81",
+        "title": "Prime Minister's Office, 10 Downing Street",
+        "locale": "en",
+        "analytics_identifier": "OT532",
+        "api_path": "/api/content/government/organisations/prime-ministers-office-10-downing-street",
+        "base_path": "/government/organisations/prime-ministers-office-10-downing-street",
+        "document_type": "organisation",
+        "schema_name": "organisation",
+        "withdrawn": false,
+        "details": {
+          "acronym": "Number 10",
+          "logo": {
+            "crest": "eo",
+            "formatted_title": "Prime Minister&#39;s Office, 10 Downing Street"
+          },
+          "brand": "cabinet-office",
+          "default_news_image": {
+            "url": "https://assets.integration.publishing.service.gov.uk/government/uploads/system/uploads/default_news_organisation_image_data/file/2/s300_number10.jpg",
+            "high_resolution_url": "https://assets.integration.publishing.service.gov.uk/government/uploads/system/uploads/default_news_organisation_image_data/file/2/s960_number10.jpg"
+          },
+          "organisation_govuk_status": {
+            "url": null,
+            "status": "live",
+            "updated_at": null
+          }
+        },
+        "links": {}
+      }
+    ],
+    "roles": [
+      {
+        "content_id": "845e5811-c0f1-11e4-8223-005056011aef",
+        "title": "Prime Minister",
+        "locale": "en",
+        "analytics_identifier": null,
+        "api_path": "/api/content/government/ministers/prime-minister",
+        "base_path": "/government/ministers/prime-minister",
+        "document_type": "ministerial_role",
+        "public_updated_at": "2022-10-05T07:44:54Z",
+        "schema_name": "role",
+        "withdrawn": false,
+        "details": {
+          "body": [
+            {
+              "content": "The Prime Minister is the leader of His Majesty's Government and is ultimately responsible for the policy and decisions of the government.\r\n\r\nAs leader of the UK government the Prime Minister also:\r\n\r\n* oversees the [operation of the Civil Service](https://www.gov.uk/government/ministers/minister-for-the-civil-service) and government agencies\r\n* chooses members of the government\r\n* is the principal government figure in the House of Commons\r\n\r\nAs [Minister for the Union](https://www.gov.uk/government/ministers/minister-for-the-union), the Prime Minister works to ensure that all of government is acting on behalf of the entire United Kingdom: England, Northern Ireland, Scotland, and Wales.\r\n",
+              "content_type": "text/govspeak"
+            },
+            {
+              "content_type": "text/html",
+              "content": "<p>The Prime Minister is the leader of His Majesty’s Government and is ultimately responsible for the policy and decisions of the government.</p>\n\n<p>As leader of the UK government the Prime Minister also:</p>\n\n<ul>\n  <li>oversees the <a href=\"https://www.gov.uk/government/ministers/minister-for-the-civil-service\">operation of the Civil Service</a> and government agencies</li>\n  <li>chooses members of the government</li>\n  <li>is the principal government figure in the House of Commons</li>\n</ul>\n\n<p>As <a href=\"https://www.gov.uk/government/ministers/minister-for-the-union\">Minister for the Union</a>, the Prime Minister works to ensure that all of government is acting on behalf of the entire United Kingdom: England, Northern Ireland, Scotland, and Wales.</p>\n"
+            }
+          ],
+          "role_payment_type": null,
+          "seniority": 0,
+          "whip_organisation": {}
+        },
+        "links": {}
+      }
+    ],
+    "suggested_ordered_related_items": [
+      {
+        "content_id": "eecb3c7e-58bd-453f-a858-3c60eafb3056",
+        "title": "Ebola medal for service in West Africa",
+        "locale": "en",
+        "analytics_identifier": null,
+        "api_path": "/api/content/government/publications/ebola-medal-for-service-in-west-africa",
+        "base_path": "/government/publications/ebola-medal-for-service-in-west-africa",
+        "document_type": "policy_paper",
+        "public_updated_at": "2015-06-11T11:14:56Z",
+        "schema_name": "publication",
+        "withdrawn": false,
+        "links": {}
+      },
+      {
+        "content_id": "5eb7e1ad-7631-11e4-a3cb-005056011aef",
+        "title": "HMT Public Expenditure Statistical Analyses (PESA)",
+        "locale": "en",
+        "analytics_identifier": null,
+        "api_path": "/api/content/government/collections/public-expenditure-statistical-analyses-pesa",
+        "base_path": "/government/collections/public-expenditure-statistical-analyses-pesa",
+        "document_type": "document_collection",
+        "public_updated_at": "2023-07-19T14:20:54Z",
+        "schema_name": "document_collection",
+        "withdrawn": false,
+        "links": {}
+      },
+      {
+        "content_id": "674e6678-08cb-4155-a0e7-0a7563d2404b",
+        "title": "UK-New Zealand Mutual Recognition Agreement",
+        "locale": "en",
+        "analytics_identifier": null,
+        "api_path": "/api/content/guidance/uk-new-zealand-mutual-recognition-agreement",
+        "base_path": "/guidance/uk-new-zealand-mutual-recognition-agreement",
+        "document_type": "detailed_guide",
+        "public_updated_at": "2019-03-12T00:00:00Z",
+        "schema_name": "detailed_guide",
+        "withdrawn": false,
+        "links": {}
+      },
+      {
+        "content_id": "5eb7e008-7631-11e4-a3cb-005056011aef",
+        "title": "Bilateral treaties published in the Country Series",
+        "locale": "en",
+        "analytics_identifier": null,
+        "api_path": "/api/content/government/collections/command-papers-by-country-2013",
+        "base_path": "/government/collections/command-papers-by-country-2013",
+        "document_type": "document_collection",
+        "public_updated_at": "2019-08-28T22:05:52Z",
+        "schema_name": "document_collection",
+        "withdrawn": false,
+        "links": {}
+      }
+    ],
+    "taxons": [
+      {
+        "content_id": "668cd623-c7a8-4159-9575-90caac36d4b4",
+        "title": "Community and society",
+        "locale": "en",
+        "analytics_identifier": null,
+        "api_path": "/api/content/society-and-culture/community-and-society",
+        "base_path": "/society-and-culture/community-and-society",
+        "document_type": "taxon",
+        "public_updated_at": "2018-08-22T13:12:16Z",
+        "schema_name": "taxon",
+        "withdrawn": false,
+        "description": null,
+        "details": {
+          "internal_name": "Community and society [PA]",
+          "notes_for_editors": "",
+          "visible_to_departmental_editors": false
+        },
+        "phase": "live",
+        "links": {
+          "parent_taxons": [
+            {
+              "content_id": "e2ca2f1a-0ff3-43ce-b813-16645ff27904",
+              "title": "Society and culture",
+              "locale": "en",
+              "analytics_identifier": null,
+              "api_path": "/api/content/society-and-culture",
+              "base_path": "/society-and-culture",
+              "document_type": "taxon",
+              "public_updated_at": "2018-09-16T20:31:27Z",
+              "schema_name": "taxon",
+              "withdrawn": false,
+              "description": "",
+              "details": {
+                "internal_name": "Society and culture",
+                "notes_for_editors": "",
+                "visible_to_departmental_editors": true
+              },
+              "phase": "live",
+              "links": {
+                "root_taxon": [
+                  {
+                    "content_id": "f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a",
+                    "title": "GOV.UK homepage",
+                    "locale": "en",
+                    "analytics_identifier": null,
+                    "api_path": "/api/content/",
+                    "base_path": "/",
+                    "document_type": "homepage",
+                    "public_updated_at": "2023-06-28T09:32:34Z",
+                    "schema_name": "homepage",
+                    "withdrawn": false,
+                    "links": {}
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "content_id": "c31256e8-f328-462b-993f-dce50b7892e9",
+        "title": "Infectious diseases",
+        "locale": "en",
+        "analytics_identifier": null,
+        "api_path": "/api/content/health-and-social-care/health-protection-infectious-diseases",
+        "base_path": "/health-and-social-care/health-protection-infectious-diseases",
+        "document_type": "taxon",
+        "public_updated_at": "2018-08-22T12:56:17Z",
+        "schema_name": "taxon",
+        "withdrawn": false,
+        "description": null,
+        "details": {
+          "internal_name": "Infectious diseases [T]",
+          "notes_for_editors": "",
+          "visible_to_departmental_editors": false
+        },
+        "phase": "live",
+        "links": {
+          "parent_taxons": [
+            {
+              "content_id": "30ba2d05-d0d6-4978-a5d6-707511894111",
+              "title": "Health protection",
+              "locale": "en",
+              "analytics_identifier": null,
+              "api_path": "/api/content/health-and-social-care/health-protection",
+              "base_path": "/health-and-social-care/health-protection",
+              "document_type": "taxon",
+              "public_updated_at": "2019-03-11T14:19:39Z",
+              "schema_name": "taxon",
+              "withdrawn": false,
+              "description": "",
+              "details": {
+                "internal_name": "Health protection",
+                "notes_for_editors": "",
+                "visible_to_departmental_editors": false
+              },
+              "phase": "live",
+              "links": {
+                "parent_taxons": [
+                  {
+                    "content_id": "d6a4884e-769d-4b81-8ba5-b64394362d92",
+                    "title": "Public health",
+                    "locale": "en",
+                    "analytics_identifier": null,
+                    "api_path": "/api/content/health-and-social-care/public-health",
+                    "base_path": "/health-and-social-care/public-health",
+                    "document_type": "taxon",
+                    "public_updated_at": "2018-09-17T15:15:14Z",
+                    "schema_name": "taxon",
+                    "withdrawn": false,
+                    "description": "",
+                    "details": {
+                      "internal_name": "Public health",
+                      "notes_for_editors": "",
+                      "visible_to_departmental_editors": false
+                    },
+                    "phase": "live",
+                    "links": {
+                      "parent_taxons": [
+                        {
+                          "content_id": "8124ead8-8ebc-4faf-88ad-dd5cbcc92ba8",
+                          "title": "Health and social care",
+                          "locale": "en",
+                          "analytics_identifier": null,
+                          "api_path": "/api/content/health-and-social-care",
+                          "base_path": "/health-and-social-care",
+                          "document_type": "taxon",
+                          "public_updated_at": "2018-09-16T20:30:51Z",
+                          "schema_name": "taxon",
+                          "withdrawn": false,
+                          "description": "",
+                          "details": {
+                            "internal_name": "Health and social care",
+                            "notes_for_editors": "",
+                            "visible_to_departmental_editors": true
+                          },
+                          "phase": "live",
+                          "links": {
+                            "root_taxon": [
+                              {
+                                "content_id": "f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a",
+                                "title": "GOV.UK homepage",
+                                "locale": "en",
+                                "analytics_identifier": null,
+                                "api_path": "/api/content/",
+                                "base_path": "/",
+                                "document_type": "homepage",
+                                "public_updated_at": "2023-06-28T09:32:34Z",
+                                "schema_name": "homepage",
+                                "withdrawn": false,
+                                "links": {}
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "available_translations": [
+      {
+        "title": "Ebola medal for over 3000 heroes",
+        "public_updated_at": "2015-06-11T11:14:00Z",
+        "analytics_identifier": null,
+        "document_type": "press_release",
+        "schema_name": "news_article",
+        "base_path": "/government/news/ebola-medal-for-over-3000-heroes",
+        "api_path": "/api/content/government/news/ebola-medal-for-over-3000-heroes",
+        "withdrawn": true,
+        "content_id": "f75d26a3-25a4-4c31-beea-a77cada4ce12",
+        "locale": "en"
+      }
+    ]
+  },
+  "user_journey_document_supertype": "thing",
+  "email_document_supertype": "announcements",
+  "government_document_supertype": "press-releases",
+  "content_purpose_subgroup": "news",
+  "content_purpose_supergroup": "news_and_communications",
+  "withdrawn_notice": {
+    "explanation": "<div class=\"govspeak\"><p>This news story has been withdrawn because it’s over 4 years old. See <a href=\"https://www.gov.uk/search/news-and-communications?organisations%5B%5D=public-health-england&amp;parent=public-health-england\" class=\"govuk-link\">PHE’s latest news</a>.</p>\n</div>",
+    "withdrawn_at": "2019-06-19T15:16:59Z"
+  },
+  "publishing_request_id": "2776-1656074746.518-10.13.2.120-11082",
+  "govuk_request_id": "21-1695042279.005-10.1.22.189-3806",
+  "links": {
+    "government": [
+      "d4fbc1b9-d47d-4386-af04-ac909f868f92"
+    ],
+    "organisations": [
+      "96ae61d6-c2a1-48cb-8e67-da9d105ae381",
+      "db994552-7644-404d-a770-a2fe659c661f",
+      "1343f283-19e9-4fbb-86b1-58c7549d874b",
+      "705dbea4-8bd7-422e-ba9c-254557f77f81"
+    ],
+    "original_primary_publishing_organisation": [
+      "705dbea4-8bd7-422e-ba9c-254557f77f81"
+    ],
+    "people": [
+      "8529186b-c0f1-11e4-8223-005056011aef"
+    ],
+    "primary_publishing_organisation": [
+      "705dbea4-8bd7-422e-ba9c-254557f77f81"
+    ],
+    "roles": [
+      "845e5811-c0f1-11e4-8223-005056011aef"
+    ],
+    "suggested_ordered_related_items": [
+      "eecb3c7e-58bd-453f-a858-3c60eafb3056",
+      "3574443a-b039-408f-b45c-be353fc7ede5",
+      "5eb7e1ad-7631-11e4-a3cb-005056011aef",
+      "674e6678-08cb-4155-a0e7-0a7563d2404b",
+      "5eb7e008-7631-11e4-a3cb-005056011aef"
+    ],
+    "taxons": [
+      "668cd623-c7a8-4159-9575-90caac36d4b4",
+      "c31256e8-f328-462b-993f-dce50b7892e9"
+    ]
+  },
+  "payload_version": 65861808
+}

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -1,0 +1,26 @@
+RSpec.describe Document do
+  describe ".from_message_hash" do
+    subject(:document) { described_class.from_message_hash(message_hash) }
+
+    context "with a valid message hash" do
+      let(:message_hash) { json_fixture_as_hash("message_queue/message.json") }
+
+      it "maps the message onto a Document" do
+        expected_document = described_class.new(
+          content_id: "f75d26a3-25a4-4c31-beea-a77cada4ce12",
+          title: "Ebola medal for over 3000 heroes",
+        )
+
+        expect(document).to eq(expected_document)
+      end
+    end
+
+    context "with a message hash missing a content ID" do
+      let(:message_hash) { { "title" => "I'm incomplete" } }
+
+      it "raises an error" do
+        expect { document }.to raise_error(KeyError)
+      end
+    end
+  end
+end

--- a/spec/queue_consumers/published_documents_queue_consumer_spec.rb
+++ b/spec/queue_consumers/published_documents_queue_consumer_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe PublishedDocumentsQueueConsumer do
 
   describe "when receiving an incoming message" do
     let(:message) { GovukMessageQueueConsumer::MockMessage.new(payload) }
-    let(:payload) { { "hello" => "world" } }
+    let(:payload) { json_fixture_as_hash("message_queue/message.json") }
 
     before do
       allow(Rails.logger).to receive(:info)
@@ -19,7 +19,8 @@ RSpec.describe PublishedDocumentsQueueConsumer do
     end
 
     it "logs the payload of incoming messages" do
-      expect(Rails.logger).to have_received(:info).with(payload)
+      expect(Rails.logger).to have_received(:info)
+        .with("Received message: f75d26a3-25a4-4c31-beea-a77cada4ce12 ('Ebola medal for over 3000 heroes')")
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,4 +29,6 @@ RSpec.configure do |config|
   config.mock_with :rspec do |mocks|
     mocks.verify_partial_doubles = true # Preempting v4 default
   end
+
+  config.include FixtureHelpers
 end

--- a/spec/support/fixture_helpers.rb
+++ b/spec/support/fixture_helpers.rb
@@ -1,0 +1,9 @@
+module FixtureHelpers
+  # Parses a JSON fixture file and returns its contents as a hash.
+  #
+  # @param path [String] The path to the JSON fixture file.
+  # @return [Hash] The contents of the JSON fixture file as a hash.
+  def json_fixture_as_hash(path)
+    JSON.parse(file_fixture(path).read)
+  end
+end


### PR DESCRIPTION
- Added `Document` domain model and ability to construct it from a message queue message
- Changed `PublishedDocumentsQueueConsumer` to only log content_id and title of incoming messages (instead of entire payload)
- Added fixture for a message and consume it from tests
- Added helper method for tests to parse fixture JSON file into hash