### PR TITLE
Concernify action logic from PublishingApiDocument

### DIFF
--- a/app/models/concerns/publishing_api/action.rb
+++ b/app/models/concerns/publishing_api/action.rb
@@ -1,0 +1,72 @@
+module PublishingApi
+  module Action
+    # When a document is unpublished in the source system, its document type changes to one of
+    # these values. While semantically different for other systems, we only need to know that they
+    # imply removal from search.
+    UNPUBLISH_DOCUMENT_TYPES = %w[gone redirect substitute vanish].freeze
+
+    # Currently, we only allow documents in English to be added to search because that is the
+    # behaviour of the existing search. This may change in the future.
+    PERMITTED_LOCALES = %w[en].freeze
+
+    def publish?
+      !unpublish? && !ignore?
+    end
+
+    def unpublish?
+      UNPUBLISH_DOCUMENT_TYPES.include?(document_type)
+    end
+
+    def ignore?
+      on_ignorelist? || ignored_locale? || unaddressable?
+    end
+
+    def ignore_reason
+      if on_ignorelist?
+        "document_type on ignorelist (#{document_type})"
+      elsif ignored_locale?
+        "locale not permitted (#{locale})"
+      elsif unaddressable?
+        "unaddressable"
+      end
+    end
+
+  private
+
+    def on_ignorelist?
+      return false if ignorelist_excepted_path?
+
+      Rails.configuration.document_type_ignorelist.any? { document_type.match?(_1) }
+    end
+
+    def ignorelist_excepted_path?
+      return false if base_path.blank?
+
+      Rails.configuration.document_type_ignorelist_path_overrides.any? { _1.match?(base_path) }
+    end
+
+    def ignored_locale?
+      locale.present? && !PERMITTED_LOCALES.include?(locale)
+    end
+
+    def unaddressable?
+      base_path.blank? && external_link.blank?
+    end
+
+    def document_type
+      document_hash.fetch(:document_type)
+    end
+
+    def base_path
+      document_hash[:base_path]
+    end
+
+    def external_link
+      document_hash.dig(:details, :url)
+    end
+
+    def locale
+      document_hash[:locale]
+    end
+  end
+end

--- a/app/models/concerns/publishing_api/metadata.rb
+++ b/app/models/concerns/publishing_api/metadata.rb
@@ -59,6 +59,8 @@ module PublishingApi
       }.compact_blank
     end
 
+  private
+
     def link
       document_hash[:base_path].presence || document_hash.dig(:details, :url)
     end

--- a/app/models/publishing_api_document.rb
+++ b/app/models/publishing_api_document.rb
@@ -1,13 +1,5 @@
 class PublishingApiDocument
-  # When a document is unpublished in the source system, its document type changes to one of
-  # these values. While semantically different for other systems, we only need to know that they
-  # imply removal from search.
-  UNPUBLISH_DOCUMENT_TYPES = %w[gone redirect substitute vanish].freeze
-
-  # Currently, we only allow documents in English to be added to search because that is the
-  # behaviour of the existing search. This may change in the future.
-  PERMITTED_LOCALES = %w[en].freeze
-
+  include ::PublishingApi::Action
   include ::PublishingApi::Metadata
   include ::PublishingApi::Content
 
@@ -19,58 +11,24 @@ class PublishingApiDocument
     delete_service: DiscoveryEngine::Delete.new
   )
     @document_hash = document_hash
-
-    @document_type = document_hash.fetch(:document_type)
-    @content_id = document_hash.fetch(:content_id)
-    @base_path = document_hash[:base_path]
-    @external_link = document_hash.dig(:details, :url)
-    @locale = document_hash[:locale]
-    @payload_version = document_hash[:payload_version]&.to_i
-
     @put_service = put_service
     @delete_service = delete_service
+
+    @content_id = document_hash.fetch(:content_id)
+    @payload_version = document_hash[:payload_version]&.to_i
   end
 
   def synchronize
-    if unpublish?
-      delete_service.call(content_id, payload_version:)
-    elsif ignore?
-      Rails.logger.info("Ignoring document '#{content_id}'")
-    else
+    if publish?
       put_service.call(content_id, metadata, content:, payload_version:)
+    elsif unpublish?
+      delete_service.call(content_id, payload_version:)
+    else
+      Rails.logger.info("Ignoring document '#{content_id}': #{ignore_reason}")
     end
   end
 
 private
 
-  attr_reader :document_hash, :document_type, :base_path, :external_link, :locale,
-              :put_service, :delete_service
-
-  def unpublish?
-    UNPUBLISH_DOCUMENT_TYPES.include?(document_type)
-  end
-
-  def ignore?
-    on_ignorelist? || ignored_locale? || unaddressable?
-  end
-
-  def on_ignorelist?
-    return false if ignorelist_excepted_path?
-
-    Rails.configuration.document_type_ignorelist.any? { document_type.match?(_1) }
-  end
-
-  def ignorelist_excepted_path?
-    return false if base_path.blank?
-
-    Rails.configuration.document_type_ignorelist_path_overrides.any? { _1.match?(base_path) }
-  end
-
-  def ignored_locale?
-    locale.present? && !PERMITTED_LOCALES.include?(locale)
-  end
-
-  def unaddressable?
-    base_path.blank? && external_link.blank?
-  end
+  attr_reader :document_hash, :put_service, :delete_service
 end

--- a/spec/models/publishing_api_document_spec.rb
+++ b/spec/models/publishing_api_document_spec.rb
@@ -46,7 +46,9 @@ RSpec.describe PublishingApiDocument do
 
       it "does not publish the document and logs a message" do
         expect(put_service).not_to have_received(:call)
-        expect(Rails.logger).to have_received(:info).with("Ignoring document 'content-id'")
+        expect(Rails.logger).to have_received(:info).with(
+          "Ignoring document 'content-id': document_type on ignorelist (test_ignored_type)",
+        )
       end
     end
 
@@ -55,7 +57,9 @@ RSpec.describe PublishingApiDocument do
 
       it "does not publish the document and logs a message" do
         expect(put_service).not_to have_received(:call)
-        expect(Rails.logger).to have_received(:info).with("Ignoring document 'content-id'")
+        expect(Rails.logger).to have_received(:info).with(
+          "Ignoring document 'content-id': document_type on ignorelist (another_test_ignored_type_foo)",
+        )
       end
     end
 
@@ -66,7 +70,9 @@ RSpec.describe PublishingApiDocument do
 
       it "does not publish the document and logs a message" do
         expect(put_service).not_to have_received(:call)
-        expect(Rails.logger).to have_received(:info).with("Ignoring document 'content-id'")
+        expect(Rails.logger).to have_received(:info).with(
+          "Ignoring document 'content-id': unaddressable",
+        )
       end
     end
 
@@ -76,7 +82,9 @@ RSpec.describe PublishingApiDocument do
 
       it "does not publish the document and logs a message" do
         expect(put_service).not_to have_received(:call)
-        expect(Rails.logger).to have_received(:info).with("Ignoring document 'content-id'")
+        expect(Rails.logger).to have_received(:info).with(
+          "Ignoring document 'content-id': locale not permitted (de)",
+        )
       end
     end
 


### PR DESCRIPTION
- Move the logic determining what action to take with a document out into a `PublishingApi::Action` concern
- Add slightly better logging with an `ignore_reason`
- Make internal methods of `PublishingApi::Metadata` private