### PR TITLE
Re-add schema validation integration tests

### DIFF
--- a/spec/integration/metadata_schema_compliance_spec.rb
+++ b/spec/integration/metadata_schema_compliance_spec.rb
@@ -1,0 +1,19 @@
+RSpec.describe "PublishingApiDocument schema-compliant metadata generation" do
+  %w[
+    external_content_message
+    historic_news_story_message
+    independent_report_message
+    organisation_message
+    press_release_message
+    travel_advice_message
+  ].each do |message_fixture|
+    context "when processing a '#{message_fixture}'" do
+      let(:document_hash) { json_fixture_as_hash("message_queue/#{message_fixture}.json") }
+      let(:document) { PublishingApiDocument::Publish.new(document_hash) }
+
+      it "results in a document validating against the datastore schema" do
+        expect(document.metadata).to match_json_schema(metadata_json_schema)
+      end
+    end
+  end
+end

--- a/spec/support/schema_helpers.rb
+++ b/spec/support/schema_helpers.rb
@@ -8,7 +8,7 @@ module SchemaHelpers
 
   # Returns a JSONSchemer object representing the JSON schema for document metadata
   def metadata_json_schema
-    @metadata_json_schema ||= begin
+    @@metadata_json_schema ||= begin # rubocop:disable Style/ClassVars
       remote_schema = Net::HTTP.get(METADATA_JSON_SCHEMA_URI)
       schema_contents = JSON.parse(remote_schema)
 


### PR DESCRIPTION
These were previously part of the removed repository-based integration tests.