### PR TITLE
Change to take serving config instead of engine from env

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,9 @@ jobs:
     name: Test Ruby
     runs-on: ubuntu-latest
     env:
-      DISCOVERY_ENGINE_ENGINE: "engine"
+      # As we're running the tests through Rake, we need to make sure they are run in the `test`
+      # Rails env rather than `development`
+      RAILS_ENV: test
     steps:
       - uses: actions/checkout@v3
         with:

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,6 +16,9 @@ module SearchApiV2
     config.time_zone = "London"
     config.api_only = true
 
-    config.discovery_engine_engine = ENV.fetch("DISCOVERY_ENGINE_ENGINE")
+    # Google Discovery Engine configuration (overridden in test environment)
+    unless Rails.env.test?
+      config.discovery_engine_serving_config = ENV.fetch("DISCOVERY_ENGINE_SERVING_CONFIG")
+    end
   end
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -8,6 +8,9 @@ require "active_support/core_ext/integer/time"
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
+  # Use a fake discovery engine client to avoid any real API calls being made in tests
+  config.discovery_engine_serving_config = "/test/serving/config"
+
   # Turn false under Spring and add config.action_view.cache_template_loading = true.
   config.cache_classes = true
 


### PR DESCRIPTION
The infrastructure setup now populates an env variable for a serving
config, instead of an engine.

- Ensure tests run in `RAILS_ENV=test` on CI
