### PR TITLE
Remove API repository configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
       # As we're running the tests through Rake, we need to make sure they are run in the `test`
       # Rails env rather than `development`
       RAILS_ENV: test
+      # All Google client library calls are mocked, but the application needs this set to boot
+      DISCOVERY_ENGINE_SERVING_CONFIG: not-used
     steps:
       - uses: actions/checkout@v3
         with:

--- a/app/models/query.rb
+++ b/app/models/query.rb
@@ -1,22 +1,10 @@
 # Represents a user's search query that can be executed against Discovery Engine
 class Query
-  def initialize(
-    repository_class: Rails.configuration.repository_class
-  )
-    @repository = repository_class.new
-  end
-
   def result_set
-    res = repository.search(nil)
-
     ResultSet.new(
-      results: res.results,
-      total: res.total,
+      results: [],
+      total: 0,
       start: 0,
     )
   end
-
-private
-
-  attr_reader :repository
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,12 +16,7 @@ module SearchApiV2
     config.time_zone = "London"
     config.api_only = true
 
-    # Google Discovery Engine configuration (overridden in test environment)
-    unless Rails.env.test?
-      config.discovery_engine_serving_config = ENV.fetch("DISCOVERY_ENGINE_SERVING_CONFIG")
-
-      require "repositories/google_discovery_engine/read_repository"
-      config.repository_class = Repositories::GoogleDiscoveryEngine::ReadRepository
-    end
+    # Google Discovery Engine configuration
+    config.discovery_engine_serving_config = ENV.fetch("DISCOVERY_ENGINE_SERVING_CONFIG")
   end
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -9,10 +9,6 @@ require "repositories/test_repository"
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
-  # Use a fake discovery engine client to avoid any real API calls being made in tests
-  config.discovery_engine_serving_config = "/test/serving/config"
-  config.repository_class = Repositories::TestRepository
-
   # Turn false under Spring and add config.action_view.cache_template_loading = true.
   config.cache_classes = true
 


### PR DESCRIPTION
Having experimented with this, we'll actually try and use the client directly without an abstraction layer for now to keep things simpler.