### PR TITLE
Coerce documents' `payload_version` to int

### DIFF
--- a/lib/document_sync_worker/document/base.rb
+++ b/lib/document_sync_worker/document/base.rb
@@ -18,7 +18,7 @@ module DocumentSyncWorker
 
       # The payload version of the document.
       def payload_version
-        document_hash.fetch("payload_version")
+        document_hash.fetch("payload_version").to_i
       end
 
     private

--- a/spec/lib/document_sync_worker/document/publish_spec.rb
+++ b/spec/lib/document_sync_worker/document/publish_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe DocumentSyncWorker::Document::Publish do
   end
 
   let(:content_id) { "123" }
-  let(:payload_version) { 1 }
+  let(:payload_version) { "1" }
   let(:document_type) { "press_release" }
   let(:document_hash) do
     {
@@ -24,7 +24,7 @@ RSpec.describe DocumentSyncWorker::Document::Publish do
 
   describe "#payload_version" do
     it "returns the payload_version from the document hash" do
-      expect(document.payload_version).to eq(payload_version)
+      expect(document.payload_version).to eq(1)
     end
   end
 
@@ -522,7 +522,7 @@ RSpec.describe DocumentSyncWorker::Document::Publish do
       document.synchronize_to(repository)
 
       expect(repository).to have_received(:put).with(
-        content_id, document.metadata, content: document.content, payload_version:
+        content_id, document.metadata, content: document.content, payload_version: 1
       )
     end
   end

--- a/spec/lib/document_sync_worker/document/unpublish_spec.rb
+++ b/spec/lib/document_sync_worker/document/unpublish_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe DocumentSyncWorker::Document::Unpublish do
   end
 
   let(:content_id) { "123" }
-  let(:payload_version) { 1 }
+  let(:payload_version) { "1" }
   let(:document_type) { "gone" }
   let(:document_hash) do
     {
@@ -24,7 +24,7 @@ RSpec.describe DocumentSyncWorker::Document::Unpublish do
 
   describe "#payload_version" do
     it "returns the payload_version from the document hash" do
-      expect(document.payload_version).to eq(payload_version)
+      expect(document.payload_version).to eq(1)
     end
   end
 
@@ -32,7 +32,7 @@ RSpec.describe DocumentSyncWorker::Document::Unpublish do
     it "deletes the document from the repository" do
       document.synchronize_to(repository)
 
-      expect(repository).to have_received(:delete).with(content_id, payload_version:)
+      expect(repository).to have_received(:delete).with(content_id, payload_version: 1)
     end
   end
 end


### PR DESCRIPTION
This may come through as either an integer or a string representation of an integer (?), so make sure it's always the former when synchronizing.