### PR TITLE
Add a basic integration test

### DIFF
--- a/spec/integration/publishing_event_pipeline_spec.rb
+++ b/spec/integration/publishing_event_pipeline_spec.rb
@@ -1,0 +1,36 @@
+require "govuk_message_queue_consumer"
+
+RSpec.describe "Publishing event pipeline" do
+  let(:repository) { PublishingEventPipeline::Repositories::TestRepository.new(documents) }
+  let(:message) { GovukMessageQueueConsumer::MockMessage.new(payload) }
+
+  before do
+    PublishingEventPipeline.configure do |config|
+      config.repository = repository
+    end
+
+    PublishingEventPipeline::MessageProcessor.new.process(message)
+  end
+
+  describe "when a message is received that a document is published" do
+    let(:documents) { {} }
+    let(:payload) { json_fixture_as_hash("message_queue/republish_message.json") }
+
+    it "is added to the repository" do
+      result = repository.get("f75d26a3-25a4-4c31-beea-a77cada4ce12")
+      # TODO: Flesh out the document model and test that it is as expected
+      expect(result).to be_present
+    end
+  end
+
+  describe "when a message is received that a document is unpublished" do
+    let(:documents) { { "966bae6d-223e-4102-a6e5-e874012390e5" => double } }
+    let(:payload) { json_fixture_as_hash("message_queue/gone_message.json") }
+
+    it "is removed from the repository" do
+      result = repository.get("966bae6d-223e-4102-a6e5-e874012390e5")
+      # TODO: Flesh out the document model and test that it is as expected
+      expect(result).to be_nil
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,9 +12,6 @@ GovukTest.configure
 # TODO: If the write side of this application is extracted to a separate unit, we will need to
 #   remove this, otherwise it can be made permanent.
 require "publishing_event_pipeline"
-PublishingEventPipeline.configure do |config|
-  config.repository = PublishingEventPipeline::Repositories::NullRepository.new
-end
 
 # See https://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|

--- a/spec/support/publishing_event_pipeline/repositories/test_repository.rb
+++ b/spec/support/publishing_event_pipeline/repositories/test_repository.rb
@@ -1,0 +1,30 @@
+module PublishingEventPipeline
+  module Repositories
+    # A fake repository for end-to-end testing purposes
+    class TestRepository
+      attr_reader :documents
+
+      def initialize(documents = {})
+        @documents = documents
+      end
+
+      def exists?(content_id)
+        documents.key?(content_id)
+      end
+
+      def get(content_id)
+        documents[content_id]
+      end
+
+      # rubocop:disable Lint/UnusedMethodArgument
+      def put(content_id, document, payload_version: nil)
+        documents[content_id] = document
+      end
+
+      def delete(content_id, payload_version: nil)
+        documents.delete(content_id)
+      end
+      # rubocop:enable Lint/UnusedMethodArgument
+    end
+  end
+end


### PR DESCRIPTION
This end-to-end test verifies that an event from the message queue results in a document being added to a test repository. Eventually we will extend this with more checks on the document content (once we have a more settled document model).