### PR TITLE
Remove body content size limit

### DIFF
--- a/app/models/concerns/publishing_api/content.rb
+++ b/app/models/concerns/publishing_api/content.rb
@@ -45,12 +45,6 @@ module PublishingApi
     ].map { JsonPath.new(_1, use_symbols: true) }.freeze
     INDEXABLE_CONTENT_SEPARATOR = "\n".freeze
 
-    # The limit of content length on Discovery Engine API is currently 500KB, so we need to truncate
-    # the content to a reasonable size.
-    #
-    # TODO: Try and get limit increased?
-    INDEXABLE_CONTENT_MAX_BYTE_SIZE = 480.kilobytes
-
     # Extracts a single string of indexable unstructured content from the document.
     def content
       values_from_json_paths = INDEXABLE_CONTENT_VALUES_JSON_PATHS.map do |item|
@@ -66,7 +60,6 @@ module PublishingApi
         .flatten
         .compact_blank
         .join(INDEXABLE_CONTENT_SEPARATOR)
-        .truncate_bytes(INDEXABLE_CONTENT_MAX_BYTE_SIZE)
     end
   end
 end

--- a/spec/models/concerns/publishing_api/content_spec.rb
+++ b/spec/models/concerns/publishing_api/content_spec.rb
@@ -72,20 +72,6 @@ RSpec.describe PublishingApi::Content do
       it { is_expected.to eq("<h1>Foo</h1>\nbar\n<h1>Bar</h1>\n<blink>baz</blink>") }
     end
 
-    describe "with excessively large content" do
-      let(:document_hash) do
-        {
-          details: {
-            body: "a" * 600.kilobytes,
-          },
-        }
-      end
-
-      it "truncates the content" do
-        expect(extracted_content.bytesize).to be <= 500.kilobytes
-      end
-    end
-
     describe "without any fields" do
       let(:document_hash) do
         {


### PR DESCRIPTION
Turns out this was a metadata size limit restriction, which explains why we still saw the error after truncating the content. Now that we have removed additional searchable text from the metadata, we should be able to safely remove any limits anyway.