### PR TITLE
Properly set up logging for worker; log errors

### DIFF
--- a/lib/document_sync_worker.rb
+++ b/lib/document_sync_worker.rb
@@ -18,12 +18,19 @@ module DocumentSyncWorker
     yield(configuration)
   end
 
+  def self.logger
+    configuration.logger
+  end
+
   def self.run
+    logger.info("Starting DocumentSyncWorker")
     GovukMessageQueueConsumer::Consumer.new(
       queue_name: DocumentSyncWorker.configuration.message_queue_name,
       processor: DocumentSyncWorker::MessageProcessor.new(
         repository: configuration.repository,
       ),
     ).run
+  rescue Interrupt
+    logger.info("Stopping DocumentSyncWorker (received interrupt)")
   end
 end

--- a/lib/document_sync_worker/configuration.rb
+++ b/lib/document_sync_worker/configuration.rb
@@ -3,7 +3,18 @@ module DocumentSyncWorker
     attr_accessor :logger, :message_queue_name, :repository
 
     def initialize
-      @logger = Logger.new($stdout, progname: "DocumentSyncWorker")
+      @logger = ActiveSupport::Logger.new($stdout, progname: "DocumentSyncWorker")
+      @logger.formatter = proc do |level, datetime, progname, message|
+        hash = {
+          message:,
+          level:,
+          progname:,
+          "@timestamp": datetime.utc.iso8601(3),
+          tags: %w[document_sync_worker],
+        }
+
+        "#{hash.to_json}\n"
+      end
     end
   end
 end

--- a/lib/document_sync_worker/message_processor.rb
+++ b/lib/document_sync_worker/message_processor.rb
@@ -13,19 +13,24 @@ module DocumentSyncWorker
       document.synchronize_to(repository)
 
       message.ack
-    rescue StandardError
+    rescue StandardError => e
       # TODO: Consider options for handling errors more granularly, and for differentiating between
       # retriable (e.g. transient connection issue in repository) and fatal (e.g. malformed document
-      # on queue) errors. For now while we aren't live, send the message to Sentry and reject it to
-      # avoid unnecessary retries that would probably fail again while we're very actively
-      # iterating.
-      extra_info = if message.payload.is_a?(Hash)
-                     # Omit details as it may be large and take us over the Sentry metadata limit
-                     message.payload.except("details")
-                   else
-                     { message_payload: message.payload.to_s }
-                   end
-      GovukError.notify("Failed to process incoming document message", extra: extra_info)
+      # on queue) errors. For now while we aren't live, log an error, send the error to Sentry, and
+      # reject the message to avoid unnecessary retries that would probably fail again while we're
+      # very actively iterating.
+      payload = if message.payload.is_a?(Hash)
+                  # Omit details as it may be large and is probably unnecessary
+                  message.payload.except("details")
+                else
+                  message.payload
+                end
+      DocumentSyncWorker.logger.error(<<~MSG)
+        Failed to process incoming document message:
+        #{e.class}: #{e.message}
+        Message content: #{payload.inspect}
+      MSG
+      GovukError.notify(e)
 
       message.discard
     end

--- a/lib/tasks/document_sync_worker.rake
+++ b/lib/tasks/document_sync_worker.rake
@@ -29,7 +29,7 @@ namespace :document_sync_worker do
       # TODO: Once we have access to the search product and written a repository for it, this should
       #  be set to the real repository. Until then, this allows us to verify that the pipeline is
       #  working as expected through the logs.
-      config.repository = Repositories::Null::Repository.new
+      config.repository = Repositories::Null::Repository.new(logger: config.logger)
       config.message_queue_name = ENV.fetch("PUBLISHED_DOCUMENTS_MESSAGE_QUEUE_NAME")
     end
 


### PR DESCRIPTION
- Make document sync worker log GOV.UK logging compliant JSON instead of plain text
- Log errors from document sync worker including message payload (which Sentry can't cope with well)
- Capture `Interrupts` and shut down quietly