### PR TITLE
Add JSON schema validation to integration tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ group :document_sync_worker do
 end
 
 group :test do
+  gem "json_schemer"
   gem "simplecov", require: false
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,6 +73,7 @@ GEM
       capybara (>= 3.36)
       puma
       selenium-webdriver (>= 4.0)
+    hana (1.3.7)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     io-console (0.6.0)
@@ -80,6 +81,10 @@ GEM
       rdoc
       reline (>= 0.3.8)
     json (2.6.3)
+    json_schemer (2.0.0)
+      hana (~> 1.3)
+      regexp_parser (~> 2.0)
+      simpleidn (~> 0.2)
     jsonpath (1.1.5)
       multi_json
     language_server-protocol (3.17.0.3)
@@ -409,6 +414,8 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    simpleidn (0.2.1)
+      unf (~> 0.1.4)
     sorted_set (1.0.3)
       rbtree
       set (~> 1.0)
@@ -417,6 +424,9 @@ GEM
     thor (1.2.2)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.8.2)
     unicode-display_width (2.5.0)
     webrick (1.8.1)
     websocket (1.2.10)
@@ -439,6 +449,7 @@ DEPENDENCIES
   govuk_app_config
   govuk_message_queue_consumer
   govuk_test
+  json_schemer
   jsonpath
   oj
   plek

--- a/spec/lib/document_sync_worker_integration_spec.rb
+++ b/spec/lib/document_sync_worker_integration_spec.rb
@@ -14,6 +14,8 @@ RSpec.describe "Document sync worker end-to-end" do
 
     it "is added to the repository" do
       result = repository.get("f75d26a3-25a4-4c31-beea-a77cada4ce12")
+
+      expect(result[:metadata]).to match_json_schema(metadata_json_schema)
       expect(result[:metadata]).to eq(
         content_id: "f75d26a3-25a4-4c31-beea-a77cada4ce12",
         title: "Ebola medal for over 3000 heroes",
@@ -30,6 +32,7 @@ RSpec.describe "Document sync worker end-to-end" do
         ],
         locale: "en",
       )
+
       expect(result[:content]).to start_with("<div class=\"govspeak\"><p>The government has")
       expect(result[:content]).to end_with("response to Ebola</a>.</p>\n</div>\n\n</div>")
       expect(result[:content].length).to eq(4_932)
@@ -42,6 +45,8 @@ RSpec.describe "Document sync worker end-to-end" do
 
     it "is added to the repository" do
       result = repository.get("b662d0a3-c20d-4167-8056-b9c7d058d860")
+
+      expect(result[:metadata]).to match_json_schema(metadata_json_schema)
       expect(result[:metadata]).to eq(
         content_id: "b662d0a3-c20d-4167-8056-b9c7d058d860",
         title: "Austria travel advice",
@@ -58,6 +63,7 @@ RSpec.describe "Document sync worker end-to-end" do
         ],
         locale: "en",
       )
+
       expect(result[:content]).to be_empty
     end
   end
@@ -68,6 +74,8 @@ RSpec.describe "Document sync worker end-to-end" do
 
     it "is added to the repository" do
       result = repository.get("5c880596-7631-11e4-a3cb-005056011aef")
+
+      expect(result[:metadata]).to match_json_schema(metadata_json_schema)
       expect(result[:metadata]).to eq(
         content_id: "5c880596-7631-11e4-a3cb-005056011aef",
         title: "Travel advice for fans going to Champions League and Europa League matches this week",
@@ -86,6 +94,7 @@ RSpec.describe "Document sync worker end-to-end" do
         ],
         locale: "en",
       )
+
       expect(result[:content]).to start_with("<div class=\"govspeak\"><p>In the UEFA Champions")
       expect(result[:content]).to end_with("football fans</a>.</p>\n</div>")
       expect(result[:content].length).to eq(2_118)
@@ -98,6 +107,8 @@ RSpec.describe "Document sync worker end-to-end" do
 
     it "is added to the repository" do
       result = repository.get("526d5caf-221b-4c7b-9e74-b3e0b189fc8d")
+
+      expect(result[:metadata]).to match_json_schema(metadata_json_schema)
       expect(result[:metadata]).to eq(
         content_id: "526d5caf-221b-4c7b-9e74-b3e0b189fc8d",
         title: "Brighton & Hove City Council",
@@ -112,6 +123,7 @@ RSpec.describe "Document sync worker end-to-end" do
         part_of_taxonomy_tree: [],
         locale: "en",
       )
+
       expect(result[:content]).to be_blank
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -35,4 +35,5 @@ RSpec.configure do |config|
   end
 
   config.include FixtureHelpers
+  config.include SchemaHelpers
 end

--- a/spec/support/matchers/match_json_schema.rb
+++ b/spec/support/matchers/match_json_schema.rb
@@ -1,0 +1,14 @@
+RSpec::Matchers.define :match_json_schema do |expected_schema|
+  match do |json_string|
+    @errors = expected_schema.validate(json_string).map { _1["error"] }
+    @errors.none?
+  end
+
+  failure_message do
+    "Expected JSON to match schema, but validation failed:\n#{@errors.join("\n")}"
+  end
+
+  failure_message_when_negated do
+    "Expected JSON not to match schema, but it did."
+  end
+end

--- a/spec/support/schema_helpers.rb
+++ b/spec/support/schema_helpers.rb
@@ -1,0 +1,18 @@
+module SchemaHelpers
+  # TODO: This is the best option out of a bad bunch right now as this schema lives in a different
+  # repository. Maybe eventually we will vendor the schema, or get it directly from the GCP API
+  # client?
+  METADATA_JSON_SCHEMA_URI = URI.parse(
+    "https://raw.githubusercontent.com/alphagov/search-v2-infrastructure/main/terraform/modules/google_discovery_engine_restapi/files/datastore_schema.json",
+  )
+
+  # Returns a JSONSchemer object representing the JSON schema for document metadata
+  def metadata_json_schema
+    @metadata_json_schema ||= begin
+      remote_schema = Net::HTTP.get(METADATA_JSON_SCHEMA_URI)
+      schema_contents = JSON.parse(remote_schema)
+
+      JSONSchemer.schema(schema_contents)
+    end
+  end
+end


### PR DESCRIPTION
As Discovery Engine won't actually validate schemas for us on ingestion, we need to be a little bit more careful around our metadata to avoid accidentally modifying the schema of a datastore. This adds a middle ground solution of validating schema compliance as part of our integration tests.

Unfortunately the source of truth for the schema is in a different repository, and it's still actively "under construction", so to avoid vendoring schema that's at risk of becoming stale, for now we'll fetch the schema on running the tests.