### PR TITLE
Implement logic for document ignoring

### DIFF
--- a/app/models/publishing_api_document.rb
+++ b/app/models/publishing_api_document.rb
@@ -10,8 +10,20 @@ module PublishingApiDocument
     case document_hash["document_type"]
     when *UNPUBLISH_DOCUMENT_TYPES
       Unpublish.new(document_hash)
+    when *Rails.configuration.document_type_ignorelist
+      return Publish.new(document_hash) if force_add_path?(document_hash["base_path"])
+
+      Ignore.new(document_hash)
     else
+      return Ignore.new(document_hash) unless document_hash["locale"].in?(["en", nil])
+
       Publish.new(document_hash)
     end
+  end
+
+  # Returns whether the given base path should be added to the search index, even if its document
+  # type is on the ignorelist.
+  def self.force_add_path?(base_path)
+    Rails.configuration.document_type_ignorelist_path_overrides.any? { _1.match?(base_path) }
   end
 end

--- a/app/models/publishing_api_document/ignore.rb
+++ b/app/models/publishing_api_document/ignore.rb
@@ -1,0 +1,8 @@
+module PublishingApiDocument
+  class Ignore < Base
+    # Synchonisation is a no-op for ignored documents
+    def synchronize(*)
+      Rails.logger.info("Ignoring document #{content_id} for synchronisation")
+    end
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -19,5 +19,11 @@ module SearchApiV2
     # Google Discovery Engine configuration
     config.discovery_engine_serving_config = ENV.fetch("DISCOVERY_ENGINE_SERVING_CONFIG")
     config.discovery_engine_datastore = ENV.fetch("DISCOVERY_ENGINE_DATASTORE")
+
+    # Document sync configuration
+    config.document_type_ignorelist = config_for(:document_type_ignorelist)
+    config.document_type_ignorelist_path_overrides = config_for(
+      :document_type_ignorelist_path_overrides,
+    )
   end
 end

--- a/config/document_type_ignorelist.yml
+++ b/config/document_type_ignorelist.yml
@@ -1,0 +1,35 @@
+# A set of document types that come through from Publishing API that we don't want to add to
+# Discovery Engine because they are not useful for search.
+shared:
+  - !ruby/regexp /^placeholder/ # any placeholder type
+  - completed_transaction
+  - email_alert_signup
+  - embassies_index
+  - facet
+  - facet_group
+  - facet_value
+  - field_of_operation
+  - fields_of_operation
+  - finder_email_signup
+  - government
+  - historic_appointment
+  - historic_appointments
+  - homepage
+  - html_publication
+  - ministers_index
+  - national
+  - need
+  - official
+  - official_statistics_announcement
+  - policy_area
+  - search
+  - service_sign_in
+  - services_and_information
+  - special_route
+  - take_part
+  - taxon
+  - working_group
+  - world_index
+  - world_location_news
+  - worldwide_office
+  - worldwide_organisation

--- a/config/document_type_ignorelist_path_overrides.yml
+++ b/config/document_type_ignorelist_path_overrides.yml
@@ -1,0 +1,10 @@
+# A set of paths for documents that should be added to search even if their document type is in the
+# ignorelist. This is used for document types that shouldn't show up in search in general, but that
+# do have a handful of exceptions.
+# This is compared using ===, so you may use regular expression tags
+shared:
+- !ruby/regexp /^\/world/[^\/]+$/ # taxon
+- /cost-of-living # special_route
+- /help # special_route
+- /help/cookies # special_route
+- /find-local-council # special_route

--- a/docs/adr/004-which-documents-to-index.md
+++ b/docs/adr/004-which-documents-to-index.md
@@ -1,0 +1,39 @@
+# ADR 004: Which documents to index
+2023-11-02
+
+## Context
+Not every document that is on the Publishing API should be searchable. At the moment, documents are
+excluded from search for reasons such as:
+- They are not in English (the existing search cannot cope well with other languages, and we want to
+  replicate the existing behaviour for now until we are ready to iterate)
+- They are not "individually identifiable", i.e. they are nested subdocuments of a parent document
+  and don't have their own URL
+- Their types are explicitly blocklisted from being indexed because having these kinds of documents
+  show up in search wouldn't be helpful (e.g. `redirect`s), or their contents are indexed as part of
+  a related primary document (e.g. `html_publication`)
+
+## Considered options
+We have considered replicating the existing logic as closely as possible, but this is complicated by
+the fact that content currently finds its way into search through two separate pathways (Publishing
+API message queue and legacy Whitehall push-based API), with the deciding logic residing across
+several applications.
+
+We have considered adding a dependency on the existing `search-api`, either in terms of logic or
+data ("does this document exist in Elasticsearch?"), but this would add undesirable coupling to the
+old API.
+
+Instead, a thorough analysis of existing data and document types across the GOV.UK estate has led us
+to simplify the approach to that outlined in "Decision".
+
+## Decision
+
+Content coming through from Publishing API will be indexed if and only if:
+- it has a locale of `en`, **and**
+- it is addressable (has a `base_path` or `details.url`), **and**
+- its document type does not start with "placeholder", **and**
+- either of the following apply:
+  - its document type is not on an explicit blocklist (based on existing search behaviour), **or**
+  - its base_path is on an explicit allowlist (based on existing configuration in `search-api`)
+
+## Status
+Accepted.

