### PR TITLE
Correct misleading spec for `government_name`

### DIFF
--- a/spec/lib/document_sync_worker/document/publish_spec.rb
+++ b/spec/lib/document_sync_worker/document/publish_spec.rb
@@ -345,31 +345,18 @@ RSpec.describe DocumentSyncWorker::Document::Publish do
     describe "government_name" do
       subject(:extracted_government_name) { document.metadata[:government_name] }
 
-      context "when the document is non-political" do
-        let(:document_hash) { { "details" => {} } }
+      let(:document_hash) { { "expanded_links" => expanded_links } }
+
+      context "without link to a government" do
+        let(:expanded_links) { {} }
 
         it { is_expected.to be_nil }
       end
 
-      context "when the document is political" do
-        let(:document_hash) do
-          {
-            "details" => { "political" => true },
-            "expanded_links" => expanded_links,
-          }
-        end
+      context "with a link to a government" do
+        let(:expanded_links) { { "government" => [{ "title" => "2096 Something Party government" }] } }
 
-        context "without link to a government" do
-          let(:expanded_links) { {} }
-
-          it { is_expected.to be_nil }
-        end
-
-        context "with a link to a government" do
-          let(:expanded_links) { { "government" => [{ "title" => "2096 Something Party government" }] } }
-
-          it { is_expected.to eq("2096 Something Party government") }
-        end
+        it { is_expected.to eq("2096 Something Party government") }
       end
     end
 


### PR DESCRIPTION
We always include the government name when present, even if the content item is not "political".