### PR TITLE
Move logic from Rake task to `PEP.run`

### DIFF
--- a/lib/publishing_event_pipeline.rb
+++ b/lib/publishing_event_pipeline.rb
@@ -1,3 +1,5 @@
+require "govuk_message_queue_consumer"
+
 require "publishing_event_pipeline/configuration"
 require "publishing_event_pipeline/document_lifecycle_event"
 
@@ -10,5 +12,14 @@ module PublishingEventPipeline
 
   def self.configure
     yield(configuration)
+  end
+
+  def self.run
+    GovukMessageQueueConsumer::Consumer.new(
+      queue_name: PublishingEventPipeline.configuration.message_queue_name,
+      processor: PublishingEventPipeline::MessageProcessor.new(
+        repository: configuration.repository,
+      ),
+    ).run
   end
 end

--- a/lib/publishing_event_pipeline/configuration.rb
+++ b/lib/publishing_event_pipeline/configuration.rb
@@ -1,6 +1,6 @@
 module PublishingEventPipeline
   class Configuration
-    attr_accessor :logger, :repository
+    attr_accessor :logger, :message_queue_name, :repository
 
     def initialize
       @logger = Logger.new($stdout)

--- a/lib/publishing_event_pipeline/message_processor.rb
+++ b/lib/publishing_event_pipeline/message_processor.rb
@@ -4,11 +4,11 @@ module PublishingEventPipeline
     attr_reader :event_class, :repository
 
     def initialize(
-      event_class: DocumentLifecycleEvent,
-      repository: PublishingEventPipeline.configuration.repository
+      repository:,
+      event_class: DocumentLifecycleEvent
     )
-      @event_class = event_class
       @repository = repository
+      @event_class = event_class
     end
 
     # Implements the callback interface required by `govuk_message_queue_consumer`

--- a/lib/tasks/publishing_event_pipeline.rake
+++ b/lib/tasks/publishing_event_pipeline.rake
@@ -1,5 +1,3 @@
-require "govuk_message_queue_consumer"
-
 require "publishing_event_pipeline"
 require "search_repositories/null/null_repository"
 
@@ -32,12 +30,10 @@ namespace :publishing_event_pipeline do
       #  be set to the real repository. Until then, this allows us to verify that the pipeline is
       #  working as expected through the logs.
       config.repository = SearchRepositories::Null::NullRepository.new
+      config.message_queue_name = ENV.fetch("PUBLISHING_EVENT_MESSAGE_QUEUE_NAME")
     end
 
-    GovukMessageQueueConsumer::Consumer.new(
-      queue_name: ENV.fetch("PUBLISHING_EVENT_MESSAGE_QUEUE_NAME"),
-      processor: PublishingEventPipeline::MessageProcessor.new,
-    ).run
+    PublishingEventPipeline.run
   end
 end
 # rubocop:enable Rails/RakeEnvironment

--- a/spec/integration/publishing_event_pipeline_spec.rb
+++ b/spec/integration/publishing_event_pipeline_spec.rb
@@ -5,11 +5,7 @@ RSpec.describe "Publishing event pipeline" do
   let(:message) { GovukMessageQueueConsumer::MockMessage.new(payload) }
 
   before do
-    PublishingEventPipeline.configure do |config|
-      config.repository = repository
-    end
-
-    PublishingEventPipeline::MessageProcessor.new.process(message)
+    PublishingEventPipeline::MessageProcessor.new(repository:).process(message)
   end
 
   describe "when a message is received that a document is published" do

--- a/spec/lib/publishing_event_pipeline_spec.rb
+++ b/spec/lib/publishing_event_pipeline_spec.rb
@@ -1,0 +1,26 @@
+require "govuk_message_queue_consumer"
+
+RSpec.describe PublishingEventPipeline do
+  describe ".run" do
+    let(:consumer) { instance_double(GovukMessageQueueConsumer::Consumer, run: nil) }
+    let(:repository) { double }
+
+    before do
+      described_class.configure do |config|
+        config.message_queue_name = "test-queue"
+        config.repository = repository
+      end
+
+      allow(GovukMessageQueueConsumer::Consumer).to receive(:new).with(
+        queue_name: "test-queue",
+        processor: an_instance_of(PublishingEventPipeline::MessageProcessor),
+      ).and_return(consumer)
+    end
+
+    it "runs our processor through govuk_message_queue_consumer" do
+      described_class.run
+
+      expect(consumer).to have_received(:run)
+    end
+  end
+end


### PR DESCRIPTION
This moves as much logic as possible from the Rake task (hard to test) to a new `PublishingEventPipeline.run` method (easier to test).