### PR TITLE
Use Google Discovery Engine repository

### DIFF
--- a/lib/repositories/google_discovery_engine/repository.rb
+++ b/lib/repositories/google_discovery_engine/repository.rb
@@ -1,0 +1,31 @@
+module Repositories
+  module GoogleDiscoveryEngine
+    # A repository integrating with Google Discovery Engine
+    # TODO: This is just a copy of the Null repository to start off with, but it should be updated
+    #       to integrate with the real product.
+    class Repository
+      def initialize(logger: Logger.new($stdout, progname: self.class.name))
+        @logger = logger
+      end
+
+      def put(content_id, metadata, content: nil, payload_version: nil)
+        content_snippet = content ? content[0..50] : "<no content>"
+
+        logger.info(
+          sprintf(
+            "[PUT %s@v%s] %s: '%s...'",
+            content_id, payload_version, metadata[:link], content_snippet
+          ),
+        )
+      end
+
+      def delete(content_id, payload_version: nil)
+        logger.info(sprintf("[DELETE %s@v%s]", content_id, payload_version))
+      end
+
+    private
+
+      attr_reader :logger
+    end
+  end
+end

--- a/lib/tasks/document_sync_worker.rake
+++ b/lib/tasks/document_sync_worker.rake
@@ -1,5 +1,5 @@
 require "document_sync_worker"
-require "repositories/null/repository"
+require "repositories/google_discovery_engine/repository"
 
 namespace :document_sync_worker do
   desc "Create RabbitMQ queue for development environment"
@@ -18,10 +18,7 @@ namespace :document_sync_worker do
   desc "Listens to and processes messages from the published documents queue"
   task run: :environment do
     DocumentSyncWorker.configure do |config|
-      # TODO: Once we have access to the search product and written a repository for it, this should
-      #  be set to the real repository. Until then, this allows us to verify that the pipeline is
-      #  working as expected through the logs.
-      config.repository = Repositories::Null::Repository.new(logger: config.logger)
+      config.repository = Repositories::GoogleDiscoveryEngine::Repository.new(logger: config.logger)
       config.message_queue_name = ENV.fetch("PUBLISHED_DOCUMENTS_MESSAGE_QUEUE_NAME")
     end
 


### PR DESCRIPTION
- Add a repository for Google Discovery Engine (no-op for now/copy of the `Null::Repository`)
- Use the new repository for the worker instead of the null repository