### PR TITLE
Implement result transformation

### DIFF
--- a/app/models/result.rb
+++ b/app/models/result.rb
@@ -1,0 +1,42 @@
+# Represents an individual result as expected by Finder Frontend
+class Result
+  include ActiveModel::Model
+
+  attr_accessor :_id, :content_id, :title, :description_with_highlighting, :link, :public_timestamp,
+                :government_name, :parts, :part_of_taxonomy_tree, :format, :is_historic,
+                :content_purpose_supergroup, :content_store_document_type
+
+  # Creates a new instance based on a document stored in Discovery Engine, transforming fields as
+  # appropriate to match what is expected by Finder Frontend
+  def self.from_stored_document(document)
+    attrs = document.symbolize_keys
+
+    public_timestamp = Time.zone.at(attrs[:public_timestamp]).iso8601 if attrs[:public_timestamp]
+
+    new(
+      attrs
+        # Fields Discovery Engine documents contains verbatim
+        .slice(
+          :content_id, :title, :link, :content_purpose_supergroup, :parts, :part_of_taxonomy_tree,
+          :government_name
+        )
+        # Fields that need to be transformed
+        .merge(
+          # Legacy Elasticsearch implementation detail for backwards compatibility
+          # (equal to link for internal content, content_id for external content)
+          _id: attrs[:link]&.start_with?("/") ? attrs[:link] : attrs[:content_id],
+          # We're not currently using snippeting, and there is no way to get Discovery Engine to
+          # highlight a description, but consumers expect this field to be present
+          description_with_highlighting: attrs[:description],
+          # No longer relevant and equal to document type now, but here for backwards compatibility
+          format: attrs[:document_type],
+          # Stored as a timestamp in Discovery Engine, but we want to return an ISO8601 string
+          public_timestamp:,
+          # Different name in Discovery Engine documents
+          content_store_document_type: attrs[:document_type],
+          # Stored as an integer in Discovery Engine to allow boosting, but consumers expect boolean
+          is_historic: attrs[:is_historic] == 1,
+        ),
+    )
+  end
+end

--- a/app/services/discovery_engine/search.rb
+++ b/app/services/discovery_engine/search.rb
@@ -19,7 +19,7 @@ module DiscoveryEngine
       ).response
 
       ResultSet.new(
-        results: response.results.map { _1.document.struct_data.to_h },
+        results: response.results.map { Result.from_stored_document(_1.document.struct_data.to_h) },
         total: response.total_size,
         start:,
       )

--- a/spec/models/result_spec.rb
+++ b/spec/models/result_spec.rb
@@ -1,0 +1,86 @@
+RSpec.describe Result, type: :model do
+  describe ".from_stored_document" do
+    subject(:result) { described_class.from_stored_document(stored_document) }
+
+    let(:stored_document) do
+      {
+        "content_id" => "12345",
+        "title" => "Sample Title",
+        "link" => "/sample-link",
+        "content_purpose_supergroup" => "news_and_communications",
+        "parts" => [],
+        "part_of_taxonomy_tree" => [],
+        "government_name" => "Sample Government",
+        "public_timestamp" => 1_698_831_790, # 2023-11-01T09:43:10+00:00
+        "description" => "Sample Description",
+        "document_type" => "news_story",
+        "is_historic" => 1,
+      }
+    end
+
+    it "creates a new Result instance with the correct attributes" do
+      expect(result).to have_attributes(
+        content_id: "12345",
+        title: "Sample Title",
+        link: "/sample-link",
+        content_purpose_supergroup: "news_and_communications",
+        parts: [],
+        part_of_taxonomy_tree: [],
+        public_timestamp: "2023-11-01T09:43:10+00:00",
+        government_name: "Sample Government",
+        description_with_highlighting: "Sample Description",
+        format: "news_story",
+        content_store_document_type: "news_story",
+        is_historic: true,
+      )
+    end
+
+    context "when the document is external (link doesn't start with '/')" do
+      let(:stored_document) { { "link" => "https://www.example.org", "content_id" => "12345" } }
+
+      it "sets _id to the value of content_id" do
+        expect(result._id).to eq("12345")
+      end
+    end
+
+    context "when public_timestamp is nil" do
+      let(:stored_document) { { "public_timestamp" => nil } }
+
+      it "sets public_timestamp to nil" do
+        expect(result.public_timestamp).to be_nil
+      end
+    end
+
+    context "when is_historic is nil" do
+      let(:stored_document) { { "is_historic" => nil } }
+
+      it "sets is_historic to false" do
+        expect(result.is_historic).to be(false)
+      end
+    end
+
+    context "when is_historic is 1" do
+      let(:stored_document) { { "is_historic" => 1 } }
+
+      it "sets is_historic to true" do
+        expect(result.is_historic).to be(true)
+      end
+    end
+
+    context "when is_historic is not 1" do
+      let(:stored_document) { { "is_historic" => 0 } }
+
+      it "sets is_historic to false" do
+        expect(result.is_historic).to be(false)
+      end
+    end
+
+    context "when document data is missing or incomplete" do
+      let(:stored_document) { {} }
+
+      it "handles missing or incomplete data gracefully" do
+        expect { result }.not_to raise_error
+      end
+    end
+  end
+end

--- a/spec/requests/search_request_spec.rb
+++ b/spec/requests/search_request_spec.rb
@@ -1,6 +1,7 @@
 RSpec.describe "Making a search request" do
   let(:search_service) { instance_double(DiscoveryEngine::Search, call: result_set) }
-  let(:result_set) { ResultSet.new(results: [], total: 42, start: 21) }
+  let(:result_set) { ResultSet.new(results:, total: 42, start: 21) }
+  let(:results) { [Result.new(content_id: "123"), Result.new(content_id: "456")] }
 
   before do
     allow(DiscoveryEngine::Search).to receive(:new).and_return(search_service)
@@ -12,7 +13,10 @@ RSpec.describe "Making a search request" do
 
       expect(response).to have_http_status(:ok)
       expect(JSON.parse(response.body)).to eq({
-        "results" => [],
+        "results" => [
+          { "content_id" => "123" },
+          { "content_id" => "456" },
+        ],
         "total" => 42,
         "start" => 21,
       })

--- a/spec/services/discovery_engine/search_spec.rb
+++ b/spec/services/discovery_engine/search_spec.rb
@@ -33,9 +33,9 @@ RSpec.describe DiscoveryEngine::Search do
       it "returns a result set with the correct contents" do
         expect(result_set.start).to eq(0)
         expect(result_set.total).to eq(42)
-        expect(result_set.results).to eq([
-          { title: "Louth Garden Centre" },
-          { title: "Cleethorpes Garden Centre" },
+        expect(result_set.results.map(&:title)).to eq([
+          "Louth Garden Centre",
+          "Cleethorpes Garden Centre",
         ])
       end
 


### PR DESCRIPTION
- Add `Result` model to represent a single result
- Add `Result.from_stored_document` to transform a document stored in Discovery Engine into a search result expected by Finder Frontend
- Change `DiscoveryEngine::Search` to use `Result.from_stored_document` to create `Result` objects