### PR TITLE
Refactor querying into `Query` model

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
   test-ruby:
     name: Test Ruby
     runs-on: ubuntu-latest
+    env:
+      DISCOVERY_ENGINE_ENGINE: "engine"
     steps:
       - uses: actions/checkout@v3
         with:

--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -1,9 +1,5 @@
 class SearchesController < ApplicationController
   def show
-    render json: {
-      results: [],
-      total: 0,
-      start: 0,
-    }
+    render json: Query.new.result_set
   end
 end

--- a/app/models/query.rb
+++ b/app/models/query.rb
@@ -1,0 +1,10 @@
+# Represents a user's search query that can be executed against Discovery Engine
+class Query
+  def result_set
+    ResultSet.new(
+      results: [],
+      total: 0,
+      start: 0,
+    )
+  end
+end

--- a/app/models/result_set.rb
+++ b/app/models/result_set.rb
@@ -1,0 +1,6 @@
+# Represents a set of results for a query as expected by Finder Frontend
+class ResultSet
+  include ActiveModel::Model
+
+  attr_accessor :results, :total, :start
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -15,5 +15,7 @@ module SearchApiV2
     config.load_defaults 7.0
     config.time_zone = "London"
     config.api_only = true
+
+    config.discovery_engine_engine = ENV.fetch("DISCOVERY_ENGINE_ENGINE")
   end
 end

--- a/spec/models/query_spec.rb
+++ b/spec/models/query_spec.rb
@@ -1,0 +1,13 @@
+RSpec.describe Query, type: :model do
+  subject(:query) { described_class.new }
+
+  describe "#result_set" do
+    subject(:result_set) { query.result_set }
+
+    it "returns an empty result set" do
+      expect(result_set.results).to be_empty
+      expect(result_set.total).to be_zero
+      expect(result_set.start).to be_zero
+    end
+  end
+end


### PR DESCRIPTION
- Add `Query` model to represent a user's search query
- Use `Query` model in `SearchesController`
- Add `ResultSet` model to represent a set of search results
- Add Rails configuration for Discovery Engine engine path