### PR TITLE
Add attachment titles to additional searchable text

### DIFF
--- a/lib/document_sync_worker/document/publish.rb
+++ b/lib/document_sync_worker/document/publish.rb
@@ -24,6 +24,7 @@ module DocumentSyncWorker
         $.details.metadata.hidden_indexable_content
         $.details.metadata.project_code
         $.details.acronym
+        $.details.attachments[*].title
       ].map { JsonPath.new(_1) }.freeze
       ADDITIONAL_SEARCHABLE_TEXT_VALUES_SEPARATOR = "\n".freeze
 

--- a/spec/fixtures/files/message_queue/independent_report_message.json
+++ b/spec/fixtures/files/message_queue/independent_report_message.json
@@ -1,0 +1,395 @@
+{
+  "title": "Directgov 2010 and beyond: revolution not evolution, a report by Martha Lane Fox",
+  "public_updated_at": "2010-11-23T00:00:00Z",
+  "publishing_app": "whitehall",
+  "rendering_app": "government-frontend",
+  "update_type": "republish",
+  "phase": "live",
+  "analytics_identifier": null,
+  "document_type": "independent_report",
+  "schema_name": "publication",
+  "first_published_at": "2010-11-23T00:00:00Z",
+  "base_path": "/government/publications/directgov-2010-and-beyond-revolution-not-evolution-a-report-by-martha-lane-fox",
+  "description": "A report from the Digital Champion Martha Lane Fox with recommendations for the future of Directgov.",
+  "details": {
+    "body": "\u003cdiv class=\"govspeak\"\u003e\u003cp\u003eA report from the Digital Champion Martha Lane Fox with recommendations for the future of Directgov sent to the Minister for the Cabinet Office Francis Maude. \u003c/p\u003e\n\u003c/div\u003e",
+    "tags": {
+      "topics": [],
+      "browse_pages": []
+    },
+    "documents": [
+      "\u003csection class=\"gem-c-attachment govuk-!-display-none-print govuk-!-margin-bottom-6\" data-module=\"ga4-link-tracker\"\u003e\n  \u003cdiv class=\"gem-c-attachment__thumbnail\"\u003e\n    \u003ca class=\"govuk-link\" target=\"_self\" tabindex=\"-1\" aria-hidden=\"true\" data-ga4-link=\"{\u0026quot;event_name\u0026quot;:\u0026quot;file_download\u0026quot;,\u0026quot;type\u0026quot;:\u0026quot;attachment\u0026quot;}\" href=\"https://assets.publishing.service.gov.uk/media/5a78f39eed915d0422066a0d/Martha_20Lane_20Fox_s_20letter_20to_20Francis_20Maude_2014th_20Oct_202010.pdf\"\u003e\u003cimg alt=\"\" class=\"gem-c-attachment__thumbnail-image gem-c-attachment__thumbnail-image--custom\" src=\"https://assets.publishing.service.gov.uk/media/5a78f39ee5274a2acd18b0e9/thumbnail_Martha_20Lane_20Fox_s_20letter_20to_20Francis_20Maude_2014th_20Oct_202010.pdf.png\" /\u003e\u003c/a\u003e\u003c/div\u003e\n  \u003cdiv class=\"gem-c-attachment__details\"\u003e\n    \u003ch2 class=\"gem-c-attachment__title\"\u003e\n      \u003ca class=\"govuk-link gem-c-attachment__link\" target=\"_self\" data-ga4-link=\"{\u0026quot;event_name\u0026quot;:\u0026quot;file_download\u0026quot;,\u0026quot;type\u0026quot;:\u0026quot;attachment\u0026quot;}\" href=\"https://assets.publishing.service.gov.uk/media/5a78f39eed915d0422066a0d/Martha_20Lane_20Fox_s_20letter_20to_20Francis_20Maude_2014th_20Oct_202010.pdf\"\u003eDirectgov 2010 and Beyond: Revolution Not Evolution - Letter from Martha Lane Fox to Francis Maude\u003c/a\u003e\n\u003c/h2\u003e\n\n\n      \u003cp class=\"gem-c-attachment__metadata\"\u003e\u003cspan class=\"gem-c-attachment__attribute\"\u003e\u003cabbr title=\"Portable Document Format\" class=\"gem-c-attachment__abbr\"\u003ePDF\u003c/abbr\u003e\u003c/span\u003e, \u003cspan class=\"gem-c-attachment__attribute\"\u003e2.58 MB\u003c/span\u003e, \u003cspan class=\"gem-c-attachment__attribute\"\u003e11 pages\u003c/span\u003e\u003c/p\u003e\n\n\n\n\n      \u003cp class=\"gem-c-attachment__metadata\"\u003eThis file may not be suitable for users of assistive technology.\u003c/p\u003e\n      \u003cdetails class=\"gem-c-details govuk-details govuk-!-margin-bottom-3\" data-module=\"govuk-details gem-details\"\u003e\n  \u003csummary class=\"govuk-details__summary\" data-details-track-click=\"\"\u003e\n    \u003cspan class=\"govuk-details__summary-text\"\u003e\n      Request an accessible format.\n    \u003c/span\u003e\n\u003c/summary\u003e  \u003cdiv class=\"govuk-details__text\"\u003e\n    \n        If you use assistive technology (such as a screen reader) and need a version of this document in a more accessible format, please email \u003ca href='mailto:accessible.formats@cabinetoffice.gov.uk' target='_blank' class='govuk-link'\u003eaccessible.formats@cabinetoffice.gov.uk\u003c/a\u003e. Please tell us what format you need. It will help us if you say what assistive technology you use.\n\n  \u003c/div\u003e\n\u003c/details\u003e\u003c/div\u003e\u003c/section\u003e",
+      "\u003csection class=\"gem-c-attachment govuk-!-display-none-print govuk-!-margin-bottom-6\" data-module=\"ga4-link-tracker\"\u003e\n  \u003cdiv class=\"gem-c-attachment__thumbnail\"\u003e\n    \u003ca class=\"govuk-link\" target=\"_self\" tabindex=\"-1\" aria-hidden=\"true\" data-ga4-link=\"{\u0026quot;event_name\u0026quot;:\u0026quot;file_download\u0026quot;,\u0026quot;type\u0026quot;:\u0026quot;attachment\u0026quot;}\" href=\"https://assets.publishing.service.gov.uk/media/5a75a041e5274a4368298b73/Francis_20Maude_s_20letter_20to_20Martha_20Lane_20Fox_2022_20Nov_202010.pdf\"\u003e\u003cimg alt=\"\" class=\"gem-c-attachment__thumbnail-image gem-c-attachment__thumbnail-image--custom\" src=\"https://assets.publishing.service.gov.uk/media/5a75a04140f0b67b3d5c7f54/thumbnail_Francis_20Maude_s_20letter_20to_20Martha_20Lane_20Fox_2022_20Nov_202010.pdf.png\" /\u003e\u003c/a\u003e\u003c/div\u003e\n  \u003cdiv class=\"gem-c-attachment__details\"\u003e\n    \u003ch2 class=\"gem-c-attachment__title\"\u003e\n      \u003ca class=\"govuk-link gem-c-attachment__link\" target=\"_self\" data-ga4-link=\"{\u0026quot;event_name\u0026quot;:\u0026quot;file_download\u0026quot;,\u0026quot;type\u0026quot;:\u0026quot;attachment\u0026quot;}\" href=\"https://assets.publishing.service.gov.uk/media/5a75a041e5274a4368298b73/Francis_20Maude_s_20letter_20to_20Martha_20Lane_20Fox_2022_20Nov_202010.pdf\"\u003eFrancis Maude\u0026#39;s reply to Martha Lane Fox\u0026#39;s letter\u003c/a\u003e\n\u003c/h2\u003e\n\n\n      \u003cp class=\"gem-c-attachment__metadata\"\u003e\u003cspan class=\"gem-c-attachment__attribute\"\u003e\u003cabbr title=\"Portable Document Format\" class=\"gem-c-attachment__abbr\"\u003ePDF\u003c/abbr\u003e\u003c/span\u003e, \u003cspan class=\"gem-c-attachment__attribute\"\u003e237 KB\u003c/span\u003e, \u003cspan class=\"gem-c-attachment__attribute\"\u003e2 pages\u003c/span\u003e\u003c/p\u003e\n\n\n\n\n      \u003cp class=\"gem-c-attachment__metadata\"\u003eThis file may not be suitable for users of assistive technology.\u003c/p\u003e\n      \u003cdetails class=\"gem-c-details govuk-details govuk-!-margin-bottom-3\" data-module=\"govuk-details gem-details\"\u003e\n  \u003csummary class=\"govuk-details__summary\" data-details-track-click=\"\"\u003e\n    \u003cspan class=\"govuk-details__summary-text\"\u003e\n      Request an accessible format.\n    \u003c/span\u003e\n\u003c/summary\u003e  \u003cdiv class=\"govuk-details__text\"\u003e\n    \n        If you use assistive technology (such as a screen reader) and need a version of this document in a more accessible format, please email \u003ca href='mailto:accessible.formats@cabinetoffice.gov.uk' target='_blank' class='govuk-link'\u003eaccessible.formats@cabinetoffice.gov.uk\u003c/a\u003e. Please tell us what format you need. It will help us if you say what assistive technology you use.\n\n  \u003c/div\u003e\n\u003c/details\u003e\u003c/div\u003e\u003c/section\u003e",
+      "\u003csection class=\"gem-c-attachment govuk-!-display-none-print govuk-!-margin-bottom-6\" data-module=\"ga4-link-tracker\"\u003e\n  \u003cdiv class=\"gem-c-attachment__thumbnail\"\u003e\n    \u003ca class=\"govuk-link\" target=\"_self\" tabindex=\"-1\" aria-hidden=\"true\" data-ga4-link=\"{\u0026quot;event_name\u0026quot;:\u0026quot;file_download\u0026quot;,\u0026quot;type\u0026quot;:\u0026quot;attachment\u0026quot;}\" href=\"https://assets.publishing.service.gov.uk/media/5a78d4f5ed915d07d35b2c5c/Directgov_20Executive_20Sum_20FINAL.pdf\"\u003e\u003cimg alt=\"\" class=\"gem-c-attachment__thumbnail-image gem-c-attachment__thumbnail-image--custom\" src=\"https://assets.publishing.service.gov.uk/media/5a78d4f7ed915d07d35b2c5d/thumbnail_Directgov_20Executive_20Sum_20FINAL.pdf.png\" /\u003e\u003c/a\u003e\u003c/div\u003e\n  \u003cdiv class=\"gem-c-attachment__details\"\u003e\n    \u003ch2 class=\"gem-c-attachment__title\"\u003e\n      \u003ca class=\"govuk-link gem-c-attachment__link\" target=\"_self\" data-ga4-link=\"{\u0026quot;event_name\u0026quot;:\u0026quot;file_download\u0026quot;,\u0026quot;type\u0026quot;:\u0026quot;attachment\u0026quot;}\" href=\"https://assets.publishing.service.gov.uk/media/5a78d4f5ed915d07d35b2c5c/Directgov_20Executive_20Sum_20FINAL.pdf\"\u003eDirectgov Strategic Review - Executive Summary\u003c/a\u003e\n\u003c/h2\u003e\n\n\n      \u003cp class=\"gem-c-attachment__metadata\"\u003e\u003cspan class=\"gem-c-attachment__attribute\"\u003e\u003cabbr title=\"Portable Document Format\" class=\"gem-c-attachment__abbr\"\u003ePDF\u003c/abbr\u003e\u003c/span\u003e, \u003cspan class=\"gem-c-attachment__attribute\"\u003e838 KB\u003c/span\u003e, \u003cspan class=\"gem-c-attachment__attribute\"\u003e5 pages\u003c/span\u003e\u003c/p\u003e\n\n\n\n\n      \u003cp class=\"gem-c-attachment__metadata\"\u003eThis file may not be suitable for users of assistive technology.\u003c/p\u003e\n      \u003cdetails class=\"gem-c-details govuk-details govuk-!-margin-bottom-3\" data-module=\"govuk-details gem-details\"\u003e\n  \u003csummary class=\"govuk-details__summary\" data-details-track-click=\"\"\u003e\n    \u003cspan class=\"govuk-details__summary-text\"\u003e\n      Request an accessible format.\n    \u003c/span\u003e\n\u003c/summary\u003e  \u003cdiv class=\"govuk-details__text\"\u003e\n    \n        If you use assistive technology (such as a screen reader) and need a version of this document in a more accessible format, please email \u003ca href='mailto:accessible.formats@cabinetoffice.gov.uk' target='_blank' class='govuk-link'\u003eaccessible.formats@cabinetoffice.gov.uk\u003c/a\u003e. Please tell us what format you need. It will help us if you say what assistive technology you use.\n\n  \u003c/div\u003e\n\u003c/details\u003e\u003c/div\u003e\u003c/section\u003e"
+    ],
+    "political": false,
+    "attachments": [
+      {
+        "id": "736845",
+        "url": "https://assets.publishing.service.gov.uk/media/5a78f39eed915d0422066a0d/Martha_20Lane_20Fox_s_20letter_20to_20Francis_20Maude_2014th_20Oct_202010.pdf",
+        "isbn": "",
+        "title": "Directgov 2010 and Beyond: Revolution Not Evolution - Letter from Martha Lane Fox to Francis Maude",
+        "filename": "Martha_20Lane_20Fox_s_20letter_20to_20Francis_20Maude_2014th_20Oct_202010.pdf",
+        "file_size": 2702963,
+        "accessible": false,
+        "content_type": "application/pdf",
+        "attachment_type": "file",
+        "number_of_pages": 11,
+        "unique_reference": "",
+        "command_paper_number": "",
+        "unnumbered_hoc_paper": false,
+        "unnumbered_command_paper": false,
+        "alternative_format_contact_email": "accessible.formats@cabinetoffice.gov.uk"
+      },
+      {
+        "id": "736846",
+        "url": "https://assets.publishing.service.gov.uk/media/5a75a041e5274a4368298b73/Francis_20Maude_s_20letter_20to_20Martha_20Lane_20Fox_2022_20Nov_202010.pdf",
+        "isbn": "",
+        "title": "Francis Maude's reply to Martha Lane Fox's letter",
+        "filename": "Francis_20Maude_s_20letter_20to_20Martha_20Lane_20Fox_2022_20Nov_202010.pdf",
+        "file_size": 243051,
+        "accessible": false,
+        "content_type": "application/pdf",
+        "attachment_type": "file",
+        "number_of_pages": 2,
+        "unique_reference": "",
+        "command_paper_number": "",
+        "unnumbered_hoc_paper": false,
+        "unnumbered_command_paper": false,
+        "alternative_format_contact_email": "accessible.formats@cabinetoffice.gov.uk"
+      },
+      {
+        "id": "736847",
+        "url": "https://assets.publishing.service.gov.uk/media/5a78d4f5ed915d07d35b2c5c/Directgov_20Executive_20Sum_20FINAL.pdf",
+        "isbn": "",
+        "title": "Directgov Strategic Review - Executive Summary",
+        "filename": "Directgov_20Executive_20Sum_20FINAL.pdf",
+        "file_size": 858482,
+        "accessible": false,
+        "content_type": "application/pdf",
+        "attachment_type": "file",
+        "number_of_pages": 5,
+        "unique_reference": "",
+        "command_paper_number": "",
+        "unnumbered_hoc_paper": false,
+        "unnumbered_command_paper": false,
+        "alternative_format_contact_email": "accessible.formats@cabinetoffice.gov.uk"
+      }
+    ],
+    "change_history": [
+      {
+        "note": "First published.",
+        "public_timestamp": "2010-11-23T00:00:00.000+00:00"
+      }
+    ],
+    "first_public_at": "2010-11-23T00:00:00.000+00:00",
+    "featured_attachments": [
+      "736845",
+      "736846",
+      "736847"
+    ],
+    "emphasised_organisations": [
+      "96ae61d6-c2a1-48cb-8e67-da9d105ae381"
+    ]
+  },
+  "routes": [
+    {
+      "path": "/government/publications/directgov-2010-and-beyond-revolution-not-evolution-a-report-by-martha-lane-fox",
+      "type": "exact"
+    }
+  ],
+  "redirects": [],
+  "content_id": "5d315ee8-7631-11e4-a3cb-005056011aef",
+  "locale": "en",
+  "expanded_links": {
+    "government": [
+      {
+        "content_id": "591c83aa-3b74-437d-a342-612bddd97572",
+        "title": "2010 to 2015 Conservative and Liberal Democrat coalition government",
+        "locale": "en",
+        "api_path": "/api/content/government/2010-to-2015-conservative-and-liberal-democrat-coalition-government",
+        "base_path": "/government/2010-to-2015-conservative-and-liberal-democrat-coalition-government",
+        "document_type": "government",
+        "details": {
+          "started_on": "2010-05-12T00:00:00+00:00",
+          "ended_on": "2015-05-08T00:00:00+00:00",
+          "current": false
+        },
+        "links": {}
+      }
+    ],
+    "organisations": [
+      {
+        "content_id": "96ae61d6-c2a1-48cb-8e67-da9d105ae381",
+        "title": "Cabinet Office",
+        "locale": "en",
+        "analytics_identifier": "D2",
+        "api_path": "/api/content/government/organisations/cabinet-office",
+        "base_path": "/government/organisations/cabinet-office",
+        "document_type": "organisation",
+        "schema_name": "organisation",
+        "withdrawn": false,
+        "details": {
+          "acronym": "",
+          "logo": {
+            "crest": "single-identity",
+            "formatted_title": "Cabinet Office"
+          },
+          "brand": "cabinet-office",
+          "default_news_image": {
+            "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/default_news_organisation_image_data/file/148/s300_cabinet-office.jpg",
+            "high_resolution_url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/default_news_organisation_image_data/file/148/s960_cabinet-office.jpg"
+          },
+          "organisation_govuk_status": {
+            "url": null,
+            "status": "live",
+            "updated_at": null
+          }
+        },
+        "links": {}
+      },
+      {
+        "content_id": "ec61fac5-95e9-46bb-8429-7129aab6d96d",
+        "title": "Efficiency and Reform Group",
+        "locale": "en",
+        "analytics_identifier": "OT507",
+        "api_path": "/api/content/government/organisations/efficiency-and-reform-group",
+        "base_path": "/government/organisations/efficiency-and-reform-group",
+        "document_type": "organisation",
+        "schema_name": "organisation",
+        "withdrawn": false,
+        "details": {
+          "acronym": "ERG",
+          "logo": {
+            "crest": "single-identity",
+            "formatted_title": "Efficiency and Reform Group"
+          },
+          "brand": "cabinet-office",
+          "default_news_image": null,
+          "organisation_govuk_status": {
+            "url": "",
+            "status": "no_longer_exists",
+            "updated_at": "2014-10-13T00:00:00.000+01:00"
+          }
+        },
+        "links": {}
+      },
+      {
+        "content_id": "af07d5a5-df63-4ddc-9383-6a666845ebe9",
+        "title": "Government Digital Service",
+        "locale": "en",
+        "analytics_identifier": "OT1056",
+        "api_path": "/api/content/government/organisations/government-digital-service",
+        "base_path": "/government/organisations/government-digital-service",
+        "document_type": "organisation",
+        "schema_name": "organisation",
+        "withdrawn": false,
+        "details": {
+          "acronym": "GDS",
+          "logo": {
+            "crest": "single-identity",
+            "formatted_title": "Government Digital Service"
+          },
+          "brand": "cabinet-office",
+          "default_news_image": null,
+          "organisation_govuk_status": {
+            "url": null,
+            "status": "live",
+            "updated_at": null
+          }
+        },
+        "links": {}
+      }
+    ],
+    "original_primary_publishing_organisation": [
+      {
+        "content_id": "96ae61d6-c2a1-48cb-8e67-da9d105ae381",
+        "title": "Cabinet Office",
+        "locale": "en",
+        "analytics_identifier": "D2",
+        "api_path": "/api/content/government/organisations/cabinet-office",
+        "base_path": "/government/organisations/cabinet-office",
+        "document_type": "organisation",
+        "schema_name": "organisation",
+        "withdrawn": false,
+        "details": {
+          "acronym": "",
+          "logo": {
+            "crest": "single-identity",
+            "formatted_title": "Cabinet Office"
+          },
+          "brand": "cabinet-office",
+          "default_news_image": {
+            "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/default_news_organisation_image_data/file/148/s300_cabinet-office.jpg",
+            "high_resolution_url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/default_news_organisation_image_data/file/148/s960_cabinet-office.jpg"
+          },
+          "organisation_govuk_status": {
+            "url": null,
+            "status": "live",
+            "updated_at": null
+          }
+        },
+        "links": {}
+      }
+    ],
+    "primary_publishing_organisation": [
+      {
+        "content_id": "96ae61d6-c2a1-48cb-8e67-da9d105ae381",
+        "title": "Cabinet Office",
+        "locale": "en",
+        "analytics_identifier": "D2",
+        "api_path": "/api/content/government/organisations/cabinet-office",
+        "base_path": "/government/organisations/cabinet-office",
+        "document_type": "organisation",
+        "schema_name": "organisation",
+        "withdrawn": false,
+        "details": {
+          "acronym": "",
+          "logo": {
+            "crest": "single-identity",
+            "formatted_title": "Cabinet Office"
+          },
+          "brand": "cabinet-office",
+          "default_news_image": {
+            "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/default_news_organisation_image_data/file/148/s300_cabinet-office.jpg",
+            "high_resolution_url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/default_news_organisation_image_data/file/148/s960_cabinet-office.jpg"
+          },
+          "organisation_govuk_status": {
+            "url": null,
+            "status": "live",
+            "updated_at": null
+          }
+        },
+        "links": {}
+      }
+    ],
+    "taxons": [
+      {
+        "content_id": "f3caf326-fe33-410f-b7f4-553f4011c81e",
+        "title": "Government spending",
+        "locale": "en",
+        "analytics_identifier": null,
+        "api_path": "/api/content/government/government-spending",
+        "base_path": "/government/government-spending",
+        "document_type": "taxon",
+        "public_updated_at": "2018-08-17T15:32:41Z",
+        "schema_name": "taxon",
+        "withdrawn": false,
+        "description": null,
+        "details": {
+          "internal_name": "Government spending (level 2)",
+          "notes_for_editors": "",
+          "visible_to_departmental_editors": false
+        },
+        "phase": "live",
+        "links": {
+          "parent_taxons": [
+            {
+              "content_id": "f3f4b5d3-49c4-487b-bd5b-be75f11ec8c5",
+              "title": "Government efficiency, transparency and accountability",
+              "locale": "en",
+              "analytics_identifier": null,
+              "api_path": "/api/content/government/government-efficiency-transparency-and-accountability",
+              "base_path": "/government/government-efficiency-transparency-and-accountability",
+              "document_type": "taxon",
+              "public_updated_at": "2018-08-17T15:32:41Z",
+              "schema_name": "taxon",
+              "withdrawn": false,
+              "description": null,
+              "details": {
+                "internal_name": "Government efficiency, transparency and accountability [PA] (level 2)",
+                "notes_for_editors": "",
+                "visible_to_departmental_editors": false
+              },
+              "phase": "live",
+              "links": {
+                "parent_taxons": [
+                  {
+                    "content_id": "e48ab80a-de80-4e83-bf59-26316856a5f9",
+                    "title": "Government",
+                    "locale": "en",
+                    "analytics_identifier": null,
+                    "api_path": "/api/content/government/all",
+                    "base_path": "/government/all",
+                    "document_type": "taxon",
+                    "public_updated_at": "2018-09-16T20:29:39Z",
+                    "schema_name": "taxon",
+                    "withdrawn": false,
+                    "description": "",
+                    "details": {
+                      "internal_name": "Government",
+                      "notes_for_editors": "",
+                      "visible_to_departmental_editors": true
+                    },
+                    "phase": "live",
+                    "links": {
+                      "root_taxon": [
+                        {
+                          "content_id": "f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a",
+                          "title": "GOV.UK homepage",
+                          "locale": "en",
+                          "analytics_identifier": null,
+                          "api_path": "/api/content/",
+                          "base_path": "/",
+                          "document_type": "homepage",
+                          "public_updated_at": "2023-06-28T09:32:34Z",
+                          "schema_name": "homepage",
+                          "withdrawn": false,
+                          "links": {}
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "available_translations": [
+      {
+        "title": "Directgov 2010 and beyond: revolution not evolution, a report by Martha Lane Fox",
+        "public_updated_at": "2010-11-23T00:00:00Z",
+        "analytics_identifier": null,
+        "document_type": "independent_report",
+        "schema_name": "publication",
+        "base_path": "/government/publications/directgov-2010-and-beyond-revolution-not-evolution-a-report-by-martha-lane-fox",
+        "api_path": "/api/content/government/publications/directgov-2010-and-beyond-revolution-not-evolution-a-report-by-martha-lane-fox",
+        "withdrawn": false,
+        "content_id": "5d315ee8-7631-11e4-a3cb-005056011aef",
+        "locale": "en"
+      }
+    ]
+  },
+  "user_journey_document_supertype": "thing",
+  "email_document_supertype": "publications",
+  "government_document_supertype": "independent-reports",
+  "content_purpose_subgroup": "research",
+  "content_purpose_supergroup": "research_and_statistics",
+  "publishing_request_id": "21-1695981308.628-10.13.33.126-698",
+  "govuk_request_id": null,
+  "links": {
+    "government": [
+      "591c83aa-3b74-437d-a342-612bddd97572"
+    ],
+    "organisations": [
+      "96ae61d6-c2a1-48cb-8e67-da9d105ae381",
+      "ec61fac5-95e9-46bb-8429-7129aab6d96d",
+      "af07d5a5-df63-4ddc-9383-6a666845ebe9"
+    ],
+    "original_primary_publishing_organisation": [
+      "96ae61d6-c2a1-48cb-8e67-da9d105ae381"
+    ],
+    "primary_publishing_organisation": [
+      "96ae61d6-c2a1-48cb-8e67-da9d105ae381"
+    ],
+    "related_policies": [
+      "5d2b59a2-7631-11e4-a3cb-005056011aef"
+    ],
+    "taxons": [
+      "f3caf326-fe33-410f-b7f4-553f4011c81e"
+    ]
+  },
+  "payload_version": "54321"
+}

--- a/spec/lib/document_sync_worker/document/publish_spec.rb
+++ b/spec/lib/document_sync_worker/document/publish_spec.rb
@@ -203,6 +203,21 @@ RSpec.describe DocumentSyncWorker::Document::Publish do
 
         it { is_expected.to eq("LOL") }
       end
+
+      describe "with attachments" do
+        let(:document_hash) do
+          {
+            "details" => {
+              "attachments" => [
+                { "title" => "A report" },
+                { "title" => "Another report" },
+              ],
+            },
+          }
+        end
+
+        it { is_expected.to eq("A report\nAnother report") }
+      end
     end
 
     describe "link" do

--- a/spec/lib/document_sync_worker_integration_spec.rb
+++ b/spec/lib/document_sync_worker_integration_spec.rb
@@ -164,6 +164,40 @@ RSpec.describe "Document sync worker end-to-end" do
     end
   end
 
+  describe "for an 'independent_report' message" do
+    let(:documents) { {} }
+    let(:payload) { json_fixture_as_hash("message_queue/independent_report_message.json") }
+
+    it "is added to the repository" do
+      result = repository.get("5d315ee8-7631-11e4-a3cb-005056011aef")
+
+      expect(result[:metadata]).to match_json_schema(metadata_json_schema)
+      expect(result[:metadata]).to eq(
+        content_id: "5d315ee8-7631-11e4-a3cb-005056011aef",
+        title: "Directgov 2010 and beyond: revolution not evolution, a report by Martha Lane Fox",
+        description: "A report from the Digital Champion Martha Lane Fox with recommendations for the future of Directgov.",
+        additional_searchable_text: <<~TEXT.chomp,
+          Directgov 2010 and Beyond: Revolution Not Evolution - Letter from Martha Lane Fox to Francis Maude
+          Francis Maude's reply to Martha Lane Fox's letter
+          Directgov Strategic Review - Executive Summary
+        TEXT
+        link: "/government/publications/directgov-2010-and-beyond-revolution-not-evolution-a-report-by-martha-lane-fox",
+        url: "http://www.dev.gov.uk/government/publications/directgov-2010-and-beyond-revolution-not-evolution-a-report-by-martha-lane-fox",
+        public_timestamp: 1_290_470_400,
+        document_type: "independent_report",
+        is_historic: 0,
+        government_name: "2010 to 2015 Conservative and Liberal Democrat coalition government",
+        content_purpose_supergroup: "research_and_statistics",
+        part_of_taxonomy_tree: %w[f3caf326-fe33-410f-b7f4-553f4011c81e],
+        locale: "en",
+      )
+
+      expect(result[:content]).to start_with("<div class=\"govspeak\"><p>A report from the Digital Champion")
+      expect(result[:content]).to end_with("Francis Maude.\u00a0</p>\n</div>")
+      expect(result[:content].length).to eq(195)
+    end
+  end
+
   describe "for an 'external_content' message" do
     let(:documents) { {} }
     let(:payload) { json_fixture_as_hash("message_queue/external_content_message.json") }


### PR DESCRIPTION
- Extract attachment titles from `details.attachment` into `additional_searchable_text`
- Add integration spec for `independent_report` document type