### PR TITLE
Refactor `DiscoveryEngine::Search`

### DIFF
--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -1,17 +1,11 @@
 class SearchesController < ApplicationController
   def show
-    result_set = DiscoveryEngine::Search.new.call(
-      query_params[:q],
-      start: query_params[:start]&.to_i,
-      count: query_params[:count]&.to_i,
-    )
-
-    render json: result_set
+    render json: DiscoveryEngine::Search.new(query_params).result_set
   end
 
 private
 
   def query_params
-    params.permit(:q, :start, :count)
+    params.permit!
   end
 end

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,0 +1,29 @@
+{
+  "ignored_warnings": [
+    {
+      "warning_type": "Mass Assignment",
+      "warning_code": 70,
+      "fingerprint": "4c13d7998d2abdaad68d35c884f9a4527c1c3085beda87c99a93ada0eaef496e",
+      "check_name": "MassAssignment",
+      "message": "Specify exact keys allowed for mass assignment instead of using `permit!` which allows any keys",
+      "file": "app/controllers/searches_controller.rb",
+      "line": 9,
+      "link": "https://brakemanscanner.org/docs/warning_types/mass_assignment/",
+      "code": "params.permit!",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "SearchesController",
+        "method": "query_params"
+      },
+      "user_input": null,
+      "confidence": "Medium",
+      "cwe_id": [
+        915
+      ],
+      "note": "Mass assignment not a risk as not using Active Record and parsing these parameters elsewhere"
+    }
+  ],
+  "updated": "2023-12-06 16:07:36 +0000",
+  "brakeman_version": "6.1.0"
+}

--- a/spec/requests/search_request_spec.rb
+++ b/spec/requests/search_request_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe "Making a search request" do
-  let(:search_service) { instance_double(DiscoveryEngine::Search, call: result_set) }
+  let(:search_service) { instance_double(DiscoveryEngine::Search, result_set:) }
   let(:result_set) { ResultSet.new(results:, total: 42, start: 21) }
   let(:results) { [Result.new(content_id: "123"), Result.new(content_id: "456")] }
 
@@ -25,7 +25,9 @@ RSpec.describe "Making a search request" do
     it "passes any query parameters to the search service in the expected format" do
       get "/search.json?q=garden+centres&start=11&count=22"
 
-      expect(search_service).to have_received(:call).with("garden centres", start: 11, count: 22)
+      expect(DiscoveryEngine::Search).to have_received(:new).with(
+        hash_including(q: "garden centres", start: "11", count: "22"),
+      )
     end
   end
 end

--- a/spec/services/discovery_engine/search_spec.rb
+++ b/spec/services/discovery_engine/search_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe DiscoveryEngine::Search do
-  subject(:search) { described_class.new(client:) }
+  subject(:search) { described_class.new(query_params, client:) }
 
   let(:client) { double("SearchService::Client", search: search_return_value) }
 
@@ -25,9 +25,11 @@ RSpec.describe DiscoveryEngine::Search do
     end
   end
 
-  describe "#call" do
+  describe "#result_set" do
+    subject!(:result_set) { search.result_set }
+
     context "when the search is successful" do
-      subject!(:result_set) { search.call("garden centres") }
+      let(:query_params) { { q: "garden centres" } }
 
       let(:search_return_value) { double(response: search_response) }
       let(:search_response) { double(total_size: 42, results:) }
@@ -58,7 +60,7 @@ RSpec.describe DiscoveryEngine::Search do
       end
 
       context "when start and count are specified" do
-        subject!(:result_set) { search.call("garden centres", start: 11, count: 22) }
+        let(:query_params) { { q: "garden centres", start: "11", count: "22" } }
 
         it "calls the client with the expected parameters" do
           expect(client).to have_received(:search).with(
@@ -77,7 +79,7 @@ RSpec.describe DiscoveryEngine::Search do
 
       context "when searching for a query that has a single best bets defined" do
         # see test section in YAML config
-        subject!(:result_set) { search.call("i want to test a single best bet") }
+        let(:query_params) { { q: "i want to test a single best bet" } }
 
         let(:expected_boost_specs) do
           super() + [{
@@ -99,7 +101,7 @@ RSpec.describe DiscoveryEngine::Search do
 
       context "when searching for a query that has multiple best bets defined" do
         # see test section in YAML config
-        subject!(:result_set) { search.call("i want to test multiple best bets") }
+        let(:query_params) { { q: "i want to test multiple best bets" } }
 
         let(:expected_boost_specs) do
           super() + [{


### PR DESCRIPTION
- Pass entirety of query parameters to search (in anticipation of implementing more querying functionality)
- Move to a more OO-y rather than "callable" structure for the class and move parameters into object attributes