### PR TITLE
Disable `RSpec/VerifiedDoubles` cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,6 +9,12 @@ inherit_mode:
   merge:
     - Exclude
 
+# We often want to test duck-typed interfaces rather than specific classes, especially in the
+# context of the Google API client, which returns dynamic objects that RSpec's `instance_double`
+# can't verify.
+RSpec/VerifiedDoubles:
+  Enabled: false
+
 # **************************************************************
 # TRY NOT TO ADD OVERRIDES IN THIS FILE
 #

--- a/spec/lib/document_sync_worker/document/publish_spec.rb
+++ b/spec/lib/document_sync_worker/document/publish_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe DocumentSyncWorker::Document::Publish do
   subject(:document) { described_class.new(document_hash) }
 
   let(:repository) do
-    double("repository", put: nil) # rubocop:disable RSpec/VerifiedDoubles (interface)
+    double("repository", put: nil)
   end
 
   let(:content_id) { "123" }

--- a/spec/lib/document_sync_worker/document/unpublish_spec.rb
+++ b/spec/lib/document_sync_worker/document/unpublish_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe DocumentSyncWorker::Document::Unpublish do
   subject(:document) { described_class.new(document_hash) }
 
   let(:repository) do
-    double("repository", delete: nil) # rubocop:disable RSpec/VerifiedDoubles (interface)
+    double("repository", delete: nil)
   end
 
   let(:content_id) { "123" }

--- a/spec/lib/document_sync_worker/message_processor_spec.rb
+++ b/spec/lib/document_sync_worker/message_processor_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe DocumentSyncWorker::MessageProcessor do
   subject(:processor) { described_class.new(repository:) }
 
   let(:repository) { double }
-  let(:document) { double(synchronize_to: nil) } # rubocop:disable RSpec/VerifiedDoubles (interface)
+  let(:document) { double(synchronize_to: nil) }
 
   it_behaves_like "a message queue processor"
 

--- a/spec/lib/repositories/google_discovery_engine/write_repository_spec.rb
+++ b/spec/lib/repositories/google_discovery_engine/write_repository_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Repositories::GoogleDiscoveryEngine::WriteRepository do
     context "when updating the document succeeds" do
       before do
         allow(client).to receive(:update_document).and_return(
-          double(name: "document-name"), # rubocop:disable RSpec/VerifiedDoubles
+          double(name: "document-name"),
         )
 
         repository.put(


### PR DESCRIPTION
We often want to test duck-typed interfaces rather than specific classes, especially in the context of the Google API client, which returns dynamic objects that RSpec's `instance_double` can't verify.