### PR TITLE
Add additional searchable text fields

### DIFF
--- a/app/models/concerns/publishing_api/metadata.rb
+++ b/app/models/concerns/publishing_api/metadata.rb
@@ -4,20 +4,36 @@ module PublishingApi
     # that should be searchable but doesn't form part of the primary document content, represented
     # as JsonPath path strings.
     ADDITIONAL_SEARCHABLE_TEXT_VALUES_JSON_PATHS = %w[
-      $.details.hidden_search_terms
-      $.details.metadata.hidden_indexable_content
-      $.details.metadata.project_code
-      $.details.metadata.aircraft_type
-      $.details.metadata.registration
-      $.details.metadata.tribunal_decision_categories_name
-      $.details.metadata.tribunal_decision_country_name
-      $.details.metadata.tribunal_decision_judges_name
-      $.details.metadata.tribunal_decision_category_name
-      $.details.metadata.tribunal_decision_sub_category_name
-      $.details.metadata.tribunal_decision_sub_categories_name
-      $.details.metadata.tribunal_decision_landmark_name
       $.details.acronym
       $.details.attachments[*]['title','isbn','unique_reference','command_paper_number','hoc_paper_number']
+      $.details.hidden_search_terms
+      $.details.licence_short_description
+      $.details.metadata.aircraft_type
+      $.details.metadata.authors
+      $.details.metadata.business_sizes
+      $.details.metadata.business_stages
+      $.details.metadata.hidden_indexable_content
+      $.details.metadata.industries
+      $.details.metadata.keyword
+      $.details.metadata.licence_transaction_industry
+      $.details.metadata.project_code
+      $.details.metadata.reference_number
+      $.details.metadata.regions
+      $.details.metadata.registration
+      $.details.metadata.research_document_type
+      $.details.metadata.result
+      $.details.metadata.stage
+      $.details.metadata.theme
+      $.details.metadata.tribunal_decision_categories_name
+      $.details.metadata.tribunal_decision_category_name
+      $.details.metadata.tribunal_decision_country_name
+      $.details.metadata.tribunal_decision_judges_name
+      $.details.metadata.tribunal_decision_landmark_name
+      $.details.metadata.tribunal_decision_sub_categories_name
+      $.details.metadata.tribunal_decision_sub_category_name
+      $.details.metadata.types_of_support
+      $.details.metadata.virus_strain
+      $.details.metadata.year_adopted
     ].map { JsonPath.new(_1, use_symbols: true) }.freeze
     ADDITIONAL_SEARCHABLE_TEXT_VALUES_SEPARATOR = "\n".freeze
 

--- a/spec/models/concerns/publishing_api/metadata_spec.rb
+++ b/spec/models/concerns/publishing_api/metadata_spec.rb
@@ -31,131 +31,19 @@ RSpec.describe PublishingApi::Metadata do
     describe "additional_searchable_text" do
       subject(:additional_searchable_text) { extracted_metadata[:additional_searchable_text] }
 
-      describe "with hidden search terms" do
-        let(:document_hash) do
-          {
-            details: {
-              hidden_search_terms: "a b c",
+      let(:document_hash) do
+        {
+          details: {
+            acronym: "BA",
+            metadata: {
+              registration: "G-CIVY",
+              aircraft_type: "Boeing 747-436",
             },
-          }
-        end
-
-        it { is_expected.to eq("a b c") }
+          },
+        }
       end
 
-      describe "with hidden indexable content as an array" do
-        let(:document_hash) do
-          {
-            details: {
-              metadata: {
-                hidden_indexable_content: %w[x y z],
-              },
-            },
-          }
-        end
-
-        it { is_expected.to eq("x\ny\nz") }
-      end
-
-      describe "with hidden indexable content as a string" do
-        let(:document_hash) do
-          {
-            details: {
-              metadata: {
-                hidden_indexable_content: "x y z",
-              },
-            },
-          }
-        end
-
-        it { is_expected.to eq("x y z") }
-      end
-
-      describe "with a project code" do
-        let(:document_hash) do
-          {
-            details: {
-              metadata: {
-                project_code: "PRINCE2",
-              },
-            },
-          }
-        end
-
-        it { is_expected.to eq("PRINCE2") }
-      end
-
-      describe "with an acronym" do
-        let(:document_hash) do
-          {
-            details: {
-              acronym: "LOL",
-            },
-          }
-        end
-
-        it { is_expected.to eq("LOL") }
-      end
-
-      describe "with a registration and aircraft type" do
-        let(:document_hash) do
-          {
-            details: {
-              metadata: {
-                registration: "G-CIVY",
-                aircraft_type: "Boeing 747-436",
-              },
-            },
-          }
-        end
-
-        it { is_expected.to eq("Boeing 747-436\nG-CIVY") }
-      end
-
-      describe "with tribunal decision details" do
-        let(:document_hash) do
-          {
-            details: {
-              metadata: {
-                tribunal_decision_categories_name: "A",
-                tribunal_decision_country_name: "B",
-                tribunal_decision_judges_name: "C",
-                tribunal_decision_category_name: "D",
-                tribunal_decision_sub_category_name: "E",
-                tribunal_decision_sub_categories_name: "F",
-                tribunal_decision_landmark_name: "G",
-              },
-            },
-          }
-        end
-
-        it { is_expected.to eq("A\nB\nC\nD\nE\nF\nG") }
-      end
-
-      describe "with attachments" do
-        let(:document_hash) do
-          {
-            details: {
-              attachments: [
-                {
-                  title: "A report",
-                  isbn: "1234567890123",
-                  unique_reference: "ABCDEF",
-                  command_paper_number: "",
-                },
-                {
-                  title: "Another report",
-                  isbn: "",
-                  command_paper_number: "CPN1234",
-                  hoc_paper_number: "ADHOC",
-                },
-              ],
-            },
-          }
-        end
-
-        it { is_expected.to eq("A report\n1234567890123\nABCDEF\nAnother report\nCPN1234\nADHOC") }
-      end
+      it { is_expected.to eq("BA\nBoeing 747-436\nG-CIVY") }
     end
 
     describe "link" do


### PR DESCRIPTION
- Add the final set of fields that should be searchable through the `additional_searchable_text` field.
- Simplify unit tests because they don't add much value here