### PR TITLE
Add ability to reject links

### DIFF
--- a/app/services/discovery_engine/search.rb
+++ b/app/services/discovery_engine/search.rb
@@ -33,6 +33,7 @@ module DiscoveryEngine
         page_size:,
         offset:,
         order_by:,
+        filter:,
         boost_spec:,
       }.compact
     end
@@ -66,6 +67,17 @@ module DiscoveryEngine
         Rails.logger.warn("Unexpected order_by value: #{query_params[:order].inspect}")
         DEFAULT_ORDER_BY
       end
+    end
+
+    def filter
+      reject_links_filter
+    end
+
+    def reject_links_filter
+      return nil if query_params[:reject_link].blank?
+
+      reject_links = Array(query_params[:reject_link]).map { "\"#{_1}\"" }.join(",")
+      "NOT link: ANY(#{reject_links})"
     end
 
     def serving_config

--- a/spec/services/discovery_engine/search_spec.rb
+++ b/spec/services/discovery_engine/search_spec.rb
@@ -107,6 +107,26 @@ RSpec.describe DiscoveryEngine::Search do
         end
       end
 
+      context "with a single reject_link parameter" do
+        let(:query_params) { { q: "garden centres", reject_link: "/foo" } }
+
+        it "calls the client with the expected parameters" do
+          expect(client).to have_received(:search).with(
+            hash_including(filter: 'NOT link: ANY("/foo")'),
+          )
+        end
+      end
+
+      context "with several reject_link parameter" do
+        let(:query_params) { { q: "garden centres", reject_link: ["/foo", "/bar"] } }
+
+        it "calls the client with the expected parameters" do
+          expect(client).to have_received(:search).with(
+            hash_including(filter: 'NOT link: ANY("/foo","/bar")'),
+          )
+        end
+      end
+
       context "when searching for a query that has a single best bets defined" do
         # see test section in YAML config
         let(:query_params) { { q: "i want to test a single best bet" } }


### PR DESCRIPTION
This is used by Finder Frontend to e.g. reject the finder itself from being shown in results.