--- a/spec/fixtures/files/message_queue/world_taxon_message.json
+++ b/spec/fixtures/files/message_queue/world_taxon_message.json
@@ -1,0 +1,732 @@
+{
+  "title": "UK help and services in Switzerland",
+  "public_updated_at": "2020-03-02T16:03:56Z",
+  "publishing_app": "content-tagger",
+  "rendering_app": "collections",
+  "update_type": "major",
+  "phase": "live",
+  "analytics_identifier": null,
+  "document_type": "taxon",
+  "schema_name": "taxon",
+  "first_published_at": "2017-06-29T14:04:04Z",
+  "base_path": "/world/switzerland",
+  "description": "Services if you're visiting, studying, working or living in Switzerland. Includes information about trading with and doing business in the UK and Switzerland, and your rights after the UK’s exit from the EU.",
+  "details": {
+    "internal_name": "UK help and services in Switzerland",
+    "notes_for_editors": "",
+    "visible_to_departmental_editors": false
+  },
+  "routes": [
+    {
+      "path": "/world/switzerland",
+      "type": "exact"
+    }
+  ],
+  "redirects": [],
+  "content_id": "f1724368-504f-4b3c-9dc2-41121046de9f",
+  "locale": "en",
+  "expanded_links": {
+    "child_taxons": [
+      {
+        "content_id": "fcdca447-3336-400d-a6f9-d6ed4661f290",
+        "title": "Living in Switzerland",
+        "locale": "en",
+        "analytics_identifier": null,
+        "api_path": "/api/content/world/living-in-switzerland",
+        "base_path": "/world/living-in-switzerland",
+        "document_type": "taxon",
+        "public_updated_at": "2020-03-03T17:05:59Z",
+        "schema_name": "taxon",
+        "withdrawn": false,
+        "description": "Guidance on your rights after the UK’s exit from the EU, accessing healthcare, getting a document legalised, English-speaking lawyers, how to vote abroad.",
+        "details": {
+          "internal_name": "Living in Switzerland",
+          "notes_for_editors": "",
+          "visible_to_departmental_editors": false
+        },
+        "phase": "live",
+        "links": {
+          "parent_taxons": [
+            {
+              "content_id": "f1724368-504f-4b3c-9dc2-41121046de9f",
+              "title": "UK help and services in Switzerland",
+              "locale": "en",
+              "analytics_identifier": null,
+              "api_path": "/api/content/world/switzerland",
+              "base_path": "/world/switzerland",
+              "document_type": "taxon",
+              "public_updated_at": "2020-03-02T16:03:56Z",
+              "schema_name": "taxon",
+              "withdrawn": false,
+              "description": "Services if you're visiting, studying, working or living in Switzerland. Includes information about trading with and doing business in the UK and Switzerland, and your rights after the UK’s exit from the EU.",
+              "details": {
+                "internal_name": "UK help and services in Switzerland",
+                "notes_for_editors": "",
+                "visible_to_departmental_editors": false
+              },
+              "phase": "live",
+              "links": {}
+            }
+          ],
+          "associated_taxons": [
+            {
+              "content_id": "f4450d6d-ae53-4da0-88e5-cfe32c76a5ee",
+              "title": "Living abroad",
+              "locale": "en",
+              "analytics_identifier": null,
+              "api_path": "/api/content/world/living-abroad",
+              "base_path": "/world/living-abroad",
+              "document_type": "taxon",
+              "public_updated_at": "2017-06-30T14:23:44Z",
+              "schema_name": "taxon",
+              "withdrawn": false,
+              "description": "Includes how to access healthcare, get a document legalised, lists of lawyers and how to vote abroad.",
+              "details": {
+                "internal_name": "Living abroad (GENERIC)",
+                "notes_for_editors": "",
+                "visible_to_departmental_editors": false
+              },
+              "phase": "live",
+              "links": {}
+            }
+          ]
+        }
+      },
+      {
+        "content_id": "8d0b5192-8f84-49db-ad40-592ada5afa79",
+        "title": "Birth, death and marriage abroad",
+        "locale": "en",
+        "analytics_identifier": null,
+        "api_path": "/api/content/world/birth-death-and-marriage-abroad-switzerland",
+        "base_path": "/world/birth-death-and-marriage-abroad-switzerland",
+        "document_type": "taxon",
+        "public_updated_at": "2017-06-29T08:18:22Z",
+        "schema_name": "taxon",
+        "withdrawn": false,
+        "description": "Includes how to get married, list of funeral directors and how to register a birth abroad.",
+        "details": {
+          "internal_name": "Birth, death and marriage abroad (Switzerland)",
+          "notes_for_editors": "",
+          "visible_to_departmental_editors": true
+        },
+        "phase": "live",
+        "links": {
+          "parent_taxons": [
+            {
+              "content_id": "f1724368-504f-4b3c-9dc2-41121046de9f",
+              "title": "UK help and services in Switzerland",
+              "locale": "en",
+              "analytics_identifier": null,
+              "api_path": "/api/content/world/switzerland",
+              "base_path": "/world/switzerland",
+              "document_type": "taxon",
+              "public_updated_at": "2020-03-02T16:03:56Z",
+              "schema_name": "taxon",
+              "withdrawn": false,
+              "description": "Services if you're visiting, studying, working or living in Switzerland. Includes information about trading with and doing business in the UK and Switzerland, and your rights after the UK’s exit from the EU.",
+              "details": {
+                "internal_name": "UK help and services in Switzerland",
+                "notes_for_editors": "",
+                "visible_to_departmental_editors": false
+              },
+              "phase": "live",
+              "links": {}
+            }
+          ],
+          "associated_taxons": [
+            {
+              "content_id": "eed5b92e-8279-4ca9-a141-5c35ed22fcf1",
+              "title": "Birth, death and marriage abroad ",
+              "locale": "en",
+              "analytics_identifier": null,
+              "api_path": "/api/content/world/birth-death-and-marriage-abroad",
+              "base_path": "/world/birth-death-and-marriage-abroad",
+              "document_type": "taxon",
+              "public_updated_at": "2017-06-23T11:04:33Z",
+              "schema_name": "taxon",
+              "withdrawn": false,
+              "description": "Includes how to get married, list of funeral directors and how to register a birth abroad.",
+              "details": {
+                "internal_name": "Birth, death and marriage abroad (GENERIC)",
+                "notes_for_editors": "",
+                "visible_to_departmental_editors": false
+              },
+              "phase": "live",
+              "links": {}
+            }
+          ]
+        }
+      },
+      {
+        "content_id": "c1e7fdbe-6313-490e-b897-fa2a8e33200f",
+        "title": "Tax, benefits, pensions and working abroad",
+        "locale": "en",
+        "analytics_identifier": null,
+        "api_path": "/api/content/world/tax-benefits-pensions-and-working-abroad-switzerland",
+        "base_path": "/world/tax-benefits-pensions-and-working-abroad-switzerland",
+        "document_type": "taxon",
+        "public_updated_at": "2017-06-29T08:18:22Z",
+        "schema_name": "taxon",
+        "withdrawn": false,
+        "description": "Includes how to pay tax, claim State Pension and get tax credits abroad.",
+        "details": {
+          "internal_name": "Tax, benefits, pensions and working abroad (Switzerland)",
+          "notes_for_editors": "",
+          "visible_to_departmental_editors": true
+        },
+        "phase": "live",
+        "links": {
+          "parent_taxons": [
+            {
+              "content_id": "f1724368-504f-4b3c-9dc2-41121046de9f",
+              "title": "UK help and services in Switzerland",
+              "locale": "en",
+              "analytics_identifier": null,
+              "api_path": "/api/content/world/switzerland",
+              "base_path": "/world/switzerland",
+              "document_type": "taxon",
+              "public_updated_at": "2020-03-02T16:03:56Z",
+              "schema_name": "taxon",
+              "withdrawn": false,
+              "description": "Services if you're visiting, studying, working or living in Switzerland. Includes information about trading with and doing business in the UK and Switzerland, and your rights after the UK’s exit from the EU.",
+              "details": {
+                "internal_name": "UK help and services in Switzerland",
+                "notes_for_editors": "",
+                "visible_to_departmental_editors": false
+              },
+              "phase": "live",
+              "links": {}
+            }
+          ],
+          "associated_taxons": [
+            {
+              "content_id": "382360ab-c4cf-4e2a-b043-0cfa395f1d0b",
+              "title": "Tax, benefits, pensions and working abroad",
+              "locale": "en",
+              "analytics_identifier": null,
+              "api_path": "/api/content/world/tax-benefits-pensions-and-working-abroad",
+              "base_path": "/world/tax-benefits-pensions-and-working-abroad",
+              "document_type": "taxon",
+              "public_updated_at": "2017-06-23T11:04:50Z",
+              "schema_name": "taxon",
+              "withdrawn": false,
+              "description": "Includes how to pay tax, claim State Pension and get tax credits abroad. ",
+              "details": {
+                "internal_name": "Tax, benefits, pensions and working abroad (GENERIC)",
+                "notes_for_editors": "",
+                "visible_to_departmental_editors": false
+              },
+              "phase": "live",
+              "links": {}
+            }
+          ]
+        }
+      },
+      {
+        "content_id": "179f5b60-c9e1-4311-9820-84cf6e79cda4",
+        "title": "British embassy or high commission",
+        "locale": "en",
+        "analytics_identifier": null,
+        "api_path": "/api/content/world/british-embassy-or-high-commission-switzerland",
+        "base_path": "/world/british-embassy-or-high-commission-switzerland",
+        "document_type": "taxon",
+        "public_updated_at": "2017-06-29T08:18:22Z",
+        "schema_name": "taxon",
+        "withdrawn": false,
+        "description": "Includes contact details, opening hours and consular fees and local services.",
+        "details": {
+          "internal_name": "British embassy or high commission (Switzerland)",
+          "notes_for_editors": "",
+          "visible_to_departmental_editors": true
+        },
+        "phase": "live",
+        "links": {
+          "parent_taxons": [
+            {
+              "content_id": "f1724368-504f-4b3c-9dc2-41121046de9f",
+              "title": "UK help and services in Switzerland",
+              "locale": "en",
+              "analytics_identifier": null,
+              "api_path": "/api/content/world/switzerland",
+              "base_path": "/world/switzerland",
+              "document_type": "taxon",
+              "public_updated_at": "2020-03-02T16:03:56Z",
+              "schema_name": "taxon",
+              "withdrawn": false,
+              "description": "Services if you're visiting, studying, working or living in Switzerland. Includes information about trading with and doing business in the UK and Switzerland, and your rights after the UK’s exit from the EU.",
+              "details": {
+                "internal_name": "UK help and services in Switzerland",
+                "notes_for_editors": "",
+                "visible_to_departmental_editors": false
+              },
+              "phase": "live",
+              "links": {}
+            }
+          ],
+          "associated_taxons": [
+            {
+              "content_id": "0d729f86-e07e-4271-a505-9f80954eeeed",
+              "title": "British embassy or high commission ",
+              "locale": "en",
+              "analytics_identifier": null,
+              "api_path": "/api/content/world/british-embassy-or-high-commission",
+              "base_path": "/world/british-embassy-or-high-commission",
+              "document_type": "taxon",
+              "public_updated_at": "2017-06-23T11:05:24Z",
+              "schema_name": "taxon",
+              "withdrawn": false,
+              "description": "Includes contact details, opening hours and consular fees and local services.",
+              "details": {
+                "internal_name": "British embassy or high commission (GENERIC)",
+                "notes_for_editors": "",
+                "visible_to_departmental_editors": false
+              },
+              "phase": "live",
+              "links": {}
+            }
+          ]
+        }
+      },
+      {
+        "content_id": "84a2093d-cd01-45c3-8d8b-cddf864bc2cd",
+        "title": "Passports and emergency travel documents",
+        "locale": "en",
+        "analytics_identifier": null,
+        "api_path": "/api/content/world/passports-and-emergency-travel-documents-switzerland",
+        "base_path": "/world/passports-and-emergency-travel-documents-switzerland",
+        "document_type": "taxon",
+        "public_updated_at": "2017-06-29T08:18:21Z",
+        "schema_name": "taxon",
+        "withdrawn": false,
+        "description": "Includes how to cancel a lost passport, renew a passport and apply for an emergency travel document.",
+        "details": {
+          "internal_name": "Passports and emergency travel documents (Switzerland)",
+          "notes_for_editors": "",
+          "visible_to_departmental_editors": true
+        },
+        "phase": "live",
+        "links": {
+          "parent_taxons": [
+            {
+              "content_id": "f1724368-504f-4b3c-9dc2-41121046de9f",
+              "title": "UK help and services in Switzerland",
+              "locale": "en",
+              "analytics_identifier": null,
+              "api_path": "/api/content/world/switzerland",
+              "base_path": "/world/switzerland",
+              "document_type": "taxon",
+              "public_updated_at": "2020-03-02T16:03:56Z",
+              "schema_name": "taxon",
+              "withdrawn": false,
+              "description": "Services if you're visiting, studying, working or living in Switzerland. Includes information about trading with and doing business in the UK and Switzerland, and your rights after the UK’s exit from the EU.",
+              "details": {
+                "internal_name": "UK help and services in Switzerland",
+                "notes_for_editors": "",
+                "visible_to_departmental_editors": false
+              },
+              "phase": "live",
+              "links": {}
+            }
+          ],
+          "associated_taxons": [
+            {
+              "content_id": "374e8288-d58c-4914-b81b-e66ab4803925",
+              "title": "Passports and emergency travel documents",
+              "locale": "en",
+              "analytics_identifier": null,
+              "api_path": "/api/content/world/passports-and-emergency-travel-documents",
+              "base_path": "/world/passports-and-emergency-travel-documents",
+              "document_type": "taxon",
+              "public_updated_at": "2017-06-23T10:57:30Z",
+              "schema_name": "taxon",
+              "withdrawn": false,
+              "description": "Includes how to cancel a lost passport, renew a passport and apply for an emergency travel document.",
+              "details": {
+                "internal_name": "Passports and emergency travel documents (GENERIC)",
+                "notes_for_editors": "",
+                "visible_to_departmental_editors": false
+              },
+              "phase": "live",
+              "links": {}
+            }
+          ]
+        }
+      },
+      {
+        "content_id": "14357240-7647-42f3-a329-a9d893f07463",
+        "title": "News and events",
+        "locale": "en",
+        "analytics_identifier": null,
+        "api_path": "/api/content/world/news-and-events-switzerland",
+        "base_path": "/world/news-and-events-switzerland",
+        "document_type": "taxon",
+        "public_updated_at": "2017-06-29T08:18:22Z",
+        "schema_name": "taxon",
+        "withdrawn": false,
+        "description": "Find out about the UK government's diplomatic, security and development work in Switzerland.",
+        "details": {
+          "internal_name": "News and events (Switzerland)",
+          "notes_for_editors": "",
+          "visible_to_departmental_editors": true
+        },
+        "phase": "live",
+        "links": {
+          "parent_taxons": [
+            {
+              "content_id": "f1724368-504f-4b3c-9dc2-41121046de9f",
+              "title": "UK help and services in Switzerland",
+              "locale": "en",
+              "analytics_identifier": null,
+              "api_path": "/api/content/world/switzerland",
+              "base_path": "/world/switzerland",
+              "document_type": "taxon",
+              "public_updated_at": "2020-03-02T16:03:56Z",
+              "schema_name": "taxon",
+              "withdrawn": false,
+              "description": "Services if you're visiting, studying, working or living in Switzerland. Includes information about trading with and doing business in the UK and Switzerland, and your rights after the UK’s exit from the EU.",
+              "details": {
+                "internal_name": "UK help and services in Switzerland",
+                "notes_for_editors": "",
+                "visible_to_departmental_editors": false
+              },
+              "phase": "live",
+              "links": {}
+            }
+          ],
+          "associated_taxons": [
+            {
+              "content_id": "0c5945fc-f65c-4bd1-a664-9e302f3d448c",
+              "title": "News and events",
+              "locale": "en",
+              "analytics_identifier": null,
+              "api_path": "/api/content/world/news-and-events",
+              "base_path": "/world/news-and-events",
+              "document_type": "taxon",
+              "public_updated_at": "2017-11-14T09:48:38Z",
+              "schema_name": "taxon",
+              "withdrawn": false,
+              "description": "Find out about the UK government's diplomatic, security and development work abroad.",
+              "details": {
+                "internal_name": "News and events (GENERIC)",
+                "notes_for_editors": "",
+                "visible_to_departmental_editors": false
+              },
+              "phase": "live",
+              "links": {}
+            }
+          ]
+        }
+      },
+      {
+        "content_id": "2d113bc4-6843-4416-9fdd-1232c14f3bc7",
+        "title": "Travelling to Switzerland",
+        "locale": "en",
+        "analytics_identifier": null,
+        "api_path": "/api/content/world/travelling-to-switzerland",
+        "base_path": "/world/travelling-to-switzerland",
+        "document_type": "taxon",
+        "public_updated_at": "2017-06-29T08:18:21Z",
+        "schema_name": "taxon",
+        "withdrawn": false,
+        "description": "Includes travel advice and how to get married abroad.",
+        "details": {
+          "internal_name": "Travelling to Switzerland",
+          "notes_for_editors": "",
+          "visible_to_departmental_editors": true
+        },
+        "phase": "live",
+        "links": {
+          "parent_taxons": [
+            {
+              "content_id": "f1724368-504f-4b3c-9dc2-41121046de9f",
+              "title": "UK help and services in Switzerland",
+              "locale": "en",
+              "analytics_identifier": null,
+              "api_path": "/api/content/world/switzerland",
+              "base_path": "/world/switzerland",
+              "document_type": "taxon",
+              "public_updated_at": "2020-03-02T16:03:56Z",
+              "schema_name": "taxon",
+              "withdrawn": false,
+              "description": "Services if you're visiting, studying, working or living in Switzerland. Includes information about trading with and doing business in the UK and Switzerland, and your rights after the UK’s exit from the EU.",
+              "details": {
+                "internal_name": "UK help and services in Switzerland",
+                "notes_for_editors": "",
+                "visible_to_departmental_editors": false
+              },
+              "phase": "live",
+              "links": {}
+            }
+          ],
+          "associated_taxons": [
+            {
+              "content_id": "4fe5a04b-9f68-4644-abb4-1f54c93f50e7",
+              "title": "Travelling abroad",
+              "locale": "en",
+              "analytics_identifier": null,
+              "api_path": "/api/content/world/travelling-abroad",
+              "base_path": "/world/travelling-abroad",
+              "document_type": "taxon",
+              "public_updated_at": "2017-06-30T14:24:24Z",
+              "schema_name": "taxon",
+              "withdrawn": false,
+              "description": "Includes travel advice and how to get married abroad.",
+              "details": {
+                "internal_name": "Travelling abroad (GENERIC)",
+                "notes_for_editors": "",
+                "visible_to_departmental_editors": false
+              },
+              "phase": "live",
+              "links": {}
+            }
+          ]
+        }
+      },
+      {
+        "content_id": "3d55560a-348e-4fca-a08a-ee9c178ed3b2",
+        "title": "Coming to the UK",
+        "locale": "en",
+        "analytics_identifier": null,
+        "api_path": "/api/content/world/coming-to-the-uk-switzerland",
+        "base_path": "/world/coming-to-the-uk-switzerland",
+        "document_type": "taxon",
+        "public_updated_at": "2017-06-29T08:18:21Z",
+        "schema_name": "taxon",
+        "withdrawn": false,
+        "description": "Get a visa to study, work or visit the UK.",
+        "details": {
+          "internal_name": "Coming to the UK (Switzerland)",
+          "notes_for_editors": "",
+          "visible_to_departmental_editors": true
+        },
+        "phase": "live",
+        "links": {
+          "parent_taxons": [
+            {
+              "content_id": "f1724368-504f-4b3c-9dc2-41121046de9f",
+              "title": "UK help and services in Switzerland",
+              "locale": "en",
+              "analytics_identifier": null,
+              "api_path": "/api/content/world/switzerland",
+              "base_path": "/world/switzerland",
+              "document_type": "taxon",
+              "public_updated_at": "2020-03-02T16:03:56Z",
+              "schema_name": "taxon",
+              "withdrawn": false,
+              "description": "Services if you're visiting, studying, working or living in Switzerland. Includes information about trading with and doing business in the UK and Switzerland, and your rights after the UK’s exit from the EU.",
+              "details": {
+                "internal_name": "UK help and services in Switzerland",
+                "notes_for_editors": "",
+                "visible_to_departmental_editors": false
+              },
+              "phase": "live",
+              "links": {}
+            }
+          ],
+          "associated_taxons": [
+            {
+              "content_id": "d0e61780-6962-40aa-bb57-298f35187e4f",
+              "title": "Coming to the UK",
+              "locale": "en",
+              "analytics_identifier": null,
+              "api_path": "/api/content/world/coming-to-the-uk",
+              "base_path": "/world/coming-to-the-uk",
+              "document_type": "taxon",
+              "public_updated_at": "2017-06-23T11:08:24Z",
+              "schema_name": "taxon",
+              "withdrawn": false,
+              "description": "Get a visa to study, work or visit the UK.",
+              "details": {
+                "internal_name": "Coming to the UK (GENERIC)",
+                "notes_for_editors": "",
+                "visible_to_departmental_editors": false
+              },
+              "phase": "live",
+              "links": {}
+            }
+          ]
+        }
+      },
+      {
+        "content_id": "3e4a999a-10dc-4fe3-a9d7-70f9c88654ff",
+        "title": "Emergency help for British nationals",
+        "locale": "en",
+        "analytics_identifier": null,
+        "api_path": "/api/content/world/emergency-help-for-british-nationals-switzerland",
+        "base_path": "/world/emergency-help-for-british-nationals-switzerland",
+        "document_type": "taxon",
+        "public_updated_at": "2017-06-29T08:18:21Z",
+        "schema_name": "taxon",
+        "withdrawn": false,
+        "description": "Get help if you're the victim of crime, you've been arrested, or are affected by a crisis abroad.",
+        "details": {
+          "internal_name": "Emergency help for British nationals (Switzerland)",
+          "notes_for_editors": "",
+          "visible_to_departmental_editors": true
+        },
+        "phase": "live",
+        "links": {
+          "parent_taxons": [
+            {
+              "content_id": "f1724368-504f-4b3c-9dc2-41121046de9f",
+              "title": "UK help and services in Switzerland",
+              "locale": "en",
+              "analytics_identifier": null,
+              "api_path": "/api/content/world/switzerland",
+              "base_path": "/world/switzerland",
+              "document_type": "taxon",
+              "public_updated_at": "2020-03-02T16:03:56Z",
+              "schema_name": "taxon",
+              "withdrawn": false,
+              "description": "Services if you're visiting, studying, working or living in Switzerland. Includes information about trading with and doing business in the UK and Switzerland, and your rights after the UK’s exit from the EU.",
+              "details": {
+                "internal_name": "UK help and services in Switzerland",
+                "notes_for_editors": "",
+                "visible_to_departmental_editors": false
+              },
+              "phase": "live",
+              "links": {}
+            }
+          ],
+          "associated_taxons": [
+            {
+              "content_id": "26adf294-1b3d-49cf-a465-46fe132511e9",
+              "title": "Emergency help for British nationals",
+              "locale": "en",
+              "analytics_identifier": null,
+              "api_path": "/api/content/world/emergency-help-for-british-nationals",
+              "base_path": "/world/emergency-help-for-british-nationals",
+              "document_type": "taxon",
+              "public_updated_at": "2017-06-23T10:56:41Z",
+              "schema_name": "taxon",
+              "withdrawn": false,
+              "description": "Get help if you're the victim of crime, you've been arrested, or are affected by a crisis abroad.",
+              "details": {
+                "internal_name": "Emergency help for British nationals (GENERIC)",
+                "notes_for_editors": "",
+                "visible_to_departmental_editors": false
+              },
+              "phase": "live",
+              "links": {}
+            }
+          ]
+        }
+      },
+      {
+        "content_id": "cf4c2666-1210-46ad-9b0e-4db0751854ad",
+        "title": "Trade and invest",
+        "locale": "en",
+        "analytics_identifier": null,
+        "api_path": "/api/content/world/trade-and-invest-switzerland",
+        "base_path": "/world/trade-and-invest-switzerland",
+        "document_type": "taxon",
+        "public_updated_at": "2017-06-29T08:18:22Z",
+        "schema_name": "taxon",
+        "withdrawn": false,
+        "description": "Includes investing and setting up a business in the UK and doing business in Switzerland.",
+        "details": {
+          "internal_name": "Trade and invest (Switzerland)",
+          "notes_for_editors": "",
+          "visible_to_departmental_editors": true
+        },
+        "phase": "live",
+        "links": {
+          "parent_taxons": [
+            {
+              "content_id": "f1724368-504f-4b3c-9dc2-41121046de9f",
+              "title": "UK help and services in Switzerland",
+              "locale": "en",
+              "analytics_identifier": null,
+              "api_path": "/api/content/world/switzerland",
+              "base_path": "/world/switzerland",
+              "document_type": "taxon",
+              "public_updated_at": "2020-03-02T16:03:56Z",
+              "schema_name": "taxon",
+              "withdrawn": false,
+              "description": "Services if you're visiting, studying, working or living in Switzerland. Includes information about trading with and doing business in the UK and Switzerland, and your rights after the UK’s exit from the EU.",
+              "details": {
+                "internal_name": "UK help and services in Switzerland",
+                "notes_for_editors": "",
+                "visible_to_departmental_editors": false
+              },
+              "phase": "live",
+              "links": {}
+            }
+          ],
+          "associated_taxons": [
+            {
+              "content_id": "172c9d39-445f-4501-b0b2-1d527cc7cabc",
+              "title": "Trade and invest",
+              "locale": "en",
+              "analytics_identifier": null,
+              "api_path": "/api/content/world/trade-and-invest",
+              "base_path": "/world/trade-and-invest",
+              "document_type": "taxon",
+              "public_updated_at": "2017-11-14T09:48:58Z",
+              "schema_name": "taxon",
+              "withdrawn": false,
+              "description": "Includes investing and setting up a business in the UK and doing business abroad.",
+              "details": {
+                "internal_name": "Trade and invest (GENERIC)",
+                "notes_for_editors": "",
+                "visible_to_departmental_editors": false
+              },
+              "phase": "live",
+              "links": {}
+            }
+          ]
+        }
+      }
+    ],
+    "parent_taxons": [
+      {
+        "content_id": "91b8ef20-74e7-4552-880c-50e6d73c2ff9",
+        "title": "Help and services around the world",
+        "locale": "en",
+        "analytics_identifier": null,
+        "api_path": "/api/content/world/all",
+        "base_path": "/world/all",
+        "document_type": "taxon",
+        "public_updated_at": "2021-07-09T10:08:54Z",
+        "schema_name": "taxon",
+        "withdrawn": false,
+        "description": "Help and services in a country",
+        "details": {
+          "url_override": "",
+          "internal_name": "Help and services around the world",
+          "notes_for_editors": "",
+          "visible_to_departmental_editors": false
+        },
+        "phase": "live",
+        "links": {}
+      }
+    ],
+    "available_translations": [
+      {
+        "title": "UK help and services in Switzerland",
+        "public_updated_at": "2020-03-02T16:03:56Z",
+        "analytics_identifier": null,
+        "document_type": "taxon",
+        "schema_name": "taxon",
+        "base_path": "/world/switzerland",
+        "api_path": "/api/content/world/switzerland",
+        "withdrawn": false,
+        "content_id": "f1724368-504f-4b3c-9dc2-41121046de9f",
+        "locale": "en"
+      }
+    ]
+  },
+  "user_journey_document_supertype": "finding",
+  "email_document_supertype": "other",
+  "government_document_supertype": "other",
+  "content_purpose_subgroup": "other",
+  "content_purpose_supergroup": "other",
+  "publishing_request_id": "18886-1583165043.422-10.3.3.1-1831",
+  "govuk_request_id": null,
+  "links": {
+    "parent_taxons": [
+      "91b8ef20-74e7-4552-880c-50e6d73c2ff9"
+    ]
+  },
+  "payload_version": "12345"
+}

