### PR TITLE
Use `oj` for faster JSON handling

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem "railties", RAILS_GEMS_VERSION
 
 gem "bootsnap", require: false
 gem "govuk_app_config"
+gem "oj"
 
 # Gems specific to the document sync worker that aren't required for the main Rails API app
 group :document_sync_worker do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,6 +101,7 @@ GEM
       racc (~> 1.4)
     nokogiri (1.15.4-x86_64-linux)
       racc (~> 1.4)
+    oj (3.16.1)
     opentelemetry-api (1.2.3)
     opentelemetry-common (0.20.0)
       opentelemetry-api (~> 1.0)
@@ -433,6 +434,7 @@ DEPENDENCIES
   govuk_message_queue_consumer
   govuk_test
   jsonpath
+  oj
   plek
   railties (= 7.0.7.2)
   rspec-rails

--- a/config/initializers/json.rb
+++ b/config/initializers/json.rb
@@ -1,0 +1,3 @@
+# Use Oj for faster JSON handling across the app
+Oj.default_options = { mode: :rails }
+Oj.optimize_rails


### PR DESCRIPTION
- Add and configure `oj` gem in Rails compatibility mode