### PR TITLE
Extract `MetadataExtractor`

### DIFF
--- a/lib/publishing_event_pipeline.rb
+++ b/lib/publishing_event_pipeline.rb
@@ -3,6 +3,7 @@ require "govuk_message_queue_consumer"
 require "publishing_event_pipeline/configuration"
 require "publishing_event_pipeline/content_extractor"
 require "publishing_event_pipeline/document_lifecycle_event"
+require "publishing_event_pipeline/metadata_extractor"
 
 require "publishing_event_pipeline/message_processor"
 

--- a/lib/publishing_event_pipeline/document_lifecycle_event.rb
+++ b/lib/publishing_event_pipeline/document_lifecycle_event.rb
@@ -9,7 +9,8 @@ module PublishingEventPipeline
     # Creates an instance from a message hash conforming to the publishing schema.
     def initialize(
       message_hash,
-      content_extractor: ContentExtractor.new
+      content_extractor: ContentExtractor.new,
+      metadata_extractor: MetadataExtractor.new
     )
       # These fields *must* be present in the message hash, and we want to fail fast if they're not
       @content_id = message_hash.fetch("content_id")
@@ -17,10 +18,7 @@ module PublishingEventPipeline
       @payload_version = message_hash.fetch("payload_version")
 
       unless delete?
-        # TODO: Flesh these out as we need them
-        @metadata = {
-          base_path: message_hash.fetch("base_path"),
-        }
+        @metadata = metadata_extractor.call(message_hash)
         @content = content_extractor.call(message_hash)
       end
     end

--- a/lib/publishing_event_pipeline/metadata_extractor.rb
+++ b/lib/publishing_event_pipeline/metadata_extractor.rb
@@ -1,0 +1,9 @@
+module PublishingEventPipeline
+  class MetadataExtractor
+    def call(message_hash)
+      {
+        base_path: message_hash.fetch("base_path"),
+      }
+    end
+  end
+end

--- a/spec/lib/publishing_event_pipeline/document_lifecycle_event_spec.rb
+++ b/spec/lib/publishing_event_pipeline/document_lifecycle_event_spec.rb
@@ -1,7 +1,8 @@
 RSpec.describe PublishingEventPipeline::DocumentLifecycleEvent do
-  subject(:event) { described_class.new(message_hash, content_extractor:) }
+  subject(:event) { described_class.new(message_hash, content_extractor:, metadata_extractor:) }
 
   let(:content_extractor) { ->(_) { "Lorem ipsum dolor sit amet" } }
+  let(:metadata_extractor) { ->(_) { { reticulating: "splines" } } }
 
   describe "#initialize" do
     context "with a valid republish message" do
@@ -59,7 +60,7 @@ RSpec.describe PublishingEventPipeline::DocumentLifecycleEvent do
 
         expect(repository).to have_received(:put).with(
           "f75d26a3-25a4-4c31-beea-a77cada4ce12",
-          { base_path: "/government/news/ebola-medal-for-over-3000-heroes" },
+          { reticulating: "splines" },
           content: "Lorem ipsum dolor sit amet",
           payload_version: 65_861_808,
         )


### PR DESCRIPTION
As we did for `ContentExtractor`, extract a `MetadataExtractor` to parse metadata out of a message hash, for now with the same behaviour as before.