### PR TITLE
Improve configuration of `GoogleDiscoveryEngine` repo

### DIFF
--- a/lib/repositories/google_discovery_engine/repository.rb
+++ b/lib/repositories/google_discovery_engine/repository.rb
@@ -4,13 +4,16 @@ module Repositories
   module GoogleDiscoveryEngine
     # A repository integrating with Google Discovery Engine
     class Repository
-      # We only ever use the default branch (for now)
-      BRANCH = "/branches/default_branch".freeze
+      DEFAULT_BRANCH_NAME = "default_branch".freeze
 
       def initialize(
+        datastore_path,
+        branch_name: DEFAULT_BRANCH_NAME,
         client: ::Google::Cloud::DiscoveryEngine.document_service(version: :v1),
         logger: Logger.new($stdout, progname: self.class.name)
       )
+        @datastore_path = datastore_path
+        @branch_name = branch_name
         @client = client
         @logger = logger
       end
@@ -42,14 +45,10 @@ module Repositories
 
     private
 
-      attr_reader :client, :logger
-
-      def datastore_path
-        ENV.fetch("DISCOVERY_ENGINE_DATASTORE")
-      end
+      attr_reader :datastore_path, :branch_name, :client, :logger
 
       def branch_path
-        datastore_path + BRANCH
+        "#{datastore_path}/branches/#{branch_name}"
       end
 
       def document_name(content_id)

--- a/lib/tasks/document_sync_worker.rake
+++ b/lib/tasks/document_sync_worker.rake
@@ -18,7 +18,10 @@ namespace :document_sync_worker do
   desc "Listens to and processes messages from the published documents queue"
   task run: :environment do
     DocumentSyncWorker.configure do |config|
-      config.repository = Repositories::GoogleDiscoveryEngine::Repository.new(logger: config.logger)
+      config.repository = Repositories::GoogleDiscoveryEngine::Repository.new(
+        ENV.fetch("DISCOVERY_ENGINE_DATASTORE"),
+        logger: config.logger,
+      )
       config.message_queue_name = ENV.fetch("PUBLISHED_DOCUMENTS_MESSAGE_QUEUE_NAME")
     end
 

--- a/spec/lib/repositories/google_discovery_engine/repository_spec.rb
+++ b/spec/lib/repositories/google_discovery_engine/repository_spec.rb
@@ -4,12 +4,18 @@ require "repositories/google_discovery_engine/repository"
 require "google/cloud/discovery_engine/v1"
 
 RSpec.describe Repositories::GoogleDiscoveryEngine::Repository do
-  let(:repository) { described_class.new(client:, logger:) }
+  let(:repository) do
+    described_class.new(
+      "datastore-path",
+      branch_name: "my_branch",
+      client:,
+      logger:,
+    )
+  end
   let(:client) { instance_double(Google::Cloud::DiscoveryEngine::V1::DocumentService::Client) }
   let(:logger) { instance_double(Logger, info: nil, warn: nil, error: nil) }
 
   before do
-    allow(ENV).to receive(:fetch).with("DISCOVERY_ENGINE_DATASTORE").and_return("datastore-path")
     allow(GovukError).to receive(:notify)
   end
 
@@ -39,7 +45,7 @@ RSpec.describe Repositories::GoogleDiscoveryEngine::Repository do
 
       it "deletes the document" do
         expect(client).to have_received(:delete_document)
-          .with(name: "datastore-path/branches/default_branch/documents/some_content_id")
+          .with(name: "datastore-path/branches/my_branch/documents/some_content_id")
       end
 
       it "logs the delete operation" do


### PR DESCRIPTION
- Pass in datastore path instead of getting it from environment
- Make branch configurable