### PR TITLE
Allow worker to depend on Rails environment

### DIFF
--- a/lib/document_sync_worker/configuration.rb
+++ b/lib/document_sync_worker/configuration.rb
@@ -3,18 +3,7 @@ module DocumentSyncWorker
     attr_accessor :logger, :message_queue_name, :repository
 
     def initialize
-      @logger = ActiveSupport::Logger.new($stdout, progname: "DocumentSyncWorker")
-      @logger.formatter = proc do |level, datetime, progname, message|
-        hash = {
-          message:,
-          level:,
-          progname:,
-          "@timestamp": datetime.utc.iso8601(3),
-          tags: %w[document_sync_worker],
-        }
-
-        "#{hash.to_json}\n"
-      end
+      @logger = Rails.logger
     end
   end
 end

--- a/lib/tasks/document_sync_worker.rake
+++ b/lib/tasks/document_sync_worker.rake
@@ -1,17 +1,9 @@
 require "document_sync_worker"
 require "repositories/null/repository"
 
-# TODO: For now, this lives within the application repository, but we may want to extract it to a
-#   completely separate unit if we can keep dependencies between the read and write sides of this
-#   project to a minimum. This isn't something that is 100% clear at this stage.
-#
-# Until then, these tasks intentionally run outside the Rails environment to avoid us adding any
-# implicit dependencies on the Rails application.
-#
-# rubocop:disable Rails/RakeEnvironment
 namespace :document_sync_worker do
   desc "Create RabbitMQ queue for development environment"
-  task :create_queue do
+  task create_queue: :environment do
     # The exchange, queue, and binding are created via Terraform outside of local development:
     # https://github.com/alphagov/govuk-aws/blob/main/terraform/projects/app-publishing-amazonmq/
     # TODO: Remove dependency on Rails if extracted to a separate unit
@@ -24,7 +16,7 @@ namespace :document_sync_worker do
   end
 
   desc "Listens to and processes messages from the published documents queue"
-  task :run do
+  task run: :environment do
     DocumentSyncWorker.configure do |config|
       # TODO: Once we have access to the search product and written a repository for it, this should
       #  be set to the real repository. Until then, this allows us to verify that the pipeline is
@@ -36,4 +28,3 @@ namespace :document_sync_worker do
     DocumentSyncWorker.run
   end
 end
-# rubocop:enable Rails/RakeEnvironment


### PR DESCRIPTION
We've decided that we won't extract the document sync worker from the Rails application for the sake of convenience and avoiding having several repos with only slightly different dependencies and configuration.

- Remove custom logger from `DocumentSyncWorker` and just use Rails logger instead
- Allow Rake task to depend on Rails environment to make sure `govuk_app_config` is properly initialised throughout