### PR TITLE
Use Zeitwerk for autoloading in document sync worker

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ group :document_sync_worker do
   gem "govuk_message_queue_consumer"
   gem "jsonpath"
   gem "plek"
+  gem "zeitwerk"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -438,6 +438,7 @@ DEPENDENCIES
   rspec-rails
   rubocop-govuk
   simplecov
+  zeitwerk
 
 RUBY VERSION
    ruby 3.2.2p53

--- a/lib/document_sync_worker.rb
+++ b/lib/document_sync_worker.rb
@@ -1,15 +1,11 @@
 # Gems specific to the document sync worker are in their own group in the Gemfile
 Bundler.require(:document_sync_worker)
 
-require "document_sync_worker/configuration"
-require "document_sync_worker/message_processor"
-
-require "document_sync_worker/document"
-require "document_sync_worker/document/base"
-require "document_sync_worker/document/publish"
-require "document_sync_worker/document/unpublish"
-
 module DocumentSyncWorker
+  loader = Zeitwerk::Loader.new
+  loader.push_dir("#{__dir__}/document_sync_worker", namespace: DocumentSyncWorker)
+  loader.setup
+
   def self.configuration
     @configuration ||= Configuration.new
   end

--- a/spec/lib/document_sync_worker/message_processor_spec.rb
+++ b/spec/lib/document_sync_worker/message_processor_spec.rb
@@ -1,4 +1,3 @@
-require "govuk_message_queue_consumer"
 require "govuk_message_queue_consumer/test_helpers"
 
 RSpec.describe DocumentSyncWorker::MessageProcessor do

--- a/spec/lib/document_sync_worker_spec.rb
+++ b/spec/lib/document_sync_worker_spec.rb
@@ -1,5 +1,3 @@
-require "govuk_message_queue_consumer"
-
 RSpec.describe DocumentSyncWorker do
   describe ".run" do
     let(:consumer) { instance_double(GovukMessageQueueConsumer::Consumer, run: nil) }


### PR DESCRIPTION
This allows us to skip having to manually require all files.