### PR TITLE
Add basic MVP unstructured content extraction

### DIFF
--- a/lib/publishing_event_pipeline.rb
+++ b/lib/publishing_event_pipeline.rb
@@ -1,6 +1,7 @@
 require "govuk_message_queue_consumer"
 
 require "publishing_event_pipeline/configuration"
+require "publishing_event_pipeline/content_extractor"
 require "publishing_event_pipeline/document_lifecycle_event"
 
 require "publishing_event_pipeline/message_processor"

--- a/lib/publishing_event_pipeline/content_extractor.rb
+++ b/lib/publishing_event_pipeline/content_extractor.rb
@@ -1,0 +1,12 @@
+module PublishingEventPipeline
+  # Extracts indexable unstructured content from a publishing event
+  class ContentExtractor
+    # Returns a string of unstructured content
+    def call(message_hash)
+      # TODO: Eventually, this should do something more sophisticated along the lines of what the
+      # existing search-api does in `lib/govuk_index/presenters/indexable_content_presenter.rb`, but
+      # this is a decent enough MVP for now.
+      message_hash.dig("details", "body")
+    end
+  end
+end

--- a/lib/publishing_event_pipeline/document_lifecycle_event.rb
+++ b/lib/publishing_event_pipeline/document_lifecycle_event.rb
@@ -7,7 +7,10 @@ module PublishingEventPipeline
     UNPUBLISH_DOCUMENT_TYPES = %w[gone redirect substitute vanish].freeze
 
     # Creates an instance from a message hash conforming to the publishing schema.
-    def initialize(message_hash)
+    def initialize(
+      message_hash,
+      content_extractor: ContentExtractor.new
+    )
       # These fields *must* be present in the message hash, and we want to fail fast if they're not
       @content_id = message_hash.fetch("content_id")
       @document_type = message_hash.fetch("document_type")
@@ -18,7 +21,7 @@ module PublishingEventPipeline
         @metadata = {
           base_path: message_hash.fetch("base_path"),
         }
-        @content = nil
+        @content = content_extractor.call(message_hash)
       end
     end
 

--- a/spec/integration/publishing_event_pipeline_spec.rb
+++ b/spec/integration/publishing_event_pipeline_spec.rb
@@ -14,11 +14,12 @@ RSpec.describe "Publishing event pipeline" do
 
     it "is added to the repository" do
       result = repository.get("f75d26a3-25a4-4c31-beea-a77cada4ce12")
-      # TODO: Flesh out the document model and test that everything is as expected
+      # TODO: Continue fleshing out the document model and test that everything is as expected
       expect(result[:metadata]).to eq(
         base_path: "/government/news/ebola-medal-for-over-3000-heroes",
       )
-      expect(result[:content]).to be_nil
+      expect(result[:content]).to start_with("<div class=\"govspeak\"><p>The government has")
+      expect(result[:content].length).to eq(4_932)
     end
   end
 

--- a/spec/lib/publishing_event_pipeline/content_extractor_spec.rb
+++ b/spec/lib/publishing_event_pipeline/content_extractor_spec.rb
@@ -1,0 +1,27 @@
+RSpec.describe PublishingEventPipeline::ContentExtractor do
+  describe "#call" do
+    subject(:content) { described_class.new.call(message_hash) }
+
+    context "when body is present" do
+      let(:message_hash) do
+        {
+          "details" => {
+            "body" => "Lorem ipsum dolor sit amet.",
+          },
+        }
+      end
+
+      it { is_expected.to eq("Lorem ipsum dolor sit amet.") }
+    end
+
+    context "when body is not present" do
+      let(:message_hash) do
+        {
+          "details" => {},
+        }
+      end
+
+      it { is_expected.to be_nil }
+    end
+  end
+end

--- a/spec/lib/publishing_event_pipeline/document_lifecycle_event_spec.rb
+++ b/spec/lib/publishing_event_pipeline/document_lifecycle_event_spec.rb
@@ -1,5 +1,7 @@
 RSpec.describe PublishingEventPipeline::DocumentLifecycleEvent do
-  subject(:event) { described_class.new(message_hash) }
+  subject(:event) { described_class.new(message_hash, content_extractor:) }
+
+  let(:content_extractor) { ->(_) { "Lorem ipsum dolor sit amet" } }
 
   describe "#initialize" do
     context "with a valid republish message" do
@@ -58,7 +60,7 @@ RSpec.describe PublishingEventPipeline::DocumentLifecycleEvent do
         expect(repository).to have_received(:put).with(
           "f75d26a3-25a4-4c31-beea-a77cada4ce12",
           { base_path: "/government/news/ebola-medal-for-over-3000-heroes" },
-          content: nil,
+          content: "Lorem ipsum dolor sit amet",
           payload_version: 65_861_808,
         )
       end


### PR DESCRIPTION
Adds `PublishingEventPipeline::ContentExtractor` to extract some content from a message (only the very basic `details.body` field for now), and uses it in the `DocumentLifecycleEvent`.