### PR TITLE
Update metadata and unstructured content extraction

### DIFF
--- a/spec/lib/document_sync_worker/document/publish_spec.rb
+++ b/spec/lib/document_sync_worker/document/publish_spec.rb
@@ -35,62 +35,19 @@ RSpec.describe DocumentSyncWorker::Document::Publish do
       let(:document_hash) do
         {
           "details" => {
-            "body" => "a",
-            "description" => "b",
-            "hidden_search_terms" => "c",
-            "introduction" => "d",
-            "introductory_paragraph" => "e",
-            "more_information" => "f",
+            "description" => "a",
+            "introduction" => "b",
+            "introductory_paragraph" => "c",
+            "title" => "d",
+            "summary" => "e",
+            "body" => "f",
             "need_to_know" => "g",
-            "summary" => "h",
-            "title" => "i",
+            "more_information" => "h",
           },
         }
       end
 
-      it { is_expected.to eq("a\nb\nc\nd\ne\nf\ng\nh\ni") }
-    end
-
-    describe "with hidden indexable content as an array" do
-      let(:document_hash) do
-        {
-          "details" => {
-            "metadata" => {
-              "hidden_indexable_content" => %w[x y z],
-            },
-          },
-        }
-      end
-
-      it { is_expected.to eq("x\ny\nz") }
-    end
-
-    describe "with hidden indexable content as a string" do
-      let(:document_hash) do
-        {
-          "details" => {
-            "metadata" => {
-              "hidden_indexable_content" => "x y z",
-            },
-          },
-        }
-      end
-
-      it { is_expected.to eq("x y z") }
-    end
-
-    describe "with a project code" do
-      let(:document_hash) do
-        {
-          "details" => {
-            "metadata" => {
-              "project_code" => "PRINCE2",
-            },
-          },
-        }
-      end
-
-      it { is_expected.to eq("PRINCE2") }
+      it { is_expected.to eq("a\nb\nc\nd\ne\nf\ng\nh") }
     end
 
     describe "with contact groups" do
@@ -145,14 +102,6 @@ RSpec.describe DocumentSyncWorker::Document::Publish do
       it { is_expected.to eq("000-000-000") }
     end
 
-    describe "document_type" do
-      subject(:extracted_document_type) { document.metadata[:document_type] }
-
-      let(:document_hash) { { "document_type" => "foo_bar" } }
-
-      it { is_expected.to eq("foo_bar") }
-    end
-
     describe "title" do
       subject(:extracted_title) { document.metadata[:title] }
 
@@ -167,6 +116,64 @@ RSpec.describe DocumentSyncWorker::Document::Publish do
       let(:document_hash) { { "description" => "Lorem ipsum dolor sit amet." } }
 
       it { is_expected.to eq("Lorem ipsum dolor sit amet.") }
+    end
+
+    describe "additional_searchable_text" do
+      subject(:additional_searchable_text) { document.metadata[:additional_searchable_text] }
+
+      describe "with hidden search terms" do
+        let(:document_hash) do
+          {
+            "details" => {
+              "hidden_search_terms" => "a b c",
+            },
+          }
+        end
+
+        it { is_expected.to eq("a b c") }
+      end
+
+      describe "with hidden indexable content as an array" do
+        let(:document_hash) do
+          {
+            "details" => {
+              "metadata" => {
+                "hidden_indexable_content" => %w[x y z],
+              },
+            },
+          }
+        end
+
+        it { is_expected.to eq("x\ny\nz") }
+      end
+
+      describe "with hidden indexable content as a string" do
+        let(:document_hash) do
+          {
+            "details" => {
+              "metadata" => {
+                "hidden_indexable_content" => "x y z",
+              },
+            },
+          }
+        end
+
+        it { is_expected.to eq("x y z") }
+      end
+
+      describe "with a project code" do
+        let(:document_hash) do
+          {
+            "details" => {
+              "metadata" => {
+                "project_code" => "PRINCE2",
+              },
+            },
+          }
+        end
+
+        it { is_expected.to eq("PRINCE2") }
+      end
     end
 
     describe "link" do
@@ -240,14 +247,6 @@ RSpec.describe DocumentSyncWorker::Document::Publish do
 
       let(:document_hash) { { "public_updated_at" => "2012-02-01T00:00:00Z" } }
 
-      it { is_expected.to eq("2012-02-01T00:00:00Z") }
-    end
-
-    describe "public_timestamp_int" do
-      subject(:extracted_public_timestamp_int) { document.metadata[:public_timestamp_int] }
-
-      let(:document_hash) { { "public_updated_at" => "2012-02-01T00:00:00Z" } }
-
       it { is_expected.to eq(1_328_054_400) }
 
       context "without a public_timestamp" do
@@ -255,6 +254,46 @@ RSpec.describe DocumentSyncWorker::Document::Publish do
 
         it { is_expected.to be_nil }
       end
