### PR TITLE
Add basic error logging to MQ consumer

### DIFF
--- a/app/commands/consume_published_document_from_message_queue.rb
+++ b/app/commands/consume_published_document_from_message_queue.rb
@@ -19,5 +19,13 @@ class ConsumePublishedDocumentFromMessageQueue
       ),
     )
     message.ack
+  rescue StandardError => e
+    Rails.logger.error(
+      sprintf(
+        "Failed to handle message\nError: %s\nMessage: %s",
+        e.message,
+        message.inspect,
+      ),
+    )
   end
 end

--- a/spec/commands/consume_published_document_from_message_queue_spec.rb
+++ b/spec/commands/consume_published_document_from_message_queue_spec.rb
@@ -27,5 +27,18 @@ RSpec.describe ConsumePublishedDocumentFromMessageQueue do
       expect(Rails.logger).to have_received(:info)
         .with("Received republish: f75d26a3-25a4-4c31-beea-a77cada4ce12 ('Ebola medal for over 3000 heroes')")
     end
+
+    context "when the message is invalid" do
+      let(:payload) { { "I am" => "not valid" } }
+
+      before do
+        allow(Rails.logger).to receive(:error)
+      end
+
+      it "logs the error" do
+        command.call
+        expect(Rails.logger).to have_received(:error)
+      end
+    end
   end
 end


### PR DESCRIPTION
This will help us investigate issues with some of the messages coming through.