### PR TITLE
Use `Time.parse` for document timestamps

### DIFF
--- a/lib/document_sync_worker/document/publish.rb
+++ b/lib/document_sync_worker/document/publish.rb
@@ -68,7 +68,7 @@ module DocumentSyncWorker
       def public_timestamp_int
         return nil unless public_timestamp
 
-        Time.zone.parse(public_timestamp).to_i
+        Time.parse(public_timestamp).to_i # rubocop:disable Rails/TimeZone (string contains TZ info)
       end
     end
   end


### PR DESCRIPTION
Rubocop prefers Rails's `Time.zone.parse` over Ruby's `Time.parse`, but this is actually counterproductive here as the `public_updated_at` timestamp contains a timezone which shouldn't get lost (and using the Rails zoned time couples us to Rails).