### PR TITLE
Extract content from message hash

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem "govuk_app_config"
 
 # Gems for publishing_event_pipeline
 gem "govuk_message_queue_consumer", require: false
+gem "jsonpath", require: false
 
 group :test do
   gem "simplecov", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,6 +79,8 @@ GEM
     irb (1.7.4)
       reline (>= 0.3.6)
     json (2.6.3)
+    jsonpath (1.1.4)
+      multi_json
     language_server-protocol (3.17.0.3)
     logstasher (2.1.5)
       activesupport (>= 5.2)
@@ -91,6 +93,7 @@ GEM
     mini_mime (1.1.5)
     minitest (5.20.0)
     msgpack (1.7.2)
+    multi_json (1.15.0)
     nio4r (2.5.9)
     nokogiri (1.15.4-aarch64-linux)
       racc (~> 1.4)
@@ -429,6 +432,7 @@ DEPENDENCIES
   govuk_app_config
   govuk_message_queue_consumer
   govuk_test
+  jsonpath
   railties (= 7.0.7.2)
   rspec-rails
   rubocop-govuk

--- a/lib/publishing_event_pipeline/extractors/content.rb
+++ b/lib/publishing_event_pipeline/extractors/content.rb
@@ -1,13 +1,33 @@
+require "jsonpath"
+
 module PublishingEventPipeline
   module Extractors
-    # Extracts indexable unstructured content from a publishing event
+    # Extracts single string of indexable unstructured content from a publishing event
     class Content
-      # Returns a string of unstructured content
+      # JSON paths of keys in the message hash to extract content from
+      # (see https://github.com/joshbuddy/jsonpath)
+      VALUE_PATHS = %w[
+        $.details.body
+        $.details.contact_groups[*].title
+        $.details.description
+        $.details.hidden_search_terms
+        $.details.introduction
+        $.details.introductory_paragraph
+        $.details.metadata.hidden_indexable_content[*]
+        $.details.metadata.project_code
+        $.details.more_information
+        $.details.need_to_know
+        $.details.parts[*].title
+        $.details.parts[*].body
+        $.details.summary
+        $.details.title
+      ].map { JsonPath.new(_1) }.freeze
+
       def call(message_hash)
-        # TODO: Eventually, this should do something more sophisticated along the lines of what the
-        # existing search-api does in `lib/govuk_index/presenters/indexable_content_presenter.rb`, but
-        # this is a decent enough MVP for now.
-        message_hash.dig("details", "body")
+        VALUE_PATHS
+          .map { _1.on(message_hash) }
+          .flatten
+          .join("\n")
       end
     end
   end

--- a/spec/lib/publishing_event_pipeline/extractors/content_spec.rb
+++ b/spec/lib/publishing_event_pipeline/extractors/content_spec.rb
@@ -2,26 +2,94 @@ RSpec.describe PublishingEventPipeline::Extractors::Content do
   describe "#call" do
     subject(:content) { described_class.new.call(message_hash) }
 
-    context "when body is present" do
+    describe "with basic top-level fields" do
       let(:message_hash) do
         {
           "details" => {
-            "body" => "Lorem ipsum dolor sit amet.",
+            "body" => "a",
+            "description" => "b",
+            "hidden_search_terms" => "c",
+            "introduction" => "d",
+            "introductory_paragraph" => "e",
+            "more_information" => "f",
+            "need_to_know" => "g",
+            "summary" => "h",
+            "title" => "i",
           },
         }
       end
 
-      it { is_expected.to eq("Lorem ipsum dolor sit amet.") }
+      it { is_expected.to eq("a\nb\nc\nd\ne\nf\ng\nh\ni") }
     end
 
-    context "when body is not present" do
+    describe "with hidden indexable content" do
+      let(:message_hash) do
+        {
+          "details" => {
+            "metadata" => {
+              "hidden_indexable_content" => %w[x y z],
+            },
+          },
+        }
+      end
+
+      it { is_expected.to eq("x\ny\nz") }
+    end
+
+    describe "with a project code" do
+      let(:message_hash) do
+        {
+          "details" => {
+            "metadata" => {
+              "project_code" => "PRINCE2",
+            },
+          },
+        }
+      end
+
+      it { is_expected.to eq("PRINCE2") }
+    end
+
+    describe "with contact groups" do
+      let(:message_hash) do
+        {
+          "details" => {
+            "contact_groups" => [
+              { "title" => "x" },
+              { "title" => "y" },
+              { "title" => "z" },
+            ],
+          },
+        }
+      end
+
+      it { is_expected.to eq("x\ny\nz") }
+    end
+
+    describe "with parts" do
+      let(:message_hash) do
+        {
+          "details" => {
+            "parts" => [
+              { "title" => "x", "body" => "a" },
+              { "title" => "y", "body" => "b" },
+              { "title" => "z", "body" => "c" },
+            ],
+          },
+        }
+      end
+
+      it { is_expected.to eq("x\ny\nz\na\nb\nc") }
+    end
+
+    describe "without any fields" do
       let(:message_hash) do
         {
           "details" => {},
         }
       end
 
-      it { is_expected.to be_nil }
+      it { is_expected.to be_blank }
     end
   end
 end


### PR DESCRIPTION
Adds `jsonpath` gem and uses it to extract all indexing-relevant content from an incoming document message into a single string to treat as unstructured content for the search engine.