### PR TITLE
Add boosting for news content at query time

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ group :test do
   gem "grpc_mock"
   gem "json_schemer"
   gem "simplecov", require: false
+  gem "timecop"
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -487,6 +487,7 @@ GEM
     statsd-ruby (1.5.0)
     stringio (3.0.9)
     thor (1.3.0)
+    timecop (0.9.8)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unf (0.1.4)
@@ -525,6 +526,7 @@ DEPENDENCIES
   rspec-rails
   rubocop-govuk
   simplecov
+  timecop
 
 RUBY VERSION
    ruby 3.2.2p53

--- a/app/services/discovery_engine/news_recency_boost.rb
+++ b/app/services/discovery_engine/news_recency_boost.rb
@@ -1,0 +1,36 @@
+module DiscoveryEngine
+  module NewsRecencyBoost
+    FRESH_AGE = 1.week
+    RECENT_AGE = 3.months
+    OLD_AGE = 1.year
+    ANCIENT_AGE = 4.years
+
+    def news_recency_boost_specs
+      [
+        {
+          boost: 0.2,
+          condition: news_boost_condition("#{FRESH_AGE.ago.to_i}i,*"),
+        },
+        {
+          boost: 0.05,
+          condition: news_boost_condition("#{RECENT_AGE.ago.to_i}i,#{FRESH_AGE.ago.to_i}e"),
+        },
+        {
+          boost: -0.5,
+          condition: news_boost_condition("#{ANCIENT_AGE.ago.to_i}i,#{OLD_AGE.ago.to_i}e"),
+        },
+        {
+          boost: -0.75,
+          condition: news_boost_condition("*,#{ANCIENT_AGE.ago.to_i}e"),
+        },
+      ]
+    end
+
+  private
+
+    def news_boost_condition(timeframe_in)
+      "content_purpose_supergroup: ANY(\"news_and_communications\")"\
+        " AND public_timestamp: IN(#{timeframe_in})"
+    end
+  end
+end

--- a/app/services/discovery_engine/search.rb
+++ b/app/services/discovery_engine/search.rb
@@ -3,6 +3,8 @@ module DiscoveryEngine
     DEFAULT_COUNT = 10
     DEFAULT_START = 0
 
+    include NewsRecencyBoost
+
     def initialize(client: ::Google::Cloud::DiscoveryEngine.search_service(version: :v1))
       @client = client
     end
@@ -16,6 +18,7 @@ module DiscoveryEngine
         serving_config:,
         page_size: count,
         offset: start,
+        boost_spec:,
       ).response
 
       ResultSet.new(
@@ -31,6 +34,14 @@ module DiscoveryEngine
 
     def serving_config
       Rails.configuration.discovery_engine_serving_config
+    end
+
+    def boost_spec
+      {
+        condition_boost_specs: [
+          *news_recency_boost_specs,
+        ],
+      }
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,8 @@ GovukTest.configure
 
 require "grpc_mock/rspec"
 
+Timecop.safe_mode = true
+
 # See https://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
   config.default_formatter = "doc" if config.files_to_run.one?


### PR DESCRIPTION
News content (specifically, content with a content_purpose_supergroup of `news_and_communications`) doesn't age very well in terms of its usefulness to mainstream search scenarios. Early on in its life, it may be more relevant to users but the model hasn't learned that yet due to a lack of events. Later on, it may have been viewed a lot but no longer be relevant and potentially misleading to users who don't notice the date.

- Add two promotion and two demotion timescales/cutoffs and apply dynamic query time boost specs depending on the content's public_timestamp
- Add `timecop` for time freezing in tests (and enforce `safe_mode`)