--- a/spec/integration/document_synchronization_spec.rb
+++ b/spec/integration/document_synchronization_spec.rb
@@ -186,6 +186,32 @@ RSpec.describe "Document synchronization" do
     end
   end
 
+  describe "for a 'taxon' message that isn't ignorelisted" do
+    let(:payload) { json_fixture_as_hash("message_queue/world_taxon_message.json") }
+
+    it "is added to Discovery Engine through the Put service" do
+      expect(put_service).to have_received(:call).with(
+        "f1724368-504f-4b3c-9dc2-41121046de9f",
+        {
+          content_id: "f1724368-504f-4b3c-9dc2-41121046de9f",
+          title: "UK help and services in Switzerland",
+          description: "Services if you're visiting, studying, working or living in Switzerland. Includes information about trading with and doing business in the UK and Switzerland, and your rights after the UK’s exit from the EU.",
+          additional_searchable_text: "",
+          link: "/world/switzerland",
+          url: "http://www.dev.gov.uk/world/switzerland",
+          public_timestamp: 1_583_165_036,
+          document_type: "taxon",
+          is_historic: 0,
+          content_purpose_supergroup: "other",
+          part_of_taxonomy_tree: %w[],
+          locale: "en",
+        },
+        content: "",
+        payload_version: 12_345,
+      )
+    end
+  end
+
   describe "for an 'external_content' message" do
     let(:payload) { json_fixture_as_hash("message_queue/external_content_message.json") }
 

