### PR TITLE
Extract (partial) parts from documents

### DIFF
--- a/lib/document_sync_worker/document/publish.rb
+++ b/lib/document_sync_worker/document/publish.rb
@@ -47,6 +47,7 @@ module DocumentSyncWorker
           # Vertex can only currently boost on numeric fields, not booleans
           is_historic: historic? ? 1 : 0,
           locale: document_hash["locale"],
+          parts:,
         }
       end
 
@@ -90,6 +91,12 @@ module DocumentSyncWorker
         government = document_hash.dig("expanded_links", "government")&.first
 
         political && government&.dig("details", "current") == false
+      end
+
+      def parts
+        document_hash
+          .dig("details", "parts")
+          &.map { { slug: _1["slug"], title: _1["title"] } } || []
       end
     end
   end

--- a/spec/lib/document_sync_worker/document/publish_spec.rb
+++ b/spec/lib/document_sync_worker/document/publish_spec.rb
@@ -318,6 +318,37 @@ RSpec.describe DocumentSyncWorker::Document::Publish do
 
       it { is_expected.to eq("en") }
     end
+
+    describe "parts" do
+      subject(:extracted_parts) { document.metadata[:parts] }
+
+      let(:document_hash) { { "details" => { "parts" => parts } } }
+
+      context "when the document has no parts" do
+        let(:parts) { nil }
+
+        it { is_expected.to be_empty }
+      end
+
+      context "when the document has parts" do
+        let(:parts) do
+          [
+            {
+              "title" => "Part 1",
+              "slug" => "/part-1",
+              "body" => "Part 1 body",
+            },
+            {
+              "title" => "Part 2",
+              "slug" => "/part-2",
+              "body" => "Part 2 body",
+            },
+          ]
+        end
+
+        it { is_expected.to eq([{ title: "Part 1", slug: "/part-1" }, { title: "Part 2", slug: "/part-2" }]) }
+      end
+    end
   end
 
   describe "#synchronize_to" do

--- a/spec/lib/document_sync_worker_integration_spec.rb
+++ b/spec/lib/document_sync_worker_integration_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe "Document sync worker end-to-end" do
           668cd623-c7a8-4159-9575-90caac36d4b4 c31256e8-f328-462b-993f-dce50b7892e9
         ],
         locale: "en",
+        parts: [],
       )
 
       expect(result[:content]).to start_with("<div class=\"govspeak\"><p>The government has")
@@ -62,6 +63,13 @@ RSpec.describe "Document sync worker end-to-end" do
           8f78544f-a4ed-46b4-8163-889679d119b9 71cd9f51-f492-4c3f-91ca-5ad694c26592
         ],
         locale: "en",
+        parts: [
+          { slug: "warnings-and-insurance", title: "Warnings and insurance" },
+          { slug: "entry-requirements", title: "Entry requirements" },
+          { slug: "safety-and-security", title: "Safety and security" },
+          { slug: "health", title: "Health" },
+          { slug: "getting-help", title: "Getting help" },
+        ],
       )
 
       expect(result[:content]).to be_empty
@@ -93,6 +101,7 @@ RSpec.describe "Document sync worker end-to-end" do
           3dbeb4a3-33c0-4bda-bd21-b721b0f8736f
         ],
         locale: "en",
+        parts: [],
       )
 
       expect(result[:content]).to start_with("<div class=\"govspeak\"><p>In the UEFA Champions")
@@ -122,6 +131,7 @@ RSpec.describe "Document sync worker end-to-end" do
         content_purpose_supergroup: "other",
         part_of_taxonomy_tree: [],
         locale: "en",
+        parts: [],
       )
 
       expect(result[:content]).to be_blank


### PR DESCRIPTION
This extracts the title and slug from the document's parts (if present).