+    end
+
+    describe "document_type" do
+      subject(:extracted_document_type) { document.metadata[:document_type] }
+
+      let(:document_hash) { { "document_type" => "foo_bar" } }
+
+      it { is_expected.to eq("foo_bar") }
+    end
+
+    describe "content_purpose_supergroup" do
+      subject(:extracted_content_purpose_supergroup) { document.metadata[:content_purpose_supergroup] }
+
+      let(:document_hash) { { "content_purpose_supergroup" => "foo_bar" } }
+
+      it { is_expected.to eq("foo_bar") }
+    end
+
+    describe "part_of_taxonomy_tree" do
+      subject(:extracted_part_of_taxonomy_tree) { document.metadata[:part_of_taxonomy_tree] }
+
+      context "with a set of taxon links" do
+        let(:document_hash) { { "links" => { "taxons" => %w[0000 ffff] } } }
+
+        it { is_expected.to eq(%w[0000 ffff]) }
+      end
+
+      context "without taxon links" do
+        let(:document_hash) { { "links": {} } }
+
+        it { is_expected.to be_empty }
+      end
+    end
+
+    describe "locale" do
+      subject(:extracted_locale) { document.metadata[:locale] }
+
+      let(:document_hash) { { "locale" => "en" } }
+
+      it { is_expected.to eq("en") }
     end
   end
 

--- a/spec/lib/document_sync_worker_integration_spec.rb
+++ b/spec/lib/document_sync_worker_integration_spec.rb
@@ -16,13 +16,18 @@ RSpec.describe "Document sync worker end-to-end" do
       result = repository.get("f75d26a3-25a4-4c31-beea-a77cada4ce12")
       expect(result[:metadata]).to eq(
         content_id: "f75d26a3-25a4-4c31-beea-a77cada4ce12",
-        document_type: "press_release",
         title: "Ebola medal for over 3000 heroes",
         description: "A new medal has been created to recognise the bravery and hard work of people who have helped to stop the spread of Ebola.",
+        additional_searchable_text: "",
         link: "/government/news/ebola-medal-for-over-3000-heroes",
         url: "http://www.dev.gov.uk/government/news/ebola-medal-for-over-3000-heroes",
-        public_timestamp: "2015-06-11T11:14:00Z",
-        public_timestamp_int: 1_434_021_240,
+        public_timestamp: 1_434_021_240,
+        document_type: "press_release",
+        content_purpose_supergroup: "news_and_communications",
+        part_of_taxonomy_tree: %w[
+          668cd623-c7a8-4159-9575-90caac36d4b4 c31256e8-f328-462b-993f-dce50b7892e9
+        ],
+        locale: "en",
       )
       expect(result[:content]).to start_with("<div class=\"govspeak\"><p>The government has")
       expect(result[:content]).to end_with("response to Ebola</a>.</p>\n</div>\n\n</div>")
@@ -38,15 +43,18 @@ RSpec.describe "Document sync worker end-to-end" do
       result = repository.get("526d5caf-221b-4c7b-9e74-b3e0b189fc8d")
       expect(result[:metadata]).to eq(
         content_id: "526d5caf-221b-4c7b-9e74-b3e0b189fc8d",
-        document_type: "external_content",
         title: "Brighton & Hove City Council",
         description: "Website of Brighton & Hove City Council",
+        additional_searchable_text: "Brighton & Hove City Council",
         link: "https://www.brighton-hove.gov.uk",
         url: "https://www.brighton-hove.gov.uk",
-        public_timestamp: "2023-09-28T14:56:19Z",
-        public_timestamp_int: 1_695_912_979,
+        public_timestamp: 1_695_912_979,
+        document_type: "external_content",
+        content_purpose_supergroup: "other",
+        part_of_taxonomy_tree: [],
+        locale: "en",
       )
-      expect(result[:content]).to eq("Brighton & Hove City Council")
+      expect(result[:content]).to be_blank
     end
   end
 


### PR DESCRIPTION
This updates the content and metadata extraction to match the new semi-final schema and cleans up the content to be more usefully snippetable.

- Move some content fields that don't really form part of the primary content to a new `additional_searchable_text` metadata field (we've originally put it in the primary indexable content out of convenience and because it's what the existing search does, but this allows us to keep the content "cleaner" in case we enable snippeting in the future)
- Reorder unstructured content fields into a more natural order (again, would make snippeting more useful)
- Reorder metadata fields to match schema (not strictly necessary as it's JSON of course, but makes it easier to follow)
- Remove `public_timestamp_int` field and make the regular `public_timestamp` an integer (there is no reason we need two fields, the API can convert the integer back into an ISO timestamp at the point of retrieval)
- Add additional fields from semi-final schema (`content_purpose_supergroup`, `part_of_taxonomy_tree`, `locale`)