### PR TITLE
Refactor `NullRepository` out into separate module

### DIFF
--- a/lib/publishing_event_pipeline.rb
+++ b/lib/publishing_event_pipeline.rb
@@ -4,8 +4,6 @@ require "publishing_event_pipeline/document_lifecycle_event"
 
 require "publishing_event_pipeline/message_processor"
 
-require "publishing_event_pipeline/repositories/null_repository"
-
 module PublishingEventPipeline
   def self.configuration
     @configuration ||= Configuration.new

--- a/lib/search_repositories/null/null_repository.rb
+++ b/lib/search_repositories/null/null_repository.rb
@@ -1,5 +1,5 @@
-module PublishingEventPipeline
-  module Repositories
+module SearchRepositories
+  module Null
     # A repository that does nothing, for use until we can integrate with the real product.
     class NullRepository
       def put(content_id, document, payload_version: nil)

--- a/lib/tasks/publishing_event_pipeline.rake
+++ b/lib/tasks/publishing_event_pipeline.rake
@@ -1,5 +1,7 @@
 require "govuk_message_queue_consumer"
+
 require "publishing_event_pipeline"
+require "search_repositories/null/null_repository"
 
 # TODO: For now, this lives within the application repository, but we may want to extract it to a
 #   completely separate unit if we can keep dependencies between the read and write sides of this
@@ -29,7 +31,7 @@ namespace :publishing_event_pipeline do
       # TODO: Once we have access to the search product and written a repository for it, this should
       #  be set to the real repository. Until then, this allows us to verify that the pipeline is
       #  working as expected through the logs.
-      config.repository = PublishingEventPipeline::Repositories::NullRepository.new
+      config.repository = SearchRepositories::Null::NullRepository.new
     end
 
     GovukMessageQueueConsumer::Consumer.new(

--- a/spec/lib/search_repositories/null/null_repository_spec.rb
+++ b/spec/lib/search_repositories/null/null_repository_spec.rb
@@ -1,4 +1,6 @@
-RSpec.describe PublishingEventPipeline::Repositories::NullRepository do
+require "search_repositories/null/null_repository"
+
+RSpec.describe SearchRepositories::Null::NullRepository do
   let(:repository) { described_class.new }
   let(:content_id) { "some_content_id" }
   let(:metadata) { { base_path: "/some/path" } }


### PR DESCRIPTION
This can and should exist relatively independently. It could even end up as a separate library shared between the read and write side of the project...