### PR TITLE
Add simple ability to define best bets

### DIFF
--- a/app/services/discovery_engine/best_bets_boost.rb
+++ b/app/services/discovery_engine/best_bets_boost.rb
@@ -1,0 +1,14 @@
+module DiscoveryEngine
+  module BestBetsBoost
+    def best_bets_boost_specs(query_string)
+      best_bets_for_query = Array(Rails.configuration.best_bets[query_string])
+      return unless best_bets_for_query.any?
+
+      condition_links = best_bets_for_query.map { "\"#{_1}\"" }.join(",")
+      [{
+        boost: 1,
+        condition: "link: ANY(#{condition_links})",
+      }]
+    end
+  end
+end

--- a/app/services/discovery_engine/search.rb
+++ b/app/services/discovery_engine/search.rb
@@ -3,6 +3,7 @@ module DiscoveryEngine
     DEFAULT_COUNT = 10
     DEFAULT_START = 0
 
+    include BestBetsBoost
     include NewsRecencyBoost
 
     def initialize(client: ::Google::Cloud::DiscoveryEngine.search_service(version: :v1))
@@ -18,7 +19,7 @@ module DiscoveryEngine
         serving_config:,
         page_size: count,
         offset: start,
-        boost_spec:,
+        boost_spec: boost_spec(query_string),
       ).response
 
       ResultSet.new(
@@ -36,10 +37,11 @@ module DiscoveryEngine
       Rails.configuration.discovery_engine_serving_config
     end
 
-    def boost_spec
+    def boost_spec(query_string)
       {
         condition_boost_specs: [
           *news_recency_boost_specs,
+          *best_bets_boost_specs(query_string),
         ],
       }
     end

--- a/config/application.rb
+++ b/config/application.rb
@@ -25,5 +25,8 @@ module SearchApiV2
     config.document_type_ignorelist_path_overrides = config_for(
       :document_type_ignorelist_path_overrides,
     )
+
+    # Query configuration
+    config.best_bets = config_for(:best_bets)
   end
 end

--- a/config/best_bets.yml
+++ b/config/best_bets.yml
@@ -1,0 +1,13 @@
+shared:
+  # TODO: Test data that we can delete once demo'ed
+  "i want to test best bets":
+    - /government/people/test-person
+    - /government/publications/test--150
+    - /service-manual/technology/test-your-services-performance
+
+test:
+  "i want to test a single best bet": /here/you/go
+  "i want to test multiple best bets":
+    - /i-am-important
+    - /i-am-also-important
+    - /also-me

--- a/spec/services/discovery_engine/search_spec.rb
+++ b/spec/services/discovery_engine/search_spec.rb
@@ -74,6 +74,50 @@ RSpec.describe DiscoveryEngine::Search do
           expect(result_set.start).to eq(11)
         end
       end
+
+      context "when searching for a query that has a single best bets defined" do
+        # see test section in YAML config
+        subject!(:result_set) { search.call("i want to test a single best bet") }
+
+        let(:expected_boost_specs) do
+          super() + [{
+            boost: 1,
+            condition: 'link: ANY("/here/you/go")',
+          }]
+        end
+
+        it "calls the client with the expected parameters" do
+          expect(client).to have_received(:search).with(
+            serving_config: "serving-config-path",
+            query: "i want to test a single best bet",
+            offset: 0,
+            page_size: 10,
+            boost_spec: { condition_boost_specs: expected_boost_specs },
+          )
+        end
+      end
+
+      context "when searching for a query that has multiple best bets defined" do
+        # see test section in YAML config
+        subject!(:result_set) { search.call("i want to test multiple best bets") }
+
+        let(:expected_boost_specs) do
+          super() + [{
+            boost: 1,
+            condition: 'link: ANY("/i-am-important","/i-am-also-important","/also-me")',
+          }]
+        end
+
+        it "calls the client with the expected parameters" do
+          expect(client).to have_received(:search).with(
+            serving_config: "serving-config-path",
+            query: "i want to test multiple best bets",
+            offset: 0,
+            page_size: 10,
+            boost_spec: { condition_boost_specs: expected_boost_specs },
+          )
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
"Best bets" allow boosting a specific set of results as much as possible for a given query string. Unlike with the previous search product, it's not possible to guarantee that this result will always be on top of the results - but it will get us close.

- Add `best_bets.yml` configuration file to define best bets
- Add ability to `DiscoveryEngine::Search` service to boost when a query matches a best bet, with slightly descending boost to allow for the definition of several best bets