### PR TITLE
Add `content_purpose_supergroup` filter

### DIFF
--- a/app/services/discovery_engine/query/filters.rb
+++ b/app/services/discovery_engine/query/filters.rb
@@ -5,7 +5,10 @@ module DiscoveryEngine::Query
     end
 
     def filter_expression
-      reject_links_filter
+      surround_and_join([
+        reject_links_filter,
+        content_purpose_supergroup_filter,
+      ], between: " AND ", surround: "(", surround_end: ")")
     end
 
   private
@@ -15,8 +18,25 @@ module DiscoveryEngine::Query
     def reject_links_filter
       return nil if query_params[:reject_link].blank?
 
-      reject_links = Array(query_params[:reject_link]).map { "\"#{_1}\"" }.join(",")
-      "NOT link: ANY(#{reject_links})"
+      values = surround_and_join(query_params[:reject_link], between: ",", surround: '"')
+      "NOT link: ANY(#{values})"
+    end
+
+    def content_purpose_supergroup_filter
+      return nil if query_params[:filter_content_purpose_supergroup].blank?
+
+      values = surround_and_join(
+        query_params[:filter_content_purpose_supergroup], between: ",", surround: '"'
+      )
+      "content_purpose_supergroup: ANY(#{values})"
+    end
+
+    def surround_and_join(string_or_strings, between:, surround:, surround_end: surround)
+      Array(string_or_strings)
+        .compact
+        .map { "#{surround}#{_1}#{surround_end}" }
+        .join(between)
+        .presence
     end
   end
 end

--- a/spec/services/discovery_engine/query/filters_spec.rb
+++ b/spec/services/discovery_engine/query/filters_spec.rb
@@ -8,20 +8,50 @@ RSpec.describe DiscoveryEngine::Query::Filters do
       it { is_expected.to be_nil }
     end
 
-    context "with a single reject_link parameter" do
-      let(:query_params) { { q: "garden centres", reject_link: "/foo" } }
+    context "with reject_link" do
+      context "with an empty parameter" do
+        let(:query_params) { { q: "garden centres", reject_link: "" } }
 
-      it "calls the client with the expected parameters" do
-        expect(filter_expression).to eq('NOT link: ANY("/foo")')
+        it { is_expected.to be_nil }
+      end
+
+      context "with a single parameter" do
+        let(:query_params) { { q: "garden centres", reject_link: "/foo" } }
+
+        it { is_expected.to eq('(NOT link: ANY("/foo"))') }
+      end
+
+      context "with several parameters" do
+        let(:query_params) { { q: "garden centres", reject_link: ["/foo", "/bar"] } }
+
+        it { is_expected.to eq('(NOT link: ANY("/foo","/bar"))') }
       end
     end
 
-    context "with several reject_link parameter" do
-      let(:query_params) { { q: "garden centres", reject_link: ["/foo", "/bar"] } }
+    context "with filter_content_purpose_supergroup" do
+      context "with an empty parameter" do
+        let(:query_params) { { q: "garden centres", filter_content_purpose_supergroup: "" } }
 
-      it "calls the client with the expected parameters" do
-        expect(filter_expression).to eq('NOT link: ANY("/foo","/bar")')
+        it { is_expected.to be_nil }
       end
+
+      context "with a single parameter" do
+        let(:query_params) { { q: "garden centres", filter_content_purpose_supergroup: "services" } }
+
+        it { is_expected.to eq('(content_purpose_supergroup: ANY("services"))') }
+      end
+
+      context "with several parameters" do
+        let(:query_params) { { q: "garden centres", filter_content_purpose_supergroup: %w[services guidance] } }
+
+        it { is_expected.to eq('(content_purpose_supergroup: ANY("services","guidance"))') }
+      end
+    end
+
+    context "with several filters specified" do
+      let(:query_params) { { q: "garden centres", reject_link: "/foo", filter_content_purpose_supergroup: "services" } }
+
+      it { is_expected.to eq('(NOT link: ANY("/foo")) AND (content_purpose_supergroup: ANY("services"))') }
     end
   end
 end


### PR DESCRIPTION
- Handle `filter_content_purpose_supergroup` query parameter
- Handle joining multiple different filter parameters
- Refactor to simplify and reduce duplication