### PR TITLE
Truncate content above Discovery Engine limit

### DIFF
--- a/spec/models/concerns/publishing_api/content_spec.rb
+++ b/spec/models/concerns/publishing_api/content_spec.rb
@@ -72,6 +72,20 @@ RSpec.describe PublishingApi::Content do
       it { is_expected.to eq("<h1>Foo</h1>\nbar\n<h1>Bar</h1>\n<blink>baz</blink>") }
     end
 
+    describe "with excessively large content" do
+      let(:document_hash) do
+        {
+          details: {
+            body: "a" * 1.1.megabytes,
+          },
+        }
+      end
+
+      it "truncates the content" do
+        expect(extracted_content.bytesize).to be <= 1.megabyte
+      end
+    end
+
     describe "without any fields" do
       let(:document_hash) do
         {


### PR DESCRIPTION
The current limit for Discovery Engine is 1MB of content, so truncate the handful of obscenely large documents to 950KB.