### PR TITLE
Move gems for the document sync worker into group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,10 +12,12 @@ gem "railties", RAILS_GEMS_VERSION
 gem "bootsnap", require: false
 gem "govuk_app_config"
 
-# Gems for document_sync_worker
-gem "govuk_message_queue_consumer", require: false
-gem "jsonpath", require: false
-gem "plek", require: false
+# Gems specific to the document sync worker that aren't required for the main Rails API app
+group :document_sync_worker do
+  gem "govuk_message_queue_consumer"
+  gem "jsonpath"
+  gem "plek"
+end
 
 group :test do
   gem "simplecov", require: false

--- a/lib/document_sync_worker.rb
+++ b/lib/document_sync_worker.rb
@@ -1,6 +1,5 @@
-require "govuk_message_queue_consumer"
-require "jsonpath"
-require "plek"
+# Gems specific to the document sync worker are in their own group in the Gemfile
+Bundler.require(:document_sync_worker)
 
 require "document_sync_worker/configuration"
 require "document_sync_worker/message_processor"


### PR DESCRIPTION
This lets us load these gems separately in the worker and not need to either a) set `require: false` and manually require them, or b) have them in the main API Rails app where we don't need them.