### PR TITLE
Set up gRPC mocking

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ group :document_sync_worker do
 end
 
 group :test do
+  gem "grpc_mock"
   gem "json_schemer"
   gem "simplecov", require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,6 +129,8 @@ GEM
     grpc (1.59.0-x86_64-linux)
       google-protobuf (~> 3.24)
       googleapis-common-protos-types (~> 1.0)
+    grpc_mock (0.4.6)
+      grpc (>= 1.12.0, < 2)
     hana (1.3.7)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
@@ -513,6 +515,7 @@ DEPENDENCIES
   govuk_app_config
   govuk_message_queue_consumer
   govuk_test
+  grpc_mock
   json_schemer
   jsonpath
   loofah

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,8 @@ GovukTest.configure
 #   remove this, otherwise it can be made permanent.
 require "document_sync_worker"
 
+require "grpc_mock/rspec"
+
 # See https://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
   config.default_formatter = "doc" if config.files_to_run.one?
@@ -36,4 +38,6 @@ RSpec.configure do |config|
 
   config.include FixtureHelpers
   config.include SchemaHelpers
+
+  GrpcMock.disable_net_connect!
 end


### PR DESCRIPTION
- Add `grpc_mock` library
- Disable gRPC requests in test suite