### PR TITLE
Fix over-eager document type ignorelist and overrides

### DIFF
--- a/app/models/concerns/publishing_api/action.rb
+++ b/app/models/concerns/publishing_api/action.rb
@@ -33,17 +33,19 @@ module PublishingApi
 
   private
 
+    # rubocop:disable Style/CaseEquality (no semantically equal alternative to compare String/Regex)
     def on_ignorelist?
       return false if ignorelist_excepted_path?
 
-      Rails.configuration.document_type_ignorelist.any? { document_type.match?(_1) }
+      Rails.configuration.document_type_ignorelist.any? { _1 === document_type }
     end
 
     def ignorelist_excepted_path?
       return false if base_path.blank?
 
-      Rails.configuration.document_type_ignorelist_path_overrides.any? { _1.match?(base_path) }
+      Rails.configuration.document_type_ignorelist_path_overrides.any? { _1 === base_path }
     end
+    # rubocop:enable Style/CaseEquality
 
     def ignored_locale?
       locale.present? && !PERMITTED_LOCALES.include?(locale)

--- a/config/document_type_ignorelist.yml
+++ b/config/document_type_ignorelist.yml
@@ -1,5 +1,8 @@
 # A set of document types that come through from Publishing API that we don't want to add to
 # Discovery Engine because they are not useful for search.
+#
+# Compared against document_type using `===` so either YAML regular expression tags or exact Strings
+# can be used.
 shared:
   - !ruby/regexp /^placeholder/ # any placeholder type
   - completed_transaction

--- a/config/document_type_ignorelist_path_overrides.yml
+++ b/config/document_type_ignorelist_path_overrides.yml
@@ -1,7 +1,9 @@
 # A set of paths for documents that should be added to search even if their document type is in the
 # ignorelist. This is used for document types that shouldn't show up in search in general, but that
 # do have a handful of exceptions.
-# This is compared using ===, so you may use regular expression tags
+#
+# Compared against base_path using `===` so either YAML regular expression tags or exact Strings can
+# be used.
 shared:
 - !ruby/regexp /^\/world/[^\/]+$/ # taxon
 - /cost-of-living # special_route

--- a/spec/models/concerns/publishing_api/action_spec.rb
+++ b/spec/models/concerns/publishing_api/action_spec.rb
@@ -25,6 +25,18 @@ RSpec.describe PublishingApi::Action do
     end
   end
 
+  context "when part of (but not the whole) document type is on the ignore list as a string" do
+    let(:document_type) { "test_ignored_type_foo" } # see test section in YAML config
+
+    it { is_expected.to be_publish }
+  end
+
+  context "when a type is on the ignore list as a string that contains the document_type" do
+    let(:document_type) { "test_ignored" } # see test section in YAML config
+
+    it { is_expected.to be_publish }
+  end
+
   context "when the document type is on the ignore list as a pattern" do
     let(:document_type) { "another_test_ignored_type_foo" } # see test section in YAML config
 
@@ -65,6 +77,13 @@ RSpec.describe PublishingApi::Action do
     let(:base_path) { "/test_ignored_path_override" } # see test section in YAML config
 
     it { is_expected.to be_publish }
+  end
+
+  context "when the document type is on the ignore list and a non-exact subset of the path is excluded" do
+    let(:document_type) { "test_ignored_type" } # see test section in YAML config
+    let(:base_path) { "/test_ignored_path" } # see test section in YAML config
+
+    it { is_expected.to be_ignore }
   end
 
   context "when the document doesn't have a base path but does have a url" do


### PR DESCRIPTION
The `String#match?` method will implicitly convert its argument to a regex, which means that the exact strings in the ignorelist and ignorelist overrides suddenly become a bit too eager and start ignoring/overriding non-exact matches. Use `===` (despite Rubocop's protestations) for the desired behaviour for both strings and regular expressions.