### PR TITLE
Refactor initial document handling

### DIFF
--- a/app/message_processors/publishing_api_message_processor.rb
+++ b/app/message_processors/publishing_api_message_processor.rb
@@ -2,7 +2,7 @@ class PublishingApiMessageProcessor
   # Implements the callback interface required by `govuk_message_queue_consumer`
   def process(message)
     document_hash = message.payload.deep_symbolize_keys
-    document = PublishingApiDocument.for(document_hash)
+    document = PublishingApiDocument.new(document_hash)
     document.synchronize
 
     message.ack

--- a/app/models/publishing_api_action/base.rb
+++ b/app/models/publishing_api_action/base.rb
@@ -1,4 +1,4 @@
-module PublishingApiDocument
+module PublishingApiAction
   # Abstract base class for documents from the Publishing API that can be synchronized to a service.
   # Concrete subclasses are responsible for implementing synchronization logic for their particular
   # type of document, which may involve creating or deleting a record remotely.

--- a/app/models/publishing_api_action/content_with_multiple_types.rb
+++ b/app/models/publishing_api_action/content_with_multiple_types.rb
@@ -1,4 +1,4 @@
-module PublishingApiDocument
+module PublishingApiAction
   class ContentWithMultipleTypes
     def initialize(content_with_multiple_types)
       @content_with_multiple_types = content_with_multiple_types

--- a/app/models/publishing_api_action/ignore.rb
+++ b/app/models/publishing_api_action/ignore.rb
@@ -1,4 +1,4 @@
-module PublishingApiDocument
+module PublishingApiAction
   class Ignore < Base
     # Synchonisation is a no-op for ignored documents
     def synchronize(*)

--- a/app/models/publishing_api_action/publish.rb
+++ b/app/models/publishing_api_action/publish.rb
@@ -1,4 +1,4 @@
-module PublishingApiDocument
+module PublishingApiAction
   class Publish < Base
     # All the possible keys in the message hash that can contain the primary unstructured document
     # content that we want to index, represented as JsonPath path strings.

--- a/app/models/publishing_api_action/unpublish.rb
+++ b/app/models/publishing_api_action/unpublish.rb
@@ -1,4 +1,4 @@
-module PublishingApiDocument
+module PublishingApiAction
   class Unpublish < Base
     # Synchronize the document to the given service (i.e. delete it remotely).
     def synchronize(service: DiscoveryEngine::Delete.new)

--- a/spec/integration/metadata_schema_compliance_spec.rb
+++ b/spec/integration/metadata_schema_compliance_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "PublishingApiDocument schema-compliant metadata generation" do
   ].each do |message_fixture|
     context "when processing a '#{message_fixture}'" do
       let(:document_hash) { json_fixture_as_hash("message_queue/#{message_fixture}.json") }
-      let(:document) { PublishingApiDocument::Publish.new(document_hash.deep_symbolize_keys) }
+      let(:document) { PublishingApiAction::Publish.new(document_hash.deep_symbolize_keys) }
 
       it "results in a document validating against the datastore schema" do
         expect(document.metadata).to match_json_schema(metadata_json_schema)

--- a/spec/models/publishing_api_action/ignore_spec.rb
+++ b/spec/models/publishing_api_action/ignore_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe PublishingApiDocument::Ignore do
+RSpec.describe PublishingApiAction::Ignore do
   subject(:document) { described_class.new(document_hash) }
 
   let(:content_id) { "123" }

--- a/spec/models/publishing_api_action/publish_spec.rb
+++ b/spec/models/publishing_api_action/publish_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe PublishingApiDocument::Publish do
+RSpec.describe PublishingApiAction::Publish do
   subject(:document) { described_class.new(document_hash) }
 
   let(:content_id) { "123" }

--- a/spec/models/publishing_api_action/unpublish_spec.rb
+++ b/spec/models/publishing_api_action/unpublish_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe PublishingApiDocument::Unpublish do
+RSpec.describe PublishingApiAction::Unpublish do
   subject(:document) { described_class.new(document_hash) }
 
   let(:content_id) { "123" }

