### PR TITLE
Add `GoogleDiscoveryEngine::ReadRepository`

### DIFF
--- a/lib/repositories/google_discovery_engine/read_repository.rb
+++ b/lib/repositories/google_discovery_engine/read_repository.rb
@@ -1,0 +1,41 @@
+require "google/cloud/discovery_engine"
+
+module Repositories
+  module GoogleDiscoveryEngine
+    # A repository to search Google Discovery Engine
+    class ReadRepository
+      SearchResults = Data.define(:results, :total)
+
+      DEFAULT_START = 0
+      DEFAULT_COUNT = 0
+
+      def initialize(
+        serving_config_path,
+        client: ::Google::Cloud::DiscoveryEngine.search_service(version: :v1),
+        logger: Logger.new($stdout, progname: self.class.name)
+      )
+        @serving_config_path = serving_config_path
+        @client = client
+        @logger = logger
+      end
+
+      def search(query_string, start: DEFAULT_START, count: DEFAULT_COUNT)
+        response = client.search(
+          query: query_string,
+          serving_config: serving_config_path,
+          page_size: count,
+          offset: start,
+        ).response
+
+        SearchResults.new(
+          results: response.results.map { _1.document.struct_data.to_h },
+          total: response.total_size,
+        )
+      end
+
+    private
+
+      attr_reader :client, :serving_config_path, :logger
+    end
+  end
+end

--- a/spec/lib/repositories/google_discovery_engine/read_repository_spec.rb
+++ b/spec/lib/repositories/google_discovery_engine/read_repository_spec.rb
@@ -1,0 +1,48 @@
+require "repositories/google_discovery_engine/read_repository"
+
+# Require v1 specifically to instance_double it (repository itself uses non-versioned API)
+require "google/cloud/discovery_engine/v1"
+
+RSpec.describe Repositories::GoogleDiscoveryEngine::ReadRepository do
+  let(:repository) do
+    described_class.new(
+      "serving-config-path",
+      client:,
+      logger:,
+    )
+  end
+  let(:client) { instance_double(Google::Cloud::DiscoveryEngine::V1::SearchService::Client) }
+  let(:logger) { instance_double(Logger) }
+
+  describe "#search" do
+    let(:search_return_value) { double(response: search_response) }
+    let(:search_response) { double(total_size: 42, results:) }
+    let(:results) do
+      [
+        double(document: double(struct_data: { foo: "bar" })),
+        double(document: double(struct_data: { foo: "baz" })),
+      ]
+    end
+
+    before do
+      allow(client).to receive(:search).and_return(search_return_value)
+    end
+
+    it "performs a search" do
+      search = repository.search("garden centres", start: 11, count: 22)
+
+      expect(client).to have_received(:search).with(
+        serving_config: "serving-config-path",
+        query: "garden centres",
+        offset: 11,
+        page_size: 22,
+      )
+
+      expect(search.total).to eq(42)
+      expect(search.results).to eq([
+        { foo: "bar" },
+        { foo: "baz" },
+      ])
+    end
+  end
+end


### PR DESCRIPTION
This is a basic repository that allows searching Google Discovery Engine with a query string, start value (offset), and count (page size).