### PR TITLE
Make publishing event pipeline more modular

### DIFF
--- a/lib/publishing_event_pipeline.rb
+++ b/lib/publishing_event_pipeline.rb
@@ -1,0 +1,17 @@
+require "publishing_event_pipeline/configuration"
+require "publishing_event_pipeline/document"
+require "publishing_event_pipeline/document_lifecycle_event"
+
+require "publishing_event_pipeline/message_processor"
+
+require "publishing_event_pipeline/repositories/null_repository"
+
+module PublishingEventPipeline
+  def self.configuration
+    @configuration ||= Configuration.new
+  end
+
+  def self.configure
+    yield(configuration)
+  end
+end

--- a/lib/publishing_event_pipeline/configuration.rb
+++ b/lib/publishing_event_pipeline/configuration.rb
@@ -1,0 +1,9 @@
+module PublishingEventPipeline
+  class Configuration
+    attr_accessor :logger, :repository
+
+    def initialize
+      @logger = Logger.new($stdout)
+    end
+  end
+end

--- a/lib/publishing_event_pipeline/document_lifecycle_event.rb
+++ b/lib/publishing_event_pipeline/document_lifecycle_event.rb
@@ -1,5 +1,3 @@
-require_relative "document"
-
 module PublishingEventPipeline
   # Domain model for a content change event coming through from a publishing system
   class DocumentLifecycleEvent

--- a/lib/publishing_event_pipeline/message_processor.rb
+++ b/lib/publishing_event_pipeline/message_processor.rb
@@ -1,6 +1,3 @@
-require_relative "document_lifecycle_event"
-require_relative "repositories/null_repository"
-
 module PublishingEventPipeline
   # Processes incoming content changes from the publishing message queue.
   class MessageProcessor
@@ -8,7 +5,7 @@ module PublishingEventPipeline
 
     def initialize(
       event_class: DocumentLifecycleEvent,
-      repository: Repositories::NullRepository.new
+      repository: PublishingEventPipeline.configuration.repository
     )
       @event_class = event_class
       @repository = repository

--- a/lib/publishing_event_pipeline/repositories/null_repository.rb
+++ b/lib/publishing_event_pipeline/repositories/null_repository.rb
@@ -1,5 +1,3 @@
-require_relative "../document"
-
 module PublishingEventPipeline
   module Repositories
     # A repository that does nothing, for use until we can integrate with the real product.

--- a/spec/lib/publishing_event_pipeline/document_lifecycle_event_spec.rb
+++ b/spec/lib/publishing_event_pipeline/document_lifecycle_event_spec.rb
@@ -1,5 +1,3 @@
-require "publishing_event_pipeline/document_lifecycle_event"
-
 RSpec.describe PublishingEventPipeline::DocumentLifecycleEvent do
   subject(:event) { described_class.new(message_hash) }
 

--- a/spec/lib/publishing_event_pipeline/message_processor_spec.rb
+++ b/spec/lib/publishing_event_pipeline/message_processor_spec.rb
@@ -1,5 +1,3 @@
-require "publishing_event_pipeline/message_processor"
-
 require "govuk_message_queue_consumer"
 require "govuk_message_queue_consumer/test_helpers"
 

--- a/spec/lib/publishing_event_pipeline/repositories/null_repository_spec.rb
+++ b/spec/lib/publishing_event_pipeline/repositories/null_repository_spec.rb
@@ -1,5 +1,3 @@
-require "publishing_event_pipeline/repositories/null_repository"
-
 RSpec.describe PublishingEventPipeline::Repositories::NullRepository do
   let(:repository) { described_class.new }
   let(:content_id) { "some_content_id" }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,13 @@ require "rspec/rails"
 Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
 GovukTest.configure
 
+# TODO: If the write side of this application is extracted to a separate unit, we will need to
+#   remove this, otherwise it can be made permanent.
+require "publishing_event_pipeline"
+PublishingEventPipeline.configure do |config|
+  config.repository = PublishingEventPipeline::Repositories::NullRepository.new
+end
+
 # See https://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
   config.default_formatter = "doc" if config.files_to_run.one?


### PR DESCRIPTION
We're not sure right now if the write-side of this project is going to remain a part of this application (because we may discover that there is a requirement for shared code between it and the API Rails app), or if they can safely be separated into completely independent units. Until then, this makes the pipeline code a bit more modular if we do want to extract it into another unit.

- Make logger and repository used by `PublishingEventPipeline` configurable, and set configuration in Rake task and tests
- Remove dependency on Rails environment from pipeline Rake task
- Consolidate `require` statements for library code into top level module file