### PR TITLE
Include absolute URL in metadata

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem "govuk_app_config"
 # Gems for publishing_event_pipeline
 gem "govuk_message_queue_consumer", require: false
 gem "jsonpath", require: false
+gem "plek", require: false
 
 group :test do
   gem "simplecov", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -433,6 +433,7 @@ DEPENDENCIES
   govuk_message_queue_consumer
   govuk_test
   jsonpath
+  plek
   railties (= 7.0.7.2)
   rspec-rails
   rubocop-govuk

--- a/lib/publishing_event_pipeline.rb
+++ b/lib/publishing_event_pipeline.rb
@@ -1,5 +1,6 @@
 require "govuk_message_queue_consumer"
 require "jsonpath"
+require "plek"
 
 require "publishing_event_pipeline/configuration"
 require "publishing_event_pipeline/document_event_mapper"

--- a/lib/publishing_event_pipeline/extractors/metadata.rb
+++ b/lib/publishing_event_pipeline/extractors/metadata.rb
@@ -4,10 +4,18 @@ module PublishingEventPipeline
       include Helpers::Extract
 
       def call(message_hash)
+        link = extract_first(message_hash, %w[$.base_path $.details.url])
+        url = if link&.start_with?("/")
+                Plek.website_root + link
+              else
+                link
+              end
+
         {
           title: extract_single(message_hash, "$.title"),
           description: extract_single(message_hash, "$.description"),
-          link: extract_first(message_hash, %w[$.base_path $.details.url]),
+          link:,
+          url:,
         }
       end
     end

--- a/spec/integration/publishing_event_pipeline_spec.rb
+++ b/spec/integration/publishing_event_pipeline_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe "Publishing event pipeline" do
         title: "Ebola medal for over 3000 heroes",
         description: "A new medal has been created to recognise the bravery and hard work of people who have helped to stop the spread of Ebola.",
         link: "/government/news/ebola-medal-for-over-3000-heroes",
+        url: "http://www.dev.gov.uk/government/news/ebola-medal-for-over-3000-heroes",
       )
       expect(result[:content]).to start_with("<div class=\"govspeak\"><p>The government has")
       expect(result[:content]).to end_with("response to Ebola</a>.</p>\n</div>\n\n</div>")
@@ -36,6 +37,7 @@ RSpec.describe "Publishing event pipeline" do
         title: "Brighton & Hove City Council",
         description: "Website of Brighton & Hove City Council",
         link: "https://www.brighton-hove.gov.uk",
+        url: "https://www.brighton-hove.gov.uk",
       )
       expect(result[:content]).to eq("Brighton & Hove City Council")
     end

--- a/spec/lib/publishing_event_pipeline/extractors/metadata_spec.rb
+++ b/spec/lib/publishing_event_pipeline/extractors/metadata_spec.rb
@@ -47,5 +47,41 @@ RSpec.describe PublishingEventPipeline::Extractors::Metadata do
         it { is_expected.to be_nil }
       end
     end
+
+    describe "url" do
+      subject(:url) { extracted_data[:url] }
+
+      before do
+        allow(Plek).to receive(:new).and_return(
+          instance_double(Plek, website_root: "https://test.gov.uk"),
+        )
+      end
+
+      context "with a base_path" do
+        let(:message_hash) { { "base_path" => "/test" } }
+
+        it { is_expected.to eq("https://test.gov.uk/test") }
+      end
+
+      context "with an external URL" do
+        let(:message_hash) { { "details" => { "url" => "https://liverpool.gov.uk/" } } }
+
+        it { is_expected.to eq("https://liverpool.gov.uk/") }
+      end
+
+      context "with both a base_path and an external URL" do
+        let(:message_hash) do
+          { "base_path" => "/test", "details" => { "url" => "https://liverpool.gov.uk/" } }
+        end
+
+        it { is_expected.to eq("https://test.gov.uk/test") }
+      end
+
+      context "without a base_path or external URL" do
+        let(:message_hash) { {} }
+
+        it { is_expected.to be_nil }
+      end
+    end
   end
 end


### PR DESCRIPTION
In addition to the existing `link` field in the current search, which provides either a relative URI fragment (for internal content on GOV.UK) or a full absolute URL (for external content on other websites), we want to keep track of a full URL for every content item as our new search product requires it to correlate content items with event data.

- Add `plek` gem for service discovery
- Add `url` field to metadata and use Plek to find website root