--- a/spec/integration/metadata_schema_compliance_spec.rb
+++ b/spec/integration/metadata_schema_compliance_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe "PublishingApiDocument schema-compliant metadata generation" do
     organisation_message
     press_release_message
     travel_advice_message
+    world_taxon_message
   ].each do |message_fixture|
     context "when processing a '#{message_fixture}'" do
       let(:document_hash) { json_fixture_as_hash("message_queue/#{message_fixture}.json") }

--- a/spec/models/publishing_api_document/ignore_spec.rb
+++ b/spec/models/publishing_api_document/ignore_spec.rb
@@ -1,0 +1,36 @@
+RSpec.describe PublishingApiDocument::Ignore do
+  subject(:document) { described_class.new(document_hash) }
+
+  let(:content_id) { "123" }
+  let(:payload_version) { "1" }
+  let(:document_type) { "ignored" }
+  let(:document_hash) do
+    {
+      "content_id" => content_id,
+      "payload_version" => payload_version,
+      "document_type" => document_type,
+    }
+  end
+
+  describe "#content_id" do
+    it "returns the content_id from the document hash" do
+      expect(document.content_id).to eq(content_id)
+    end
+  end
+
+  describe "#payload_version" do
+    it "returns the payload_version from the document hash" do
+      expect(document.payload_version).to eq(1)
+    end
+  end
+
+  describe "#synchronize" do
+    let(:service) { double("A service", call: nil) }
+
+    it "does not call the service" do
+      document.synchronize(service:)
+
+      expect(service).not_to have_received(:call)
+    end
+  end
+end