--- a/spec/models/publishing_api_document_spec.rb
+++ b/spec/models/publishing_api_document_spec.rb
@@ -1,22 +1,24 @@
 RSpec.describe PublishingApiDocument do
-  describe ".for" do
-    subject(:document) { described_class.for(document_hash) }
+  describe "#action" do
+    subject(:document) { described_class.new(document_hash).action }
 
     let(:document_hash) do
       {
         document_type:,
         base_path:,
+        details: { url: },
         locale:,
       }
     end
     let(:base_path) { "/base-path" }
+    let(:url) { nil }
     let(:locale) { "en" }
 
     %w[gone redirect substitute vanish].each do |document_type|
       context "when the document type is #{document_type}" do
         let(:document_type) { document_type }
 
-        it { is_expected.to be_a(PublishingApiDocument::Unpublish) }
+        it { is_expected.to be_a(PublishingApiAction::Unpublish) }
       end
     end
 
@@ -27,7 +29,7 @@ RSpec.describe PublishingApiDocument do
         allow(Rails.configuration).to receive(:document_type_ignorelist).and_return(%w[ignored])
       end
 
-      it { is_expected.to be_a(PublishingApiDocument::Ignore) }
+      it { is_expected.to be_a(PublishingApiAction::Ignore) }
     end
 
     context "when the document type is on the ignore list as a pattern" do
@@ -37,7 +39,7 @@ RSpec.describe PublishingApiDocument do
         allow(Rails.configuration).to receive(:document_type_ignorelist).and_return([/^ignored_/])
       end
 
-      it { is_expected.to be_a(PublishingApiDocument::Ignore) }
+      it { is_expected.to be_a(PublishingApiAction::Ignore) }
     end
 
     context "when the document type is on the ignore list but the path is excluded" do
@@ -49,27 +51,43 @@ RSpec.describe PublishingApiDocument do
           .and_return(%w[/base-path])
       end
 
-      it { is_expected.to be_a(PublishingApiDocument::Publish) }
+      it { is_expected.to be_a(PublishingApiAction::Publish) }
     end
 
     context "when the document doesn't have an English locale" do
       let(:document_type) { "dokument" }
       let(:locale) { "de" }
 
-      it { is_expected.to be_a(PublishingApiDocument::Ignore) }
+      it { is_expected.to be_a(PublishingApiAction::Ignore) }
+    end
+
+    context "when the document doesn't have a base path or a details.url" do
+      let(:document_type) { "internal" }
+      let(:base_path) { nil }
+      let(:url) { nil }
+
+      it { is_expected.to be_a(PublishingApiAction::Ignore) }
+    end
+
+    context "when the document doesn't have a base path but does have a url" do
+      let(:document_type) { "external_content" }
+      let(:base_path) { nil }
+      let(:url) { "https://www.example.com" }
+
+      it { is_expected.to be_a(PublishingApiAction::Publish) }
     end
 
     context "when the document has a blank locale but otherwise should be added" do
       let(:document_type) { "stuff" }
       let(:locale) { nil }
 
-      it { is_expected.to be_a(PublishingApiDocument::Publish) }
+      it { is_expected.to be_a(PublishingApiAction::Publish) }
     end
 
     context "when the document type is anything else" do
       let(:document_type) { "anything-else" }
 
-      it { is_expected.to be_a(PublishingApiDocument::Publish) }
+      it { is_expected.to be_a(PublishingApiAction::Publish) }
     end
   end
 end


### PR DESCRIPTION
This is a first step to a cleaner design for establishing what to do with an incoming document from the Publishing API.

- Make `PublishingApiDocument` a class in its own right
- Temporarily rename `PublishingApiDocument` module to `PublishingApiAction` until we refactor the classes within
- Tweak logic for deciding what to do with a document