### PR TITLE
Accept datastore branch instead of datastore path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       RAILS_ENV: test
       # All Google client library calls are mocked, but the application needs this set to boot
       DISCOVERY_ENGINE_SERVING_CONFIG: not-used
-      DISCOVERY_ENGINE_DATASTORE: not-used
+      DISCOVERY_ENGINE_DATASTORE_BRANCH: not-used
     steps:
       - uses: actions/checkout@v3
         with:

--- a/app/services/discovery_engine/document_name.rb
+++ b/app/services/discovery_engine/document_name.rb
@@ -1,10 +1,7 @@
 module DiscoveryEngine
   module DocumentName
-    DEFAULT_BRANCH = "/branches/default_branch".freeze
-
     def document_name(content_id)
-      branch_path = Rails.configuration.discovery_engine_datastore + DEFAULT_BRANCH
-      "#{branch_path}/documents/#{content_id}"
+      "#{Rails.configuration.discovery_engine_datastore_branch}/documents/#{content_id}"
     end
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -18,7 +18,7 @@ module SearchApiV2
 
     # Google Discovery Engine configuration
     config.discovery_engine_serving_config = ENV.fetch("DISCOVERY_ENGINE_SERVING_CONFIG")
-    config.discovery_engine_datastore = ENV.fetch("DISCOVERY_ENGINE_DATASTORE")
+    config.discovery_engine_datastore_branch = ENV.fetch("DISCOVERY_ENGINE_DATASTORE_BRANCH")
 
     # Document sync configuration
     config.document_type_ignorelist = config_for(:document_type_ignorelist)

--- a/spec/services/discovery_engine/delete_spec.rb
+++ b/spec/services/discovery_engine/delete_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe DiscoveryEngine::Delete do
 
   before do
     allow(Rails).to receive(:logger).and_return(logger)
-    allow(Rails.configuration).to receive(:discovery_engine_datastore).and_return("datastore-path")
+    allow(Rails.configuration).to receive(:discovery_engine_datastore_branch).and_return("branch")
     allow(GovukError).to receive(:notify)
   end
 
@@ -19,7 +19,7 @@ RSpec.describe DiscoveryEngine::Delete do
 
     it "deletes the document" do
       expect(client).to have_received(:delete_document)
-        .with(name: "datastore-path/branches/default_branch/documents/some_content_id")
+        .with(name: "branch/documents/some_content_id")
     end
 
     it "logs the delete operation" do

--- a/spec/services/discovery_engine/put_spec.rb
+++ b/spec/services/discovery_engine/put_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe DiscoveryEngine::Put do
 
   before do
     allow(Rails).to receive(:logger).and_return(logger)
-    allow(Rails.configuration).to receive(:discovery_engine_datastore).and_return("datastore-path")
+    allow(Rails.configuration).to receive(:discovery_engine_datastore_branch).and_return("branch")
     allow(GovukError).to receive(:notify)
   end
 
@@ -28,7 +28,7 @@ RSpec.describe DiscoveryEngine::Put do
       expect(client).to have_received(:update_document).with(
         document: {
           id: "some_content_id",
-          name: "datastore-path/branches/default_branch/documents/some_content_id",
+          name: "branch/documents/some_content_id",
           json_data: "{\"foo\":\"bar\",\"payload_version\":\"1\"}",
           content: {
             mime_type: "text/html",


### PR DESCRIPTION
The infrastructure setup now populates an environment variable for `DISCOVERY_ENGINE_DATASTORE_BRANCH` that we can use directly.