### PR TITLE
Do not sync withdrawn documents

### DIFF
--- a/app/models/concerns/publishing_api/action.rb
+++ b/app/models/concerns/publishing_api/action.rb
@@ -18,7 +18,7 @@ module PublishingApi
     end
 
     def ignore?
-      on_ignorelist? || ignored_locale? || unaddressable?
+      on_ignorelist? || ignored_locale? || unaddressable? || withdrawn?
     end
 
     def ignore_reason
@@ -28,6 +28,8 @@ module PublishingApi
         "locale not permitted (#{locale})"
       elsif unaddressable?
         "unaddressable"
+      elsif withdrawn?
+        "withdrawn"
       end
     end
 
@@ -53,6 +55,10 @@ module PublishingApi
 
     def unaddressable?
       base_path.blank? && external_link.blank?
+    end
+
+    def withdrawn?
+      document_hash[:withdrawn_notice].present?
     end
 
     def document_type

--- a/spec/fixtures/files/message_queue/press_release_message.json
+++ b/spec/fixtures/files/message_queue/press_release_message.json
@@ -1,6 +1,6 @@
 {
-  "title": "Ebola medal for over 3000 heroes",
-  "public_updated_at": "2015-06-11T11:14:00Z",
+  "title": "UK and Japan strengthen cooperation in the area of digital government",
+  "public_updated_at": "2022-10-31T12:00:14Z",
   "publishing_app": "whitehall",
   "rendering_app": "government-frontend",
   "update_type": "republish",
@@ -8,43 +8,42 @@
   "analytics_identifier": null,
   "document_type": "press_release",
   "schema_name": "news_article",
-  "first_published_at": "2015-06-11T11:14:00Z",
-  "base_path": "/government/news/ebola-medal-for-over-3000-heroes",
-  "description": "A new medal has been created to recognise the bravery and hard work of people who have helped to stop the spread of Ebola.",
+  "first_published_at": "2022-10-31T12:00:14Z",
+  "base_path": "/government/news/uk-and-japan-strengthen-cooperation-in-the-area-of-digital-government",
+  "description": "On Monday 31 October 2022, the UK and Japan signed a Memorandum of Cooperation (MoC) to deepen ties on digital government transformation.",
   "details": {
-    "body": "<div class=\"govspeak\"><p>The government has today (11 June 2015) set out the details of a new medal that will recognise the bravery and hard work of thousands of people who helped to tackle Ebola in West Africa.</p>\n\n<p>The medal is expected to go to over 3,000 people who travelled from the UK to work in high risk areas to stop the spread of the disease.</p>\n\n<p>This is the first time a medal has been created specifically to recognise those who have tackled a humanitarian crisis and is in recognition of the highly dangerous environment that workers were required to enter.</p>\n\n<p>The medal has been designed by John Bergdahl, who has been an engraver for over 40 years and recently designed a new coin set to celebrate the birth of Prince George. Mr Bergdahl’s design was chosen following a competition run by the Royal Mint Advisory Committee. It shows a flame on a background depicting the Ebola virus – above this are the words “For Service” and below  “Ebola Epidemic West Africa”.</p>\n\n<p>The obverse bears a portrait of Her Majesty The Queen designed by Ian Rank-Broadley.</p>\n\n<p>The medal will be awarded to military and civilian personnel who have been tackling Ebola on behalf of the UK in West Africa such as people from our armed forces, doctors and nurses from the <abbr title=\"National Health Service\">NHS</abbr>, laboratory specialists and members of the civil service and non-governmental organisations. Eligibility is set out in detail in a <a href=\"https://www.gov.uk/government/publications/ebola-medal-for-service-in-west-africa\" class=\"govuk-link\">command paper</a> published today.</p>\n\n<p>The first awards of the medal will be made as early as this summer and will be ongoing thereafter. The Prime Minister will also host a summer reception to congratulate in person some of the recipients.</p>\n\n<p>The Prime Minister, David Cameron, said:</p>\n\n<blockquote>\n  <p>The Ebola outbreak was one of the most devastating epidemics of our generation but we managed to stop its spread thanks to the hard work of British people who travelled to West Africa.</p>\n\n  <p class=\"last-child\">As a result of their efforts, many lives were saved and the outbreak contained.</p>\n</blockquote>\n\n<blockquote>\n  <p class=\"last-child\">This medal is about paying tribute to those people. They put themselves at considerable personal risk and we owe them a debt of gratitude.</p>\n</blockquote>\n\n<h2 id=\"notes-to-editors\">Notes to editors</h2>\n\n<p>All those eligible should receive their medal during the course of this year, other than those who need to self-nominate. Read <a href=\"https://www.gov.uk/government/publications/ebola-medal\" class=\"govuk-link\">more information on self-nomination</a>.</p>\n\n<h3 id=\"about-the-medal\">About the medal</h3>\n\n<p>The Committee on the Grant of Honours, Decorations and Medals recommended specific eligibility criteria to Her Majesty The Queen, who graciously approved them.</p>\n\n<p>Eligible personnel, including civil servants, the military, UK Med, Public Health England, Stabilisation Unit, Conflict Humanitarian and Security Department (CHASE) Operations Team, UK nationals who worked for DFID-funded NGOs supporting government efforts who served at least 21 days of continuous service (or 30 days of accumulated service) within the geographical territories of Sierra Leone, Liberia, Guinea and their territorial waters, would automatically receive the medal.</p>\n\n<p>The medal will be sent to most people automatically, but a few people who have not gone as part of the UK government effort will need to <a href=\"https://www.gov.uk/government/publications/ebola-medal\" class=\"govuk-link\">nominate themselves</a>.</p>\n\n<p>This new medal has been introduced following approval by Her Majesty The Queen and the Honours and Decorations Committee. The medal will be manufactured in the UK by Worcestershire Medal Service and will be awarded to those eligible continuously from the summer.</p>\n\n<p>Read the PM’s <a rel=\"external\" href=\"http://www.parliament.uk/business/publications/written-questions-answers-statements/written-statement/Commons/2015-06-11/HCWS28\" class=\"govuk-link\">written ministerial statement on the Ebola Medal</a>.</p>\n\n<h3 id=\"about-uk-government-response-to-ebola\">About UK government response to Ebola</h3>\n\n<p>£427 million has been committed to the effort by UK government. Our contribution has included supporting more than half of all the beds available for Ebola patients in Sierra Leone, funded over 100 burial teams, trained 4,000 frontline staff, provided three labs to test one third of all samples collected nationally and delivered over one million <abbr title=\"personal protective equipment\">PPE</abbr> suits and 150 vehicles.</p>\n\n<div class=\"call-to-action\">\n<p>Find our more about the <a href=\"https://www.gov.uk/government/topical-events/ebola-virus-government-response\" class=\"govuk-link\">UK government’s response to Ebola</a>.</p>\n</div>\n\n</div>",
+    "body": "\u003cdiv class=\"govspeak\"\u003e\u003cp\u003eThe UK was represented remotely by Minister Jeremy Quin and in-person by Government Digital Service CEO Tom Read. Japan was represented by Digital Transformation Minister KONO Taro and the ceremony took place in Tokyo.\u003c/p\u003e\n\n\u003cp\u003eThe MoC establishes links between the UK’s Government Digital Service (GDS) and Japan’s Digital Agency. The two agencies will work together to exchange knowledge and strategies to promote the adoption, design and diffusion of digital tools and services across public sectors in the UK and Japan.\u003c/p\u003e\n\n\u003cp\u003eCooperation will also focus on sharing best practices in training and building technical capabilities across government departments and agencies, and delivering greater efficiencies in government procurement and spending.\u003c/p\u003e\n\n\u003cp\u003eTo coincide with the MoC signing, the UK has sent a delegation of digital experts to take part in workshops, teach-ins and policy exchanges with Japan’s Digital Agency.\u003c/p\u003e\n\n\u003cp\u003eUK’s Minister for the Cabinet Office and Paymaster General, Minister Jeremy Quin said:\u003c/p\u003e\n\n\u003cblockquote\u003e\n  \u003cp class=\"last-child\"\u003eThe UK and Japan are two of the largest, most advanced economies in the world, with thriving tech sectors and clear ambitions to become world leaders in digital. By sharing expertise in areas like digital government transformation, we look to support each other in delivering better services and unlocking greater opportunities for our citizens and businesses.\u003c/p\u003e\n\u003c/blockquote\u003e\n\n\u003cp\u003eJapan’s Digital Transformation Minister KONO Taro said:\u003c/p\u003e\n\n\u003cblockquote\u003e\n  \u003cp class=\"last-child\"\u003eThe UK is an important partner for Japan and we are working together to maximise the benefits of digital. We are happy to welcome the GDS delegation as we have learned from the UK’s experience in delivering our own digital government initiatives, like the establishment of the Digital Agency. By sharing expertise and lessons learned, we are assisting each other in promoting digital transformation in the government and across society to ensure no one is left behind.\u003c/p\u003e\n\u003c/blockquote\u003e\n\n\u003cp\u003eThe MoC comes after the UK and Japan \u003ca href=\"https://www.gov.uk/government/news/uk-japan-joint-announcement-on-deepening-digital-collaboration\" class=\"govuk-link\"\u003eannounced deepening digital collaboration\u003c/a\u003e in May 2022, which covers all facets of joint digital priorities including digital infrastructure, data, digital regulation and standards as well as digital transformation.\u003c/p\u003e\n\u003c/div\u003e",
     "tags": {
       "topics": [],
       "browse_pages": []
     },
     "image": {
-      "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/default_news_organisation_image_data/file/2/s300_number10.jpg",
+      "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/image_data/file/165936/s300_JapanGDS2.png",
       "caption": null,
-      "alt_text": "",
-      "high_resolution_url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/default_news_organisation_image_data/file/2/s960_number10.jpg"
+      "alt_text": "Photo of Government Digital Service CEO Tom Read and Japan's Digital Transformation Minister KONO Taro holding iPads..",
+      "high_resolution_url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/image_data/file/165936/s960_JapanGDS2.png"
     },
-    "political": true,
+    "political": false,
     "attachments": [],
     "change_history": [
       {
         "note": "First published.",
-        "public_timestamp": "2015-06-11T12:14:00.000+01:00"
+        "public_timestamp": "2022-10-31T12:00:14.000+00:00"
       }
     ],
-    "first_public_at": "2015-06-11T12:14:00.000+01:00",
+    "first_public_at": "2022-10-31T12:00:14.000+00:00",
     "emphasised_organisations": [
-      "705dbea4-8bd7-422e-ba9c-254557f77f81",
-      "96ae61d6-c2a1-48cb-8e67-da9d105ae381"
+      "af07d5a5-df63-4ddc-9383-6a666845ebe9"
     ]
   },
   "routes": [
     {
-      "path": "/government/news/ebola-medal-for-over-3000-heroes",
+      "path": "/government/news/uk-and-japan-strengthen-cooperation-in-the-area-of-digital-government",
       "type": "exact"
     }
   ],
   "redirects": [],
-  "content_id": "f75d26a3-25a4-4c31-beea-a77cada4ce12",
+  "content_id": "5941cb22-5d52-4212-83b6-255d75d2c680",
   "locale": "en",
   "expanded_links": {
     "government": [
@@ -65,113 +64,23 @@
     ],
     "organisations": [
       {
-        "content_id": "96ae61d6-c2a1-48cb-8e67-da9d105ae381",
-        "title": "Cabinet Office",
+        "content_id": "af07d5a5-df63-4ddc-9383-6a666845ebe9",
+        "title": "Government Digital Service",
         "locale": "en",
-        "analytics_identifier": "D2",
-        "api_path": "/api/content/government/organisations/cabinet-office",
-        "base_path": "/government/organisations/cabinet-office",
+        "analytics_identifier": "OT1056",
+        "api_path": "/api/content/government/organisations/government-digital-service",
+        "base_path": "/government/organisations/government-digital-service",
         "document_type": "organisation",
         "schema_name": "organisation",
         "withdrawn": false,
         "details": {
-          "acronym": "",
+          "acronym": "GDS",
           "logo": {
             "crest": "single-identity",
-            "formatted_title": "Cabinet Office"
+            "formatted_title": "Government Digital Service"
           },
           "brand": "cabinet-office",
-          "default_news_image": {
-            "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/default_news_organisation_image_data/file/148/s300_cabinet-office.jpg",
-            "high_resolution_url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/default_news_organisation_image_data/file/148/s960_cabinet-office.jpg"
-          },
-          "organisation_govuk_status": {
-            "url": null,
-            "status": "live",
-            "updated_at": null
-          }
-        },
-        "links": {}
-      },
-      {
-        "content_id": "db994552-7644-404d-a770-a2fe659c661f",
-        "title": "Department for International Development",
-        "locale": "en",
-        "analytics_identifier": "D8",
-        "api_path": "/api/content/government/organisations/department-for-international-development",
-        "base_path": "/government/organisations/department-for-international-development",
-        "document_type": "organisation",
-        "schema_name": "organisation",
-        "withdrawn": false,
-        "details": {
-          "acronym": "DFID",
-          "logo": {
-            "crest": "single-identity",
-            "formatted_title": "Department<br/>for International <br/>Development"
-          },
-          "brand": "department-for-international-development",
-          "default_news_image": {
-            "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/default_news_organisation_image_data/file/27/s300_DFID-default-image-v2.jpg",
-            "high_resolution_url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/default_news_organisation_image_data/file/27/s960_DFID-default-image-v2.jpg"
-          },
-          "organisation_govuk_status": {
-            "url": "http://www.dfid.gov.uk/",
-            "status": "replaced",
-            "updated_at": "2020-09-02T00:00:00.000+01:00"
-          }
-        },
-        "links": {}
-      },
-      {
-        "content_id": "1343f283-19e9-4fbb-86b1-58c7549d874b",
-        "title": "Public Health England",
-        "locale": "en",
-        "analytics_identifier": "EA480",
-        "api_path": "/api/content/government/organisations/public-health-england",
-        "base_path": "/government/organisations/public-health-england",
-        "document_type": "organisation",
-        "schema_name": "organisation",
-        "withdrawn": false,
-        "details": {
-          "acronym": "PHE",
-          "logo": {
-            "crest": "single-identity",
-            "formatted_title": "Public Health <br/>England"
-          },
-          "brand": "department-of-health",
-          "default_news_image": {
-            "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/default_news_organisation_image_data/file/36/s300_sign5.jpg",
-            "high_resolution_url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/default_news_organisation_image_data/file/36/s960_sign5.jpg"
-          },
-          "organisation_govuk_status": {
-            "url": "https://www.gov.uk/phe",
-            "status": "split",
-            "updated_at": "2021-10-01T00:00:00.000+01:00"
-          }
-        },
-        "links": {}
-      },
-      {
-        "content_id": "705dbea4-8bd7-422e-ba9c-254557f77f81",
-        "title": "Prime Minister's Office, 10 Downing Street",
-        "locale": "en",
-        "analytics_identifier": "OT532",
-        "api_path": "/api/content/government/organisations/prime-ministers-office-10-downing-street",
-        "base_path": "/government/organisations/prime-ministers-office-10-downing-street",
-        "document_type": "organisation",
-        "schema_name": "organisation",
-        "withdrawn": false,
-        "details": {
-          "acronym": "Number 10",
-          "logo": {
-            "crest": "eo",
-            "formatted_title": "Prime Minister&#39;s Office, 10 Downing Street"
-          },
-          "brand": "cabinet-office",
-          "default_news_image": {
-            "url": "https://assets.integration.publishing.service.gov.uk/government/uploads/system/uploads/default_news_organisation_image_data/file/2/s300_number10.jpg",
-            "high_resolution_url": "https://assets.integration.publishing.service.gov.uk/government/uploads/system/uploads/default_news_organisation_image_data/file/2/s960_number10.jpg"
-          },
+          "default_news_image": null,
           "organisation_govuk_status": {
             "url": null,
             "status": "live",
@@ -183,72 +92,51 @@
     ],
     "original_primary_publishing_organisation": [
       {
-        "content_id": "705dbea4-8bd7-422e-ba9c-254557f77f81",
-        "title": "Prime Minister's Office, 10 Downing Street",
+        "content_id": "af07d5a5-df63-4ddc-9383-6a666845ebe9",
+        "title": "Government Digital Service",
         "locale": "en",
-        "analytics_identifier": "OT532",
-        "api_path": "/api/content/government/organisations/prime-ministers-office-10-downing-street",
-        "base_path": "/government/organisations/prime-ministers-office-10-downing-street",
+        "analytics_identifier": "OT1056",
+        "api_path": "/api/content/government/organisations/government-digital-service",
+        "base_path": "/government/organisations/government-digital-service",
         "document_type": "organisation",
         "schema_name": "organisation",
         "withdrawn": false,
         "details": {
-          "acronym": "Number 10",
+          "acronym": "GDS",
           "logo": {
-            "crest": "eo",
-            "formatted_title": "Prime Minister&#39;s Office, 10 Downing Street"
+            "crest": "single-identity",
+            "formatted_title": "Government Digital Service"
           },
           "brand": "cabinet-office",
-          "default_news_image": {
-            "url": "https://assets.integration.publishing.service.gov.uk/government/uploads/system/uploads/default_news_organisation_image_data/file/2/s300_number10.jpg",
-            "high_resolution_url": "https://assets.integration.publishing.service.gov.uk/government/uploads/system/uploads/default_news_organisation_image_data/file/2/s960_number10.jpg"
-          },
+          "default_news_image": null,
           "organisation_govuk_status": {
             "url": null,
             "status": "live",
             "updated_at": null
           }
         },
-        "links": {}
-      }
-    ],
-    "people": [
-      {
-        "content_id": "8529186b-c0f1-11e4-8223-005056011aef",
-        "title": "The Rt Hon David Cameron",
-        "locale": "en",
-        "analytics_identifier": null,
-        "api_path": "/api/content/government/people/david-cameron",
-        "base_path": "/government/people/david-cameron",
-        "document_type": "person",
-        "public_updated_at": "2019-11-07T15:02:24Z",
-        "schema_name": "person",
-        "withdrawn": false,
         "links": {}
       }
     ],
     "primary_publishing_organisation": [
       {
-        "content_id": "705dbea4-8bd7-422e-ba9c-254557f77f81",
-        "title": "Prime Minister's Office, 10 Downing Street",
+        "content_id": "af07d5a5-df63-4ddc-9383-6a666845ebe9",
+        "title": "Government Digital Service",
         "locale": "en",
-        "analytics_identifier": "OT532",
-        "api_path": "/api/content/government/organisations/prime-ministers-office-10-downing-street",
-        "base_path": "/government/organisations/prime-ministers-office-10-downing-street",
+        "analytics_identifier": "OT1056",
+        "api_path": "/api/content/government/organisations/government-digital-service",
+        "base_path": "/government/organisations/government-digital-service",
         "document_type": "organisation",
         "schema_name": "organisation",
         "withdrawn": false,
         "details": {
-          "acronym": "Number 10",
+          "acronym": "GDS",
           "logo": {
-            "crest": "eo",
-            "formatted_title": "Prime Minister&#39;s Office, 10 Downing Street"
+            "crest": "single-identity",
+            "formatted_title": "Government Digital Service"
           },
           "brand": "cabinet-office",
-          "default_news_image": {
-            "url": "https://assets.integration.publishing.service.gov.uk/government/uploads/system/uploads/default_news_organisation_image_data/file/2/s300_number10.jpg",
-            "high_resolution_url": "https://assets.integration.publishing.service.gov.uk/government/uploads/system/uploads/default_news_organisation_image_data/file/2/s960_number10.jpg"
-          },
+          "default_news_image": null,
           "organisation_govuk_status": {
             "url": null,
             "status": "live",
@@ -258,251 +146,39 @@
         "links": {}
       }
     ],
-    "roles": [
-      {
-        "content_id": "845e5811-c0f1-11e4-8223-005056011aef",
-        "title": "Prime Minister",
-        "locale": "en",
-        "analytics_identifier": null,
-        "api_path": "/api/content/government/ministers/prime-minister",
-        "base_path": "/government/ministers/prime-minister",
-        "document_type": "ministerial_role",
-        "public_updated_at": "2022-10-05T07:44:54Z",
-        "schema_name": "role",
-        "withdrawn": false,
-        "details": {
-          "body": [
-            {
-              "content": "The Prime Minister is the leader of His Majesty's Government and is ultimately responsible for the policy and decisions of the government.\r\n\r\nAs leader of the UK government the Prime Minister also:\r\n\r\n* oversees the [operation of the Civil Service](https://www.gov.uk/government/ministers/minister-for-the-civil-service) and government agencies\r\n* chooses members of the government\r\n* is the principal government figure in the House of Commons\r\n\r\nAs [Minister for the Union](https://www.gov.uk/government/ministers/minister-for-the-union), the Prime Minister works to ensure that all of government is acting on behalf of the entire United Kingdom: England, Northern Ireland, Scotland, and Wales.\r\n",
-              "content_type": "text/govspeak"
-            },
-            {
-              "content_type": "text/html",
-              "content": "<p>The Prime Minister is the leader of His Majesty’s Government and is ultimately responsible for the policy and decisions of the government.</p>\n\n<p>As leader of the UK government the Prime Minister also:</p>\n\n<ul>\n  <li>oversees the <a href=\"https://www.gov.uk/government/ministers/minister-for-the-civil-service\">operation of the Civil Service</a> and government agencies</li>\n  <li>chooses members of the government</li>\n  <li>is the principal government figure in the House of Commons</li>\n</ul>\n\n<p>As <a href=\"https://www.gov.uk/government/ministers/minister-for-the-union\">Minister for the Union</a>, the Prime Minister works to ensure that all of government is acting on behalf of the entire United Kingdom: England, Northern Ireland, Scotland, and Wales.</p>\n"
-            }
-          ],
-          "role_payment_type": null,
-          "seniority": 0,
-          "whip_organisation": {}
-        },
-        "links": {}
-      }
-    ],
-    "suggested_ordered_related_items": [
-      {
-        "content_id": "eecb3c7e-58bd-453f-a858-3c60eafb3056",
-        "title": "Ebola medal for service in West Africa",
-        "locale": "en",
-        "analytics_identifier": null,
-        "api_path": "/api/content/government/publications/ebola-medal-for-service-in-west-africa",
-        "base_path": "/government/publications/ebola-medal-for-service-in-west-africa",
-        "document_type": "policy_paper",
-        "public_updated_at": "2015-06-11T11:14:56Z",
-        "schema_name": "publication",
-        "withdrawn": false,
-        "links": {}
-      },
-      {
-        "content_id": "5eb7e1ad-7631-11e4-a3cb-005056011aef",
-        "title": "HMT Public Expenditure Statistical Analyses (PESA)",
-        "locale": "en",
-        "analytics_identifier": null,
-        "api_path": "/api/content/government/collections/public-expenditure-statistical-analyses-pesa",
-        "base_path": "/government/collections/public-expenditure-statistical-analyses-pesa",
-        "document_type": "document_collection",
-        "public_updated_at": "2023-07-19T14:20:54Z",
-        "schema_name": "document_collection",
-        "withdrawn": false,
-        "links": {}
-      },
-      {
-        "content_id": "674e6678-08cb-4155-a0e7-0a7563d2404b",
-        "title": "UK-New Zealand Mutual Recognition Agreement",
-        "locale": "en",
-        "analytics_identifier": null,
-        "api_path": "/api/content/guidance/uk-new-zealand-mutual-recognition-agreement",
-        "base_path": "/guidance/uk-new-zealand-mutual-recognition-agreement",
-        "document_type": "detailed_guide",
-        "public_updated_at": "2019-03-12T00:00:00Z",
-        "schema_name": "detailed_guide",
-        "withdrawn": false,
-        "links": {}
-      },
-      {
-        "content_id": "5eb7e008-7631-11e4-a3cb-005056011aef",
-        "title": "Bilateral treaties published in the Country Series",
-        "locale": "en",
-        "analytics_identifier": null,
-        "api_path": "/api/content/government/collections/command-papers-by-country-2013",
-        "base_path": "/government/collections/command-papers-by-country-2013",
-        "document_type": "document_collection",
-        "public_updated_at": "2019-08-28T22:05:52Z",
-        "schema_name": "document_collection",
-        "withdrawn": false,
-        "links": {}
-      }
-    ],
     "taxons": [
       {
-        "content_id": "668cd623-c7a8-4159-9575-90caac36d4b4",
-        "title": "Community and society",
+        "content_id": "37d0fa26-abed-4c74-8835-b3b51ae1c8b2",
+        "title": "International",
         "locale": "en",
         "analytics_identifier": null,
-        "api_path": "/api/content/society-and-culture/community-and-society",
-        "base_path": "/society-and-culture/community-and-society",
+        "api_path": "/api/content/international",
+        "base_path": "/international",
         "document_type": "taxon",
-        "public_updated_at": "2018-08-22T13:12:16Z",
+        "public_updated_at": "2018-09-16T20:30:28Z",
         "schema_name": "taxon",
         "withdrawn": false,
-        "description": null,
+        "description": "",
         "details": {
-          "internal_name": "Community and society [PA]",
+          "internal_name": "International",
           "notes_for_editors": "",
-          "visible_to_departmental_editors": false
+          "visible_to_departmental_editors": true
         },
         "phase": "live",
         "links": {
-          "parent_taxons": [
+          "root_taxon": [
             {
-              "content_id": "e2ca2f1a-0ff3-43ce-b813-16645ff27904",
-              "title": "Society and culture",
+              "content_id": "f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a",
+              "title": "GOV.UK homepage",
               "locale": "en",
               "analytics_identifier": null,
-              "api_path": "/api/content/society-and-culture",
-              "base_path": "/society-and-culture",
-              "document_type": "taxon",
-              "public_updated_at": "2018-09-16T20:31:27Z",
-              "schema_name": "taxon",
+              "api_path": "/api/content/",
+              "base_path": "/",
+              "document_type": "homepage",
+              "public_updated_at": "2023-06-28T09:32:34Z",
+              "schema_name": "homepage",
               "withdrawn": false,
-              "description": "",
-              "details": {
-                "internal_name": "Society and culture",
-                "notes_for_editors": "",
-                "visible_to_departmental_editors": true
-              },
-              "phase": "live",
-              "links": {
-                "root_taxon": [
-                  {
-                    "content_id": "f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a",
-                    "title": "GOV.UK homepage",
-                    "locale": "en",
-                    "analytics_identifier": null,
-                    "api_path": "/api/content/",
-                    "base_path": "/",
-                    "document_type": "homepage",
-                    "public_updated_at": "2023-06-28T09:32:34Z",
-                    "schema_name": "homepage",
-                    "withdrawn": false,
-                    "links": {}
-                  }
-                ]
-              }
-            }
-          ]
-        }
-      },
-      {
-        "content_id": "c31256e8-f328-462b-993f-dce50b7892e9",
-        "title": "Infectious diseases",
-        "locale": "en",
-        "analytics_identifier": null,
-        "api_path": "/api/content/health-and-social-care/health-protection-infectious-diseases",
-        "base_path": "/health-and-social-care/health-protection-infectious-diseases",
-        "document_type": "taxon",
-        "public_updated_at": "2018-08-22T12:56:17Z",
-        "schema_name": "taxon",
-        "withdrawn": false,
-        "description": null,
-        "details": {
-          "internal_name": "Infectious diseases [T]",
-          "notes_for_editors": "",
-          "visible_to_departmental_editors": false
-        },
-        "phase": "live",
-        "links": {
-          "parent_taxons": [
-            {
-              "content_id": "30ba2d05-d0d6-4978-a5d6-707511894111",
-              "title": "Health protection",
-              "locale": "en",
-              "analytics_identifier": null,
-              "api_path": "/api/content/health-and-social-care/health-protection",
-              "base_path": "/health-and-social-care/health-protection",
-              "document_type": "taxon",
-              "public_updated_at": "2019-03-11T14:19:39Z",
-              "schema_name": "taxon",
-              "withdrawn": false,
-              "description": "",
-              "details": {
-                "internal_name": "Health protection",
-                "notes_for_editors": "",
-                "visible_to_departmental_editors": false
-              },
-              "phase": "live",
-              "links": {
-                "parent_taxons": [
-                  {
-                    "content_id": "d6a4884e-769d-4b81-8ba5-b64394362d92",
-                    "title": "Public health",
-                    "locale": "en",
-                    "analytics_identifier": null,
-                    "api_path": "/api/content/health-and-social-care/public-health",
-                    "base_path": "/health-and-social-care/public-health",
-                    "document_type": "taxon",
-                    "public_updated_at": "2018-09-17T15:15:14Z",
-                    "schema_name": "taxon",
-                    "withdrawn": false,
-                    "description": "",
-                    "details": {
-                      "internal_name": "Public health",
-                      "notes_for_editors": "",
-                      "visible_to_departmental_editors": false
-                    },
-                    "phase": "live",
-                    "links": {
-                      "parent_taxons": [
-                        {
-                          "content_id": "8124ead8-8ebc-4faf-88ad-dd5cbcc92ba8",
-                          "title": "Health and social care",
-                          "locale": "en",
-                          "analytics_identifier": null,
-                          "api_path": "/api/content/health-and-social-care",
-                          "base_path": "/health-and-social-care",
-                          "document_type": "taxon",
-                          "public_updated_at": "2018-09-16T20:30:51Z",
-                          "schema_name": "taxon",
-                          "withdrawn": false,
-                          "description": "",
-                          "details": {
-                            "internal_name": "Health and social care",
-                            "notes_for_editors": "",
-                            "visible_to_departmental_editors": true
-                          },
-                          "phase": "live",
-                          "links": {
-                            "root_taxon": [
-                              {
-                                "content_id": "f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a",
-                                "title": "GOV.UK homepage",
-                                "locale": "en",
-                                "analytics_identifier": null,
-                                "api_path": "/api/content/",
-                                "base_path": "/",
-                                "document_type": "homepage",
-                                "public_updated_at": "2023-06-28T09:32:34Z",
-                                "schema_name": "homepage",
-                                "withdrawn": false,
-                                "links": {}
-                              }
-                            ]
-                          }
-                        }
-                      ]
-                    }
-                  }
-                ]
-              }
+              "links": {}
             }
           ]
         }
@@ -510,15 +186,15 @@
     ],
     "available_translations": [
       {
-        "title": "Ebola medal for over 3000 heroes",
-        "public_updated_at": "2015-06-11T11:14:00Z",
+        "title": "UK and Japan strengthen cooperation in the area of digital government",
+        "public_updated_at": "2022-10-31T12:00:14Z",
         "analytics_identifier": null,
         "document_type": "press_release",
         "schema_name": "news_article",
-        "base_path": "/government/news/ebola-medal-for-over-3000-heroes",
-        "api_path": "/api/content/government/news/ebola-medal-for-over-3000-heroes",
-        "withdrawn": true,
-        "content_id": "f75d26a3-25a4-4c31-beea-a77cada4ce12",
+        "base_path": "/government/news/uk-and-japan-strengthen-cooperation-in-the-area-of-digital-government",
+        "api_path": "/api/content/government/news/uk-and-japan-strengthen-cooperation-in-the-area-of-digital-government",
+        "withdrawn": false,
+        "content_id": "5941cb22-5d52-4212-83b6-255d75d2c680",
         "locale": "en"
       }
     ]
@@ -528,45 +204,24 @@
   "government_document_supertype": "press-releases",
   "content_purpose_subgroup": "news",
   "content_purpose_supergroup": "news_and_communications",
-  "withdrawn_notice": {
-    "explanation": "<div class=\"govspeak\"><p>This news story has been withdrawn because it’s over 4 years old. See <a href=\"https://www.gov.uk/search/news-and-communications?organisations%5B%5D=public-health-england&amp;parent=public-health-england\" class=\"govuk-link\">PHE’s latest news</a>.</p>\n</div>",
-    "withdrawn_at": "2019-06-19T15:16:59Z"
-  },
-  "publishing_request_id": "2776-1656074746.518-10.13.2.120-11082",
-  "govuk_request_id": "21-1695042279.005-10.1.22.189-3806",
+  "publishing_request_id": "10388-1667221716.342-10.13.2.247-544882",
+  "govuk_request_id": null,
   "links": {
     "government": [
       "d4fbc1b9-d47d-4386-af04-ac909f868f92"
     ],
     "organisations": [
-      "96ae61d6-c2a1-48cb-8e67-da9d105ae381",
-      "db994552-7644-404d-a770-a2fe659c661f",
-      "1343f283-19e9-4fbb-86b1-58c7549d874b",
-      "705dbea4-8bd7-422e-ba9c-254557f77f81"
+      "af07d5a5-df63-4ddc-9383-6a666845ebe9"
     ],
     "original_primary_publishing_organisation": [
-      "705dbea4-8bd7-422e-ba9c-254557f77f81"
-    ],
-    "people": [
-      "8529186b-c0f1-11e4-8223-005056011aef"
+      "af07d5a5-df63-4ddc-9383-6a666845ebe9"
     ],
     "primary_publishing_organisation": [
-      "705dbea4-8bd7-422e-ba9c-254557f77f81"
-    ],
-    "roles": [
-      "845e5811-c0f1-11e4-8223-005056011aef"
-    ],
-    "suggested_ordered_related_items": [
-      "eecb3c7e-58bd-453f-a858-3c60eafb3056",
-      "3574443a-b039-408f-b45c-be353fc7ede5",
-      "5eb7e1ad-7631-11e4-a3cb-005056011aef",
-      "674e6678-08cb-4155-a0e7-0a7563d2404b",
-      "5eb7e008-7631-11e4-a3cb-005056011aef"
+      "af07d5a5-df63-4ddc-9383-6a666845ebe9"
     ],
     "taxons": [
-      "668cd623-c7a8-4159-9575-90caac36d4b4",
-      "c31256e8-f328-462b-993f-dce50b7892e9"
+      "37d0fa26-abed-4c74-8835-b3b51ae1c8b2"
     ]
   },
-  "payload_version": 65861808
+  "payload_version": "12345"
 }

--- a/spec/fixtures/files/message_queue/withdrawn_notice_message.json
+++ b/spec/fixtures/files/message_queue/withdrawn_notice_message.json
@@ -1,0 +1,358 @@
+{
+  "title": "Walton Reach Regatta 2019: river restriction notice",
+  "public_updated_at": "2019-06-07T10:39:22Z",
+  "publishing_app": "whitehall",
+  "rendering_app": "government-frontend",
+  "update_type": "republish",
+  "phase": "live",
+  "analytics_identifier": null,
+  "document_type": "notice",
+  "schema_name": "publication",
+  "first_published_at": "2019-06-07T10:39:22Z",
+  "base_path": "/government/publications/walton-reach-regatta-2019-river-restriction-notice",
+  "description": "Information on the restrictions affecting the navigation on the River Thames.",
+  "details": {
+    "body": "\u003cdiv class=\"govspeak\"\u003e\u003cp\u003eRiver Thames restriction information for Saturday 17 August 2019.\u003c/p\u003e\n\u003c/div\u003e",
+    "tags": {
+      "topics": [],
+      "browse_pages": []
+    },
+    "documents": [
+      "\u003csection class=\"gem-c-attachment govuk-!-display-none-print govuk-!-margin-bottom-6\" data-module=\"ga4-link-tracker\"\u003e\n  \u003cdiv class=\"gem-c-attachment__thumbnail\"\u003e\n    \u003ca class=\"govuk-link\" target=\"_self\" tabindex=\"-1\" aria-hidden=\"true\" data-ga4-link=\"{\u0026quot;event_name\u0026quot;:\u0026quot;navigation\u0026quot;,\u0026quot;type\u0026quot;:\u0026quot;attachment\u0026quot;}\" href=\"/government/publications/walton-reach-regatta-2019-river-restriction-notice/walton-reach-regatta-2019-river-restriction-notice\"\u003e\n        \u003csvg class=\"gem-c-attachment__thumbnail-image gem-c-attachment__thumbnail-image--html\" version=\"1.1\" viewBox=\"0 0 99 140\" width=\"99\" height=\"140\" aria-hidden=\"true\"\u003e\n  \u003cpath d=\"M30,95h57v9H30V95z M30,77v9h39v-9H30z M30,122h48v-9H30V122z M12,68h9v-9h-9V68z M12,104h9v-9h-9V104z M12,86h9v-9h-9V86z M12,122h9v-9h-9V122z M87,12v27H12V12H87z M33,17h-4v8h-6v-8h-4v18h4v-7l6,0v7l4,0V17z M49,17H35l0,3h5v15h4V20l5,0V17z M68,17h-4 l-5,6l-5-6h-4v18h4l0-12l5,6l5-6l0,12h4V17z M81,32h-6V17h-4v18h10V32z M30,68h57v-9H30V68z\" stroke-width=\"0\"/\u003e\n\u003c/svg\u003e\n\n\u003c/a\u003e\u003c/div\u003e\n  \u003cdiv class=\"gem-c-attachment__details\"\u003e\n    \u003ch2 class=\"gem-c-attachment__title\"\u003e\n      \u003ca class=\"govuk-link gem-c-attachment__link\" target=\"_self\" data-ga4-link=\"{\u0026quot;event_name\u0026quot;:\u0026quot;navigation\u0026quot;,\u0026quot;type\u0026quot;:\u0026quot;attachment\u0026quot;}\" href=\"/government/publications/walton-reach-regatta-2019-river-restriction-notice/walton-reach-regatta-2019-river-restriction-notice\"\u003eWalton Reach Regatta 2019: river restriction notice\u003c/a\u003e\n\u003c/h2\u003e\n\n\n      \u003cp class=\"gem-c-attachment__metadata\"\u003e\u003cspan class=\"gem-c-attachment__attribute\"\u003eHTML\u003c/span\u003e\u003c/p\u003e\n\n\n\n\n\u003c/div\u003e\u003c/section\u003e"
+    ],
+    "political": false,
+    "attachments": [
+      {
+        "id": "3435894",
+        "url": "/government/publications/walton-reach-regatta-2019-river-restriction-notice/walton-reach-regatta-2019-river-restriction-notice",
+        "isbn": "",
+        "title": "Walton Reach Regatta 2019: river restriction notice",
+        "attachment_type": "html",
+        "hoc_paper_number": "",
+        "unique_reference": "",
+        "command_paper_number": "",
+        "unnumbered_hoc_paper": false,
+        "unnumbered_command_paper": false
+      }
+    ],
+    "change_history": [
+      {
+        "note": "First published.",
+        "public_timestamp": "2019-06-07T11:39:22.000+01:00"
+      }
+    ],
+    "first_public_at": "2019-06-07T11:39:22.000+01:00",
+    "featured_attachments": [
+      "3435894"
+    ],
+    "emphasised_organisations": [
+      "16628142-57b2-4611-bc03-5912785acee3"
+    ]
+  },
+  "routes": [
+    {
+      "path": "/government/publications/walton-reach-regatta-2019-river-restriction-notice",
+      "type": "exact"
+    }
+  ],
+  "redirects": [],
+  "content_id": "e3b7c15d-1928-4101-9912-c9b40a6d6e78",
+  "locale": "en",
+  "expanded_links": {
+    "children": [
+      {
+        "content_id": "281db48f-e08a-400b-b5fc-23bf8db06650",
+        "title": "Walton Reach Regatta 2019: river restriction notice",
+        "locale": "en",
+        "analytics_identifier": null,
+        "api_path": "/api/content/government/publications/walton-reach-regatta-2019-river-restriction-notice/walton-reach-regatta-2019-river-restriction-notice",
+        "base_path": "/government/publications/walton-reach-regatta-2019-river-restriction-notice/walton-reach-regatta-2019-river-restriction-notice",
+        "document_type": "html_publication",
+        "public_updated_at": "2019-06-06T10:04:28Z",
+        "schema_name": "html_publication",
+        "withdrawn": true,
+        "links": {
+          "parent": [
+            {
+              "content_id": "e3b7c15d-1928-4101-9912-c9b40a6d6e78",
+              "title": "Walton Reach Regatta 2019: river restriction notice",
+              "locale": "en",
+              "analytics_identifier": null,
+              "api_path": "/api/content/government/publications/walton-reach-regatta-2019-river-restriction-notice",
+              "base_path": "/government/publications/walton-reach-regatta-2019-river-restriction-notice",
+              "document_type": "notice",
+              "public_updated_at": "2019-06-07T10:39:22Z",
+              "schema_name": "publication",
+              "withdrawn": false,
+              "links": {}
+            }
+          ]
+        }
+      }
+    ],
+    "government": [
+      {
+        "content_id": "d4fbc1b9-d47d-4386-af04-ac909f868f92",
+        "title": "2015 Conservative government",
+        "locale": "en",
+        "api_path": "/api/content/government/2015-conservative-government",
+        "base_path": "/government/2015-conservative-government",
+        "document_type": "government",
+        "details": {
+          "started_on": "2015-05-08T00:00:00+00:00",
+          "ended_on": null,
+          "current": true
+        },
+        "links": {}
+      }
+    ],
+    "organisations": [
+      {
+        "content_id": "16628142-57b2-4611-bc03-5912785acee3",
+        "title": "Environment Agency",
+        "locale": "en",
+        "analytics_identifier": "EA199",
+        "api_path": "/api/content/government/organisations/environment-agency",
+        "base_path": "/government/organisations/environment-agency",
+        "document_type": "organisation",
+        "schema_name": "organisation",
+        "withdrawn": false,
+        "details": {
+          "acronym": "EA",
+          "logo": {
+            "image": {
+              "url": "https://assets.publishing.service.gov.uk/media/61fd3365e90e0768a8e97523/environment-agency-logo-480w.png",
+              "alt_text": "Environment Agency"
+            },
+            "formatted_title": "Environment Agency"
+          },
+          "brand": "department-for-environment-food-rural-affairs",
+          "default_news_image": {
+            "url": "https://assets.publishing.service.gov.uk/media/62c56ed9d3bf7f30034430da/s300_EA-officer-high-viz-jacket_960x640.jpg",
+            "high_resolution_url": "https://assets.publishing.service.gov.uk/media/62c56ed9e90e0774833f5583/s960_EA-officer-high-viz-jacket_960x640.jpg"
+          },
+          "organisation_govuk_status": {
+            "url": null,
+            "status": "live",
+            "updated_at": null
+          }
+        },
+        "links": {}
+      }
+    ],
+    "original_primary_publishing_organisation": [
+      {
+        "content_id": "16628142-57b2-4611-bc03-5912785acee3",
+        "title": "Environment Agency",
+        "locale": "en",
+        "analytics_identifier": "EA199",
+        "api_path": "/api/content/government/organisations/environment-agency",
+        "base_path": "/government/organisations/environment-agency",
+        "document_type": "organisation",
+        "schema_name": "organisation",
+        "withdrawn": false,
+        "details": {
+          "acronym": "EA",
+          "logo": {
+            "image": {
+              "url": "https://assets.publishing.service.gov.uk/media/61fd3365e90e0768a8e97523/environment-agency-logo-480w.png",
+              "alt_text": "Environment Agency"
+            },
+            "formatted_title": "Environment Agency"
+          },
+          "brand": "department-for-environment-food-rural-affairs",
+          "default_news_image": {
+            "url": "https://assets.publishing.service.gov.uk/media/62c56ed9d3bf7f30034430da/s300_EA-officer-high-viz-jacket_960x640.jpg",
+            "high_resolution_url": "https://assets.publishing.service.gov.uk/media/62c56ed9e90e0774833f5583/s960_EA-officer-high-viz-jacket_960x640.jpg"
+          },
+          "organisation_govuk_status": {
+            "url": null,
+            "status": "live",
+            "updated_at": null
+          }
+        },
+        "links": {}
+      }
+    ],
+    "primary_publishing_organisation": [
+      {
+        "content_id": "16628142-57b2-4611-bc03-5912785acee3",
+        "title": "Environment Agency",
+        "locale": "en",
+        "analytics_identifier": "EA199",
+        "api_path": "/api/content/government/organisations/environment-agency",
+        "base_path": "/government/organisations/environment-agency",
+        "document_type": "organisation",
+        "schema_name": "organisation",
+        "withdrawn": false,
+        "details": {
+          "acronym": "EA",
+          "logo": {
+            "image": {
+              "url": "https://assets.publishing.service.gov.uk/media/61fd3365e90e0768a8e97523/environment-agency-logo-480w.png",
+              "alt_text": "Environment Agency"
+            },
+            "formatted_title": "Environment Agency"
+          },
+          "brand": "department-for-environment-food-rural-affairs",
+          "default_news_image": {
+            "url": "https://assets.publishing.service.gov.uk/media/62c56ed9d3bf7f30034430da/s300_EA-officer-high-viz-jacket_960x640.jpg",
+            "high_resolution_url": "https://assets.publishing.service.gov.uk/media/62c56ed9e90e0774833f5583/s960_EA-officer-high-viz-jacket_960x640.jpg"
+          },
+          "organisation_govuk_status": {
+            "url": null,
+            "status": "live",
+            "updated_at": null
+          }
+        },
+        "links": {}
+      }
+    ],
+    "suggested_ordered_related_items": [
+      {
+        "content_id": "3f1d36bb-6aaa-4e37-b156-6257aae4566e",
+        "title": "Lost or stolen items",
+        "locale": "en",
+        "analytics_identifier": null,
+        "api_path": "/api/content/government/publications/lost-or-stolen-items",
+        "base_path": "/government/publications/lost-or-stolen-items",
+        "document_type": "foi_release",
+        "public_updated_at": "2015-08-12T10:33:12Z",
+        "schema_name": "publication",
+        "withdrawn": false,
+        "links": {}
+      }
+    ],
+    "taxons": [
+      {
+        "content_id": "1f0d0dcf-a5c0-4116-9ece-b7d7d46b3e3e",
+        "title": "Boats and waterways",
+        "locale": "en",
+        "analytics_identifier": null,
+        "api_path": "/api/content/environment/boats-waterways",
+        "base_path": "/environment/boats-waterways",
+        "document_type": "taxon",
+        "public_updated_at": "2018-09-05T16:13:11Z",
+        "schema_name": "taxon",
+        "withdrawn": false,
+        "description": null,
+        "details": {
+          "internal_name": "Boats and waterways [M]",
+          "notes_for_editors": "",
+          "visible_to_departmental_editors": false
+        },
+        "phase": "live",
+        "links": {
+          "parent_taxons": [
+            {
+              "content_id": "9949c2c1-ff96-4b4f-b584-c700e316c9de",
+              "title": "Rural and countryside",
+              "locale": "en",
+              "analytics_identifier": null,
+              "api_path": "/api/content/environment/rural-and-countryside",
+              "base_path": "/environment/rural-and-countryside",
+              "document_type": "taxon",
+              "public_updated_at": "2018-09-05T16:13:10Z",
+              "schema_name": "taxon",
+              "withdrawn": false,
+              "description": null,
+              "details": {
+                "internal_name": "Rural and countryside (merged, level 2)",
+                "notes_for_editors": "",
+                "visible_to_departmental_editors": false
+              },
+              "phase": "live",
+              "links": {
+                "parent_taxons": [
+                  {
+                    "content_id": "3cf97f69-84de-41ae-bc7b-7e2cc238fa58",
+                    "title": "Environment",
+                    "locale": "en",
+                    "analytics_identifier": null,
+                    "api_path": "/api/content/environment",
+                    "base_path": "/environment",
+                    "document_type": "taxon",
+                    "public_updated_at": "2018-09-16T13:39:00Z",
+                    "schema_name": "taxon",
+                    "withdrawn": false,
+                    "description": "",
+                    "details": {
+                      "internal_name": "Environment",
+                      "notes_for_editors": "",
+                      "visible_to_departmental_editors": true
+                    },
+                    "phase": "live",
+                    "links": {
+                      "root_taxon": [
+                        {
+                          "content_id": "f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a",
+                          "title": "GOV.UK homepage",
+                          "locale": "en",
+                          "analytics_identifier": null,
+                          "api_path": "/api/content/",
+                          "base_path": "/",
+                          "document_type": "homepage",
+                          "public_updated_at": "2023-06-28T09:32:34Z",
+                          "schema_name": "homepage",
+                          "withdrawn": false,
+                          "links": {}
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "available_translations": [
+      {
+        "title": "Walton Reach Regatta 2019: river restriction notice",
+        "public_updated_at": "2019-06-07T10:39:22Z",
+        "analytics_identifier": null,
+        "document_type": "notice",
+        "schema_name": "publication",
+        "base_path": "/government/publications/walton-reach-regatta-2019-river-restriction-notice",
+        "api_path": "/api/content/government/publications/walton-reach-regatta-2019-river-restriction-notice",
+        "withdrawn": true,
+        "content_id": "e3b7c15d-1928-4101-9912-c9b40a6d6e78",
+        "locale": "en"
+      }
+    ]
+  },
+  "user_journey_document_supertype": "thing",
+  "email_document_supertype": "publications",
+  "government_document_supertype": "notices",
+  "content_purpose_subgroup": "guidance",
+  "content_purpose_supergroup": "guidance_and_regulation",
+  "withdrawn_notice": {
+    "explanation": "\u003cdiv class=\"govspeak\"\u003e\u003cp\u003eThis notice has expired.\u003c/p\u003e\n\u003c/div\u003e",
+    "withdrawn_at": "2019-08-23T12:13:01Z"
+  },
+  "publishing_request_id": "21-1695990810.629-10.13.27.71-698",
+  "govuk_request_id": null,
+  "links": {
+    "government": [
+      "d4fbc1b9-d47d-4386-af04-ac909f868f92"
+    ],
+    "organisations": [
+      "16628142-57b2-4611-bc03-5912785acee3"
+    ],
+    "original_primary_publishing_organisation": [
+      "16628142-57b2-4611-bc03-5912785acee3"
+    ],
+    "primary_publishing_organisation": [
+      "16628142-57b2-4611-bc03-5912785acee3"
+    ],
+    "suggested_ordered_related_items": [
+      "6e7df4b2-d4a3-43a8-830b-85681495fa04",
+      "3f1d36bb-6aaa-4e37-b156-6257aae4566e"
+    ],
+    "taxons": [
+      "1f0d0dcf-a5c0-4116-9ece-b7d7d46b3e3e"
+    ]
+  },
+  "payload_version": "12345"
+}

--- a/spec/integration/document_synchronization_spec.rb
+++ b/spec/integration/document_synchronization_spec.rb
@@ -18,25 +18,23 @@ RSpec.describe "Document synchronization" do
 
     it "is added to Discovery Engine through the Put service" do
       expect(put_service).to have_received(:call).with(
-        "f75d26a3-25a4-4c31-beea-a77cada4ce12",
+        "5941cb22-5d52-4212-83b6-255d75d2c680",
         {
-          content_id: "f75d26a3-25a4-4c31-beea-a77cada4ce12",
-          title: "Ebola medal for over 3000 heroes",
-          description: "A new medal has been created to recognise the bravery and hard work of people who have helped to stop the spread of Ebola.",
-          link: "/government/news/ebola-medal-for-over-3000-heroes",
-          url: "http://www.dev.gov.uk/government/news/ebola-medal-for-over-3000-heroes",
-          public_timestamp: 1_434_021_240,
+          content_id: "5941cb22-5d52-4212-83b6-255d75d2c680",
+          title: "UK and Japan strengthen cooperation in the area of digital government",
+          description: "On Monday 31 October 2022, the UK and Japan signed a Memorandum of Cooperation (MoC) to deepen ties on digital government transformation.",
+          link: "/government/news/uk-and-japan-strengthen-cooperation-in-the-area-of-digital-government",
+          url: "http://www.dev.gov.uk/government/news/uk-and-japan-strengthen-cooperation-in-the-area-of-digital-government",
+          public_timestamp: 1_667_217_614,
           document_type: "press_release",
           is_historic: 0,
           government_name: "2015 Conservative government",
           content_purpose_supergroup: "news_and_communications",
-          part_of_taxonomy_tree: %w[
-            668cd623-c7a8-4159-9575-90caac36d4b4 c31256e8-f328-462b-993f-dce50b7892e9
-          ],
+          part_of_taxonomy_tree: %w[37d0fa26-abed-4c74-8835-b3b51ae1c8b2],
           locale: "en",
         },
-        content: a_string_starting_with("<div class=\"govspeak\"><p>The government has today"),
-        payload_version: 65_861_808,
+        content: a_string_starting_with("<div class=\"govspeak\"><p>The UK was represented remotely"),
+        payload_version: 12_345,
       )
     end
   end
@@ -249,6 +247,17 @@ RSpec.describe "Document synchronization" do
         },
         content: "Brighton & Hove City Council",
         payload_version: 17,
+      )
+    end
+  end
+
+  describe "for a withdrawn 'notice' message" do
+    let(:payload) { json_fixture_as_hash("message_queue/withdrawn_notice_message.json") }
+
+    it "is ignored and deleted from Discovery Engine through the Delete service" do
+      expect(delete_service).to have_received(:call).with(
+        "e3b7c15d-1928-4101-9912-c9b40a6d6e78",
+        payload_version: 12_345,
       )
     end
   end

--- a/spec/models/concerns/publishing_api/action_spec.rb
+++ b/spec/models/concerns/publishing_api/action_spec.rb
@@ -2,10 +2,11 @@ RSpec.describe PublishingApi::Action do
   subject(:action) { concern_consumer.new(document_hash) }
 
   let(:concern_consumer) { Struct.new(:document_hash).include(described_class) }
-  let(:document_hash) { { document_type:, base_path:, locale:, details: { url: } } }
+  let(:document_hash) { { document_type:, base_path:, locale:, details: { url: }, withdrawn_notice: } }
   let(:base_path) { "/test_base_path" }
   let(:url) { nil }
   let(:locale) { "en" }
+  let(:withdrawn_notice) { nil }
 
   %w[gone redirect substitute vanish].each do |document_type|
     context "when the document type is #{document_type}" do
@@ -84,6 +85,17 @@ RSpec.describe PublishingApi::Action do
     let(:base_path) { "/test_ignored_path" } # see test section in YAML config
 
     it { is_expected.to be_ignore }
+  end
+
+  context "when the document is withdrawn" do
+    let(:document_type) { "notice" }
+    let(:withdrawn_notice) { { explanation: "test" } }
+
+    it { is_expected.to be_ignore }
+
+    it "has the expected ignore_reason" do
+      expect(action.ignore_reason).to eq("withdrawn")
+    end
   end
 
   context "when the document doesn't have a base path but does have a url" do


### PR DESCRIPTION
The previous search indexed these, only to then exclude them from results unless a debug parameter is specified. We can just not sync them to begin with.

- Add logic to exclude withdrawn documents from indexing
- Add withdrawn `notice` document integration test
- Replace `press_release` integration test document with one that hasn't been withdrawn