--- a/spec/models/publishing_api_document_spec.rb
+++ b/spec/models/publishing_api_document_spec.rb
@@ -2,7 +2,15 @@ RSpec.describe PublishingApiDocument do
   describe ".for" do
     subject(:document) { described_class.for(document_hash) }
 
-    let(:document_hash) { { "document_type" => document_type } }
+    let(:document_hash) do
+      {
+        "document_type" => document_type,
+        "base_path" => base_path,
+        "locale" => locale,
+      }
+    end
+    let(:base_path) { "/base-path" }
+    let(:locale) { "en" }
 
     %w[gone redirect substitute vanish].each do |document_type|
       context "when the document type is #{document_type}" do
@@ -12,7 +20,53 @@ RSpec.describe PublishingApiDocument do
       end
     end
 
-    context "when the document type is not one of the unpublish document types" do
+    context "when the document type is on the ignore list as a string" do
+      let(:document_type) { "ignored" }
+
+      before do
+        allow(Rails.configuration).to receive(:document_type_ignorelist).and_return(%w[ignored])
+      end
+
+      it { is_expected.to be_a(PublishingApiDocument::Ignore) }
+    end
+
+    context "when the document type is on the ignore list as a pattern" do
+      let(:document_type) { "ignored_thing" }
+
+      before do
+        allow(Rails.configuration).to receive(:document_type_ignorelist).and_return([/^ignored_/])
+      end
+
+      it { is_expected.to be_a(PublishingApiDocument::Ignore) }
+    end
+
+    context "when the document type is on the ignore list but the path is excluded" do
+      let(:document_type) { "ignored" }
+
+      before do
+        allow(Rails.configuration).to receive(:document_type_ignorelist).and_return(%w[ignored])
+        allow(Rails.configuration).to receive(:document_type_ignorelist_path_overrides)
+          .and_return(%w[/base-path])
+      end
+
+      it { is_expected.to be_a(PublishingApiDocument::Publish) }
+    end
+
+    context "when the document doesn't have an English locale" do
+      let(:document_type) { "dokument" }
+      let(:locale) { "de" }
+
+      it { is_expected.to be_a(PublishingApiDocument::Ignore) }
+    end
+
+    context "when the document has a blank locale but otherwise should be added" do
+      let(:document_type) { "stuff" }
+      let(:locale) { nil }
+
+      it { is_expected.to be_a(PublishingApiDocument::Publish) }
+    end
+
+    context "when the document type is anything else" do
       let(:document_type) { "anything-else" }
 
       it { is_expected.to be_a(PublishingApiDocument::Publish) }


### PR DESCRIPTION
Some documents that come through to us via the Publishing API should not
be added to Discovery Engine, in particular blocklisted document types.

- Create `PublishingApiDocument::Ignore` to represent a synchronization
  noop
- Add ignorelist and ignorelist override configuration files
- Update `PublishingApiDocument.for` to consider configuration files and
  locale
- Add fixture, integration test, and schema test for a world taxon
  message
- Add ADR 004 to document how we arrived at this logic