### PR TITLE
Improve logging across the modules

### DIFF
--- a/lib/publishing_event_pipeline/configuration.rb
+++ b/lib/publishing_event_pipeline/configuration.rb
@@ -3,7 +3,7 @@ module PublishingEventPipeline
     attr_accessor :logger, :message_queue_name, :repository
 
     def initialize
-      @logger = Logger.new($stdout)
+      @logger = Logger.new($stdout, progname: "PublishingEventPipeline")
     end
   end
 end

--- a/lib/search_repositories/null/null_repository.rb
+++ b/lib/search_repositories/null/null_repository.rb
@@ -1,26 +1,30 @@
 module SearchRepositories
   module Null
-    # A repository that does nothing, for use until we can integrate with the real product.
+    # A repository that does nothing other than logging out any received calls, for use until we can
+    # integrate with the real product.
     class NullRepository
+      def initialize(logger: Logger.new($stdout, progname: self.class.name))
+        @logger = logger
+      end
+
       def put(content_id, metadata, content: nil, payload_version: nil)
         content_snippet = content ? content[0..50] : "<no content>"
 
-        Rails.logger.info(
+        logger.info(
           sprintf(
-            "[%s] Persisted %s: %s (@v%s): '%s...'",
-            self.class.name, content_id, metadata[:base_path], payload_version, content_snippet
+            "[PUT %s@v%s] %s: '%s...'",
+            content_id, payload_version, metadata[:base_path], content_snippet
           ),
         )
       end
 
       def delete(content_id, payload_version: nil)
-        Rails.logger.info(
-          sprintf(
-            "[%s] Deleted %s (@v%s)",
-            self.class.name, content_id, payload_version
-          ),
-        )
+        logger.info(sprintf("[DELETE %s@v%s]", content_id, payload_version))
       end
+
+    private
+
+      attr_reader :logger
     end
   end
 end

--- a/spec/lib/search_repositories/null/null_repository_spec.rb
+++ b/spec/lib/search_repositories/null/null_repository_spec.rb
@@ -1,32 +1,30 @@
 require "search_repositories/null/null_repository"
 
 RSpec.describe SearchRepositories::Null::NullRepository do
-  let(:repository) { described_class.new }
-  let(:content_id) { "some_content_id" }
-  let(:metadata) { { base_path: "/some/path" } }
-  let(:content) { "Lorem ipsum dolor sit amet, consecutur edipiscing elit" }
-  let(:payload_version) { "1" }
+  let(:repository) { described_class.new(logger:) }
+  let(:logger) { instance_double(Logger, info: nil) }
 
   describe "#put" do
     it "logs the put operation" do
-      expect(Rails.logger).to receive(:info).with(
-        a_string_ending_with(
-          "Persisted some_content_id: /some/path (@v1): " \
-          "'Lorem ipsum dolor sit amet, consecutur edipiscing e...'",
-        ),
+      repository.put(
+        "some_content_id",
+        { base_path: "/some/path" },
+        content: "Lorem ipsum dolor sit amet, consecutur edipiscing elit",
+        payload_version: "1",
       )
 
-      repository.put(content_id, metadata, content:, payload_version:)
+      expect(logger).to have_received(:info).with(
+        "[PUT some_content_id@v1] /some/path: " \
+          "'Lorem ipsum dolor sit amet, consecutur edipiscing e...'",
+      )
     end
   end
 
   describe "#delete" do
     it "logs the delete operation" do
-      expect(Rails.logger).to receive(:info).with(
-        a_string_ending_with("Deleted some_content_id (@v1)"),
-      )
+      repository.delete("some_content_id", payload_version: "1")
 
-      repository.delete(content_id, payload_version:)
+      expect(logger).to have_received(:info).with("[DELETE some_content_id@v1]")
     end
   end
 end


### PR DESCRIPTION
- Ensure `NullRepository` has its own logger and doesn't depend on the Rails one (which it doesn't and shouldn't have access to)
- Ensure loggers have meaningful `progname`s
- Tidy up `NullRepository` specs