### PR TITLE
Fix issue with hidden indexable content extraction

### DIFF
--- a/lib/document_sync_worker/document/publish.rb
+++ b/lib/document_sync_worker/document/publish.rb
@@ -10,7 +10,7 @@ module DocumentSyncWorker
         $.details.hidden_search_terms
         $.details.introduction
         $.details.introductory_paragraph
-        $.details.metadata.hidden_indexable_content[*]
+        $.details.metadata.hidden_indexable_content
         $.details.metadata.project_code
         $.details.more_information
         $.details.need_to_know

--- a/spec/lib/document_sync_worker/document/publish_spec.rb
+++ b/spec/lib/document_sync_worker/document/publish_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe DocumentSyncWorker::Document::Publish do
       it { is_expected.to eq("a\nb\nc\nd\ne\nf\ng\nh\ni") }
     end
 
-    describe "with hidden indexable content" do
+    describe "with hidden indexable content as an array" do
       let(:document_hash) do
         {
           "details" => {
@@ -63,6 +63,20 @@ RSpec.describe DocumentSyncWorker::Document::Publish do
       end
 
       it { is_expected.to eq("x\ny\nz") }
+    end
+
+    describe "with hidden indexable content as a string" do
+      let(:document_hash) do
+        {
+          "details" => {
+            "metadata" => {
+              "hidden_indexable_content" => "x y z",
+            },
+          },
+        }
+      end
+
+      it { is_expected.to eq("x y z") }
     end
 
     describe "with a project code" do


### PR DESCRIPTION
This can be either an array or a string, and is currently breaking for documents where the value is a string. We can just treat it as an arbitrary value instead of assuming it is an array and the flattening will take care of the array scenario anyway.