### PR TITLE
Add full parts content to unstructured content

### DIFF
--- a/spec/lib/document_sync_worker/document/publish_spec.rb
+++ b/spec/lib/document_sync_worker/document/publish_spec.rb
@@ -66,6 +66,39 @@ RSpec.describe DocumentSyncWorker::Document::Publish do
       it { is_expected.to eq("x\ny\nz") }
     end
 
+    describe "with parts" do
+      let(:document_hash) do
+        {
+          "details" => {
+            "parts" => [
+              {
+                "title" => "Foo",
+                "slug" => "/foo",
+                "body" => [
+                  {
+                    "content" => "bar",
+                    "content_type" => "text/html",
+                  },
+                ],
+              },
+              {
+                "title" => "Bar",
+                "slug" => "/bar",
+                "body" => [
+                  {
+                    "content" => "<blink>baz</blink>",
+                    "content_type" => "text/html",
+                  },
+                ],
+              },
+            ],
+          },
+        }
+      end
+
+      it { is_expected.to eq("<h1>Foo</h1>\nbar\n<h1>Bar</h1>\n<blink>baz</blink>") }
+    end
+
     describe "without any fields" do
       let(:document_hash) do
         {

--- a/spec/lib/document_sync_worker_integration_spec.rb
+++ b/spec/lib/document_sync_worker_integration_spec.rb
@@ -92,7 +92,11 @@ RSpec.describe "Document sync worker end-to-end" do
         ],
       )
 
-      expect(result[:content]).to be_empty
+      expect(result[:content]).to include("<h1>Warnings and insurance</h1>\n<p>The Foreign,")
+      expect(result[:content]).to include("<h1>Entry requirements</h1>\n<p>This advice reflects")
+      expect(result[:content]).to include("<h1>Safety and security</h1>\n<h2 id=\"terrorism\">")
+      expect(result[:content]).to include("<h1>Health</h1>\n<p>Before you travel")
+      expect(result[:content]).to include("<h1>Getting help</h1>\n<p>The Foreign,")
     end
   end
 


### PR DESCRIPTION
This adds the full HTML content of the `details.parts` property to the unstructured content, turning the titles into `<h1>` elements to give the search engine a better understanding of document structure.