### PR TITLE
Make API read repository configurable

### DIFF
--- a/app/models/query.rb
+++ b/app/models/query.rb
@@ -1,10 +1,22 @@
 # Represents a user's search query that can be executed against Discovery Engine
 class Query
+  def initialize(
+    repository_class: Rails.configuration.repository_class
+  )
+    @repository = repository_class.new
+  end
+
   def result_set
+    res = repository.search(nil)
+
     ResultSet.new(
-      results: [],
-      total: 0,
+      results: res.results,
+      total: res.total,
       start: 0,
     )
   end
+
+private
+
+  attr_reader :repository
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -19,6 +19,9 @@ module SearchApiV2
     # Google Discovery Engine configuration (overridden in test environment)
     unless Rails.env.test?
       config.discovery_engine_serving_config = ENV.fetch("DISCOVERY_ENGINE_SERVING_CONFIG")
+
+      require "repositories/google_discovery_engine/read_repository"
+      config.repository_class = Repositories::GoogleDiscoveryEngine::ReadRepository
     end
   end
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -11,6 +11,7 @@ Rails.application.configure do
 
   # Use a fake discovery engine client to avoid any real API calls being made in tests
   config.discovery_engine_serving_config = "/test/serving/config"
+  config.repository_class = Repositories::TestRepository
 
   # Turn false under Spring and add config.action_view.cache_template_loading = true.
   config.cache_classes = true

--- a/lib/repositories/google_discovery_engine/read_repository.rb
+++ b/lib/repositories/google_discovery_engine/read_repository.rb
@@ -10,7 +10,7 @@ module Repositories
       DEFAULT_COUNT = 0
 
       def initialize(
-        serving_config_path,
+        serving_config_path = Rails.configuration.discovery_engine_serving_config,
         client: ::Google::Cloud::DiscoveryEngine.search_service(version: :v1),
         logger: Logger.new($stdout, progname: self.class.name)
       )

--- a/lib/repositories/test_repository.rb
+++ b/lib/repositories/test_repository.rb
@@ -1,26 +1,32 @@
 # A fake repository for end-to-end testing purposes
-class TestRepository
-  attr_reader :documents
+module Repositories
+  class TestRepository
+    attr_reader :documents
 
-  def initialize(documents = {})
-    @documents = documents
-  end
+    def initialize(documents = {})
+      @documents = documents
+    end
 
-  def exists?(content_id)
-    documents.key?(content_id)
-  end
+    def exists?(content_id)
+      documents.key?(content_id)
+    end
 
-  def get(content_id)
-    documents[content_id]
-  end
+    def get(content_id)
+      documents[content_id]
+    end
 
-  # rubocop:disable Lint/UnusedMethodArgument
-  def put(content_id, metadata, content: nil, payload_version: nil)
-    documents[content_id] = { metadata:, content: }
-  end
+    # rubocop:disable Lint/UnusedMethodArgument
+    def search(query_string, start: 0, count: 1)
+      OpenStruct.new(results: [], total: 0)
+    end
 
-  def delete(content_id, payload_version: nil)
-    documents.delete(content_id)
+    def put(content_id, metadata, content: nil, payload_version: nil)
+      documents[content_id] = { metadata:, content: }
+    end
+
+    def delete(content_id, payload_version: nil)
+      documents.delete(content_id)
+    end
+    # rubocop:enable Lint/UnusedMethodArgument
   end
-  # rubocop:enable Lint/UnusedMethodArgument
 end

--- a/spec/lib/document_sync_worker_integration_spec.rb
+++ b/spec/lib/document_sync_worker_integration_spec.rb
@@ -1,7 +1,7 @@
 require "govuk_message_queue_consumer/test_helpers"
 
 RSpec.describe "Document sync worker end-to-end" do
-  let(:repository) { TestRepository.new(documents) }
+  let(:repository) { Repositories::TestRepository.new(documents) }
   let(:message) { GovukMessageQueueConsumer::MockMessage.new(payload) }
 
   before do


### PR DESCRIPTION
- Make repository class configurable in application config, and set it to Discovery Engine repository in dev/prod, test repository in test Rails environments
- Make Google read repository pick up on serving config from Rails config