### PR TITLE
Split `WriteRepository` out

### DIFF
--- a/lib/repositories/google_discovery_engine/write_repository.rb
+++ b/lib/repositories/google_discovery_engine/write_repository.rb
@@ -2,8 +2,8 @@ require "google/cloud/discovery_engine"
 
 module Repositories
   module GoogleDiscoveryEngine
-    # A repository integrating with Google Discovery Engine
-    class Repository
+    # A repository to add data to Google Discovery Engine
+    class WriteRepository
       DEFAULT_BRANCH_NAME = "default_branch".freeze
       MIME_TYPE = "text/html".freeze
 

--- a/lib/tasks/document_sync_worker.rake
+++ b/lib/tasks/document_sync_worker.rake
@@ -1,5 +1,5 @@
 require "document_sync_worker"
-require "repositories/google_discovery_engine/repository"
+require "repositories/google_discovery_engine/write_repository"
 
 namespace :document_sync_worker do
   desc "Create RabbitMQ queue for development environment"
@@ -18,7 +18,7 @@ namespace :document_sync_worker do
   desc "Listens to and processes messages from the published documents queue"
   task run: :environment do
     DocumentSyncWorker.configure do |config|
-      config.repository = Repositories::GoogleDiscoveryEngine::Repository.new(
+      config.repository = Repositories::GoogleDiscoveryEngine::WriteRepository.new(
         ENV.fetch("DISCOVERY_ENGINE_DATASTORE"),
         logger: config.logger,
       )

--- a/spec/lib/repositories/google_discovery_engine/write_repository_spec.rb
+++ b/spec/lib/repositories/google_discovery_engine/write_repository_spec.rb
@@ -1,9 +1,9 @@
-require "repositories/google_discovery_engine/repository"
+require "repositories/google_discovery_engine/write_repository"
 
 # Require v1 specifically to instance_double it (repository itself uses non-versioned API)
 require "google/cloud/discovery_engine/v1"
 
-RSpec.describe Repositories::GoogleDiscoveryEngine::Repository do
+RSpec.describe Repositories::GoogleDiscoveryEngine::WriteRepository do
   let(:repository) do
     described_class.new(
       "datastore-path",


### PR DESCRIPTION
The read and write sides of Google Discovery Engine will need slightly different configuration, split them out into different repositories.