### PR TITLE
Remove `oj` gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,6 @@ gem "govuk_app_config"
 gem "govuk_message_queue_consumer"
 gem "jsonpath"
 gem "loofah"
-gem "oj"
 
 group :test do
   gem "grpc_mock"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -166,7 +166,6 @@ GEM
       racc (~> 1.4)
     nokogiri (1.15.5-x86_64-linux)
       racc (~> 1.4)
-    oj (3.16.1)
     opentelemetry-api (1.2.3)
     opentelemetry-common (0.20.0)
       opentelemetry-api (~> 1.0)
@@ -520,7 +519,6 @@ DEPENDENCIES
   json_schemer
   jsonpath
   loofah
-  oj
   railties (= 7.0.7.2)
   rspec-rails
   rubocop-govuk

--- a/config/initializers/json.rb
+++ b/config/initializers/json.rb
@@ -1,3 +1,0 @@
-# Use Oj for faster JSON handling across the app
-Oj.default_options = { mode: :rails }
-Oj.optimize_rails


### PR DESCRIPTION
Other GOV.UK teams have moved away from using this because it doesn't provide enough of a performance benefit to be worth the extra dependency and upgrade hassles.