### PR TITLE
Extract `government_name` from documents

### DIFF
--- a/lib/document_sync_worker/document/publish.rb
+++ b/lib/document_sync_worker/document/publish.rb
@@ -46,9 +46,10 @@ module DocumentSyncWorker
           part_of_taxonomy_tree: document_hash.dig("links", "taxons") || [],
           # Vertex can only currently boost on numeric fields, not booleans
           is_historic: historic? ? 1 : 0,
+          government_name:,
           locale: document_hash["locale"],
           parts:,
-        }
+        }.compact
       end
 
       # Extracts a single string of indexable unstructured content from the document.
@@ -100,6 +101,13 @@ module DocumentSyncWorker
         government = document_hash.dig("expanded_links", "government")&.first
 
         political && government&.dig("details", "current") == false
+      end
+
+      def government_name
+        document_hash
+          .dig("expanded_links", "government")
+          &.first
+          &.dig("title")
       end
 
       def parts

--- a/spec/lib/document_sync_worker/document/publish_spec.rb
+++ b/spec/lib/document_sync_worker/document/publish_spec.rb
@@ -308,8 +308,6 @@ RSpec.describe DocumentSyncWorker::Document::Publish do
     describe "is_historic" do
       subject(:extracted_is_historic) { document.metadata[:is_historic] }
 
-      let(:document_hash) { { "locale" => "en" } }
-
       context "when the document is non-political" do
         let(:document_hash) { { "details" => {} } }
 
@@ -340,6 +338,37 @@ RSpec.describe DocumentSyncWorker::Document::Publish do
           let(:expanded_links) { { "government" => [{ "details" => { "current" => false } }] } }
 
           it { is_expected.to eq(1) }
+        end
+      end
+    end
+
+    describe "government_name" do
+      subject(:extracted_government_name) { document.metadata[:government_name] }
+
+      context "when the document is non-political" do
+        let(:document_hash) { { "details" => {} } }
+
+        it { is_expected.to be_nil }
+      end
+
+      context "when the document is political" do
+        let(:document_hash) do
+          {
+            "details" => { "political" => true },
+            "expanded_links" => expanded_links,
+          }
+        end
+
+        context "without link to a government" do
+          let(:expanded_links) { {} }
+
+          it { is_expected.to be_nil }
+        end
+
+        context "with a link to a government" do
+          let(:expanded_links) { { "government" => [{ "title" => "2096 Something Party government" }] } }
+
+          it { is_expected.to eq("2096 Something Party government") }
         end
       end
     end

--- a/spec/lib/document_sync_worker_integration_spec.rb
+++ b/spec/lib/document_sync_worker_integration_spec.rb
@@ -26,12 +26,12 @@ RSpec.describe "Document sync worker end-to-end" do
         public_timestamp: 1_434_021_240,
         document_type: "press_release",
         is_historic: 0,
+        government_name: "2015 Conservative government",
         content_purpose_supergroup: "news_and_communications",
         part_of_taxonomy_tree: %w[
           668cd623-c7a8-4159-9575-90caac36d4b4 c31256e8-f328-462b-993f-dce50b7892e9
         ],
         locale: "en",
-        parts: nil,
       )
 
       expect(result[:content]).to start_with("<div class=\"govspeak\"><p>The government has")
@@ -118,6 +118,7 @@ RSpec.describe "Document sync worker end-to-end" do
         public_timestamp: 1_284_336_000,
         document_type: "news_story",
         is_historic: 1,
+        government_name: "2010 to 2015 Conservative and Liberal Democrat coalition government",
         content_purpose_supergroup: "news_and_communications",
         part_of_taxonomy_tree: %w[
           06ad07f7-1e79-462f-a192-6b2c9d92089c
@@ -125,7 +126,6 @@ RSpec.describe "Document sync worker end-to-end" do
           3dbeb4a3-33c0-4bda-bd21-b721b0f8736f
         ],
         locale: "en",
-        parts: nil,
       )
 
       expect(result[:content]).to start_with("<div class=\"govspeak\"><p>In the UEFA Champions")
@@ -155,7 +155,6 @@ RSpec.describe "Document sync worker end-to-end" do
         content_purpose_supergroup: "other",
         part_of_taxonomy_tree: [],
         locale: "en",
-        parts: nil,
       )
 
       expect(result[:content]).to be_blank


### PR DESCRIPTION
- Extract `government_name` from documents
- Compact metadata in order not to return nil values for non-present fields
- Remove stray `let` statement from `is_historic` field spec