### PR TITLE
Include `world_locations` field in synced documents

### DIFF
--- a/app/models/concerns/publishing_api/metadata.rb
+++ b/app/models/concerns/publishing_api/metadata.rb
@@ -19,6 +19,7 @@ module PublishingApi
         government_name:,
         organisation_state:,
         locale: document_hash[:locale],
+        world_locations:,
         parts:,
       }.compact_blank
     end
@@ -64,6 +65,14 @@ module PublishingApi
     def organisation_state
       document_hash
         .dig(:details, :organisation_govuk_status, :status)
+    end
+
+    def world_locations
+      # This isn't great, but there is no slug coming through from publishing-api and the v1
+      # search-api also manually generates slugs for world locations by parameterizing the title.
+      document_hash
+        .dig(:expanded_links, :world_locations)
+        &.map { _1[:title].parameterize }
     end
 
     def parts

--- a/spec/fixtures/files/message_queue/worldwide_organisation_message.json
+++ b/spec/fixtures/files/message_queue/worldwide_organisation_message.json
@@ -1,0 +1,1303 @@
+{
+  "title": "British Embassy Vienna",
+  "public_updated_at": "2013-06-28T16:28:46Z",
+  "publishing_app": "whitehall",
+  "rendering_app": "government-frontend",
+  "update_type": "republish",
+  "phase": "live",
+  "analytics_identifier": "WO26",
+  "document_type": "worldwide_organisation",
+  "schema_name": "worldwide_organisation",
+  "first_published_at": "2013-02-18T08:37:07Z",
+  "base_path": "/world/organisations/british-embassy-vienna",
+  "description": "The British Embassy in Vienna maintains and develops relations between the UK and Austria.",
+  "details": {
+    "body": "\u003cdiv class=\"govspeak\"\u003e\u003cp\u003eIn addition to the British Embassy, the UK’s diplomatic presence in Austria also consists of the \u003ca href=\"https://www.gov.uk/world/organisations/united-kingdom-mission-to-the-united-nations\" class=\"govuk-link\"\u003eUK Mission to the UN\u003c/a\u003e and the \u003ca href=\"https://www.gov.uk/world/organisations/organization-for-security-and-co-operation-in-europe\" class=\"govuk-link\"\u003eDelegation to the Organization for Security and Co-operation in Europe (OSCE)\u003c/a\u003e.\u003c/p\u003e\n\n\u003cp\u003eFind out more about our work on the \u003ca href=\"https://www.gov.uk/world/austria/news\" class=\"govuk-link\"\u003eUK and Austria news page\u003c/a\u003e.\u003c/p\u003e\n\n\u003ch2 id=\"getting-help-in-austria\"\u003eGetting help in Austria\u003c/h2\u003e\n\n\u003cp\u003eIf you need urgent medical help or are a victim of crime, call the local emergency services on 112. Contact your insurance provider if you have one. They will tell you what your policy covers, and what you need to do to make a claim.\u003c/p\u003e\n\n\u003cp\u003eIn many situations, you will be able to help yourself without needing to contact the British Embassy. Check our guidance on:\u003c/p\u003e\n\n\u003cul\u003e\n  \u003cli\u003efinding English-speaking \u003ca rel=\"external\" href=\"https://find-a-professional-service-abroad.service.csd.fcdo.gov.uk/find?serviceType=lawyers\u0026amp;country=Austria\u0026amp;utm_source=british-embassy-vienna\u0026amp;utm_medium=Embassy\u0026amp;utm_campaign=Austria\" class=\"govuk-link\"\u003elawyers\u003c/a\u003e, \u003ca rel=\"external\" href=\"https://find-a-professional-service-abroad.service.csd.fcdo.gov.uk/find?serviceType=funeral-directors\u0026amp;country=Austria\u0026amp;utm_source=british-embassy-vienna\u0026amp;utm_medium=Embassy\u0026amp;utm_campaign=Austria\" class=\"govuk-link\"\u003efuneral directors\u003c/a\u003e and \u003ca rel=\"external\" href=\"https://find-a-professional-service-abroad.service.csd.fcdo.gov.uk/find?serviceType=translators-interpreters\u0026amp;country=Austria\u0026amp;utm_source=british-embassy-vienna\u0026amp;utm_medium=Embassy\u0026amp;utm_campaign=Austria\" class=\"govuk-link\"\u003etranslators and interpreters\u003c/a\u003e in Austria\u003c/li\u003e\n  \u003cli\u003edealing with a \u003ca href=\"https://www.gov.uk/government/publications/bereavement-guide-for-austria?utm_source=british-embassy-vienna\u0026amp;utm_medium=Embassy\u0026amp;utm_campaign=Austria\" class=\"govuk-link\"\u003edeath in Austria\u003c/a\u003e\n\u003c/li\u003e\n  \u003cli\u003ebeing \u003ca href=\"https://www.gov.uk/government/publications/austria-prisoner-pack-austrian-prison-rules?utm_source=british-embassy-vienna\u0026amp;utm_medium=Embassy\u0026amp;utm_campaign=Austria\" class=\"govuk-link\"\u003earrested in Austria\u003c/a\u003e\n\u003c/li\u003e\n  \u003cli\u003egetting help if you’re a \u003ca href=\"https://www.gov.uk/guidance/victim-of-crime-abroad?utm_source=british-embassy-vienna\u0026amp;utm_medium=Embassy\u0026amp;utm_campaign=Austria\" class=\"govuk-link\"\u003evictim of crime\u003c/a\u003e\n\u003c/li\u003e\n  \u003cli\u003ewhat to do if you’re \u003ca href=\"https://www.gov.uk/guidance/in-hospital-abroad?utm_source=british-embassy-vienna\u0026amp;utm_medium=Embassy\u0026amp;utm_campaign=Austria\" class=\"govuk-link\"\u003ein hospital\u003c/a\u003e\n\u003c/li\u003e\n  \u003cli\u003e\n\u003ca href=\"https://www.gov.uk/foreign-travel-advice/austria\" class=\"govuk-link\"\u003etravel advice\u003c/a\u003e for Austria\u003c/li\u003e\n\u003c/ul\u003e\n\n\u003ch3 id=\"if-you-need-urgent-or-emergency-assistance\"\u003eIf you need urgent or emergency assistance\u003c/h3\u003e\n\n\u003cp\u003eWe can help British nationals in emergencies in Austria. We will prioritise helping those who are vulnerable and need our help the most. For example if you:\u003c/p\u003e\n\n\u003cul\u003e\n  \u003cli\u003ehave been injured or assaulted\u003c/li\u003e\n  \u003cli\u003eare arrested for a crime\u003c/li\u003e\n  \u003cli\u003eknow a British national in Austria who has died and you need assistance\u003c/li\u003e\n\u003c/ul\u003e\n\n\u003cp\u003eIf you need emergency assistance, or if our guidance has not given you the help you need:\u003c/p\u003e\n\n\u003cul\u003e\n  \u003cli\u003ein Austria call +43 (1) 716 130\u003c/li\u003e\n  \u003cli\u003ein the UK call +44 (0)  20 7008 5000\u003c/li\u003e\n\u003c/ul\u003e\n\n\u003cp\u003eOur phone lines are open 24/7.\u003c/p\u003e\n\n\u003ch2 id=\"if-you-cannot-use-your-passport\"\u003eIf you cannot use your passport\u003c/h2\u003e\n\n\u003cp\u003eYou can apply for an \u003ca href=\"https://www.gov.uk/emergency-travel-document\" class=\"govuk-link\"\u003eemergency travel document\u003c/a\u003e if you need to travel urgently and cannot use your passport because it is lost, stolen or damaged.\u003c/p\u003e\n\n\u003cp\u003eIf you are travelling in more than 3 weeks, check if you can \u003ca href=\"https://www.gov.uk/renew-adult-passport\" class=\"govuk-link\"\u003eget a new or replacement passport\u003c/a\u003e in time to travel.\u003c/p\u003e\n\n\u003cp\u003eIf you do not need to travel urgently, you should still \u003ca href=\"https://www.gov.uk/report-a-lost-or-stolen-passport\" class=\"govuk-link\"\u003ereport a lost or stolen passport\u003c/a\u003e.\u003c/p\u003e\n\n\u003ch2 id=\"getting-a-visa-to-the-uk\"\u003eGetting a visa to the UK\u003c/h2\u003e\n\n\u003cp\u003eThe British Embassy does not provide visas and cannot advise on UK visas. If you have any questions about the application process or your visa status, \u003ca href=\"https://www.gov.uk/contact-ukvi-inside-outside-uk\" class=\"govuk-link\"\u003econtact UK Visas and Immigration\u003c/a\u003e.\u003c/p\u003e\n\n\u003cp\u003eA Schengen visa or residence permit does not allow you to travel to the UK without a visa. You can \u003ca href=\"https://www.gov.uk/check-uk-visa\" class=\"govuk-link\"\u003echeck if you need a visa and apply for one\u003c/a\u003e.\u003c/p\u003e\n\n\u003ch2 id=\"official-documents-and-services-we-provide\"\u003eOfficial documents and services we provide\u003c/h2\u003e\n\n\u003cp\u003eWe provide a limited range of \u003ca href=\"https://www.gov.uk/guidance/notarial-and-documentary-services-guide-for-austria\" class=\"govuk-link\"\u003enotarial and documentary services\u003c/a\u003e when local notary publics, solicitors, or lawyers cannot provide them. You will need to \u003ca href=\"https://www.gov.uk/government/publications/austria-consular-fees\" class=\"govuk-link\"\u003epay a fee\u003c/a\u003e for these services.\u003c/p\u003e\n\n\u003ch2 id=\"support-for-british-nationals-living-in-austria\"\u003eSupport for British nationals living in Austria\u003c/h2\u003e\n\n\u003cp\u003eRead our guidance for \u003ca href=\"https://www.gov.uk/guidance/living-in-austria\" class=\"govuk-link\"\u003eliving in Austria\u003c/a\u003e for information on travelling to, living, working and studying there.\u003c/p\u003e\n\n\u003cp\u003eYou can find a full list of \u003ca href=\"https://www.gov.uk/world/austria\" class=\"govuk-link\"\u003eUK help and services\u003c/a\u003e available in Austria.\u003c/p\u003e\n\u003c/div\u003e",
+    "logo": {
+      "crest": "single-identity",
+      "formatted_title": "British Embassy \u003cbr/\u003eVienna"
+    },
+    "social_media_links": [
+      {
+        "href": "http://www.facebook.com/ukinaustria",
+        "title": "Our Embassy on Facebook",
+        "service_type": "facebook"
+      },
+      {
+        "href": "http://www.flickr.com/photos/ukinaustria",
+        "title": "Our Embassy on Flickr",
+        "service_type": "flickr"
+      },
+      {
+        "href": "http://twitter.com/ukinaustria",
+        "title": "@UKinAustria",
+        "service_type": "twitter"
+      },
+      {
+        "href": "https://www.youtube.com/channel/UCSYuWovmq6-wIm4k-s4vg8w/videos?shelf_id=0\u0026sort=dd\u0026view=0",
+        "title": "Our Embassy on YouTube",
+        "service_type": "youtube"
+      },
+      {
+        "href": "https://www.instagram.com/ukinaustria/",
+        "title": "Our Embassy on Instagram",
+        "service_type": "instagram"
+      }
+    ],
+    "world_location_names": [
+      {
+        "name": "Austria",
+        "content_id": "5e9ed0c6-7706-11e4-a3cb-005056011aef"
+      }
+    ],
+    "ordered_corporate_information_pages": [
+      {
+        "title": "Complaints procedure",
+        "content_id": "5f552474-7631-11e4-a3cb-005056011aef"
+      },
+      {
+        "title": "Working for British Embassy Vienna",
+        "content_id": "5f5524c0-7631-11e4-a3cb-005056011aef"
+      }
+    ],
+    "secondary_corporate_information_pages": ""
+  },
+  "routes": [
+    {
+      "path": "/world/organisations/british-embassy-vienna",
+      "type": "exact"
+    }
+  ],
+  "redirects": [],
+  "content_id": "f4c394f9-7a30-11e4-a3cb-005056011aef",
+  "locale": "en",
+  "expanded_links": {
+    "children": [
+      {
+        "content_id": "7bbebbc6-9603-4013-aca2-2571fbb858bd",
+        "title": "British Embassy Vienna",
+        "locale": "en",
+        "analytics_identifier": null,
+        "api_path": "/api/content/world/organisations/british-embassy-vienna/office/united-kingdom-delegation-to-the-organization-for-security-and-co-operation-in-europe-osce",
+        "base_path": "/world/organisations/british-embassy-vienna/office/united-kingdom-delegation-to-the-organization-for-security-and-co-operation-in-europe-osce",
+        "document_type": "worldwide_office",
+        "public_updated_at": "2023-05-17T15:29:32Z",
+        "schema_name": "worldwide_office",
+        "withdrawn": false,
+        "details": {
+          "access_and_opening_times": "\u003cdiv class=\"govspeak\"\u003e\u003ch2 id=\"public-holidays\"\u003e2022 public holidays\u003c/h2\u003e\n\n\u003ctable\u003e\n  \u003ctbody\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eMonday 3 January\u003c/td\u003e\n      \u003ctd\u003eNew Year\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eThursday 6 January\u003c/td\u003e\n      \u003ctd\u003eThree Kings Day\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eFriday 15 April\u003c/td\u003e\n      \u003ctd\u003eGood Friday\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eMonday 18 April\u003c/td\u003e\n      \u003ctd\u003eEaster Monday\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eThursday 26 May\u003c/td\u003e\n      \u003ctd\u003eAscension Day\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eMonday 6 June\u003c/td\u003e\n      \u003ctd\u003eWhit Monday\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eThursday 16 June\u003c/td\u003e\n      \u003ctd\u003eCorpus Christi\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eMonday 15 August\u003c/td\u003e\n      \u003ctd\u003eAssumption of Mary\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eWednesday 26 October\u003c/td\u003e\n      \u003ctd\u003eNational Day of Austria\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eTuesday 1 November\u003c/td\u003e\n      \u003ctd\u003eAll Saints’ Day\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eThursday 8 December\u003c/td\u003e\n      \u003ctd\u003eImmaculate Conception\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eMonday 26 December\u003c/td\u003e\n      \u003ctd\u003eBoxing Day\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eTuesday 27 December\u003c/td\u003e\n      \u003ctd\u003eChristmas Day (substitute day)\u003c/td\u003e\n    \u003c/tr\u003e\n  \u003c/tbody\u003e\n\u003c/table\u003e\n\n\u003cp\u003eIf you are a British national needing urgent consular assistance when the Embassy is closed, please call +43 (1) 716130.\u003c/p\u003e\n\u003c/div\u003e"
+        },
+        "links": {
+          "parent": [
+            {
+              "content_id": "f4c394f9-7a30-11e4-a3cb-005056011aef",
+              "title": "British Embassy Vienna",
+              "locale": "en",
+              "analytics_identifier": "WO26",
+              "api_path": "/api/content/world/organisations/british-embassy-vienna",
+              "base_path": "/world/organisations/british-embassy-vienna",
+              "document_type": "worldwide_organisation",
+              "public_updated_at": "2013-06-28T16:28:46Z",
+              "schema_name": "worldwide_organisation",
+              "withdrawn": false,
+              "description": "The British Embassy in Vienna maintains and develops relations between the UK and Austria.",
+              "details": {
+                "logo": {
+                  "crest": "single-identity",
+                  "formatted_title": "British Embassy \u003cbr/\u003eVienna"
+                },
+                "world_location_names": [
+                  {
+                    "name": "Austria",
+                    "content_id": "5e9ed0c6-7706-11e4-a3cb-005056011aef"
+                  }
+                ]
+              },
+              "links": {}
+            }
+          ]
+        }
+      },
+      {
+        "content_id": "4918dc76-c2ab-41eb-a01b-12dc4e68f498",
+        "title": "British Embassy Vienna",
+        "locale": "en",
+        "analytics_identifier": null,
+        "api_path": "/api/content/world/organisations/british-embassy-vienna/office/uk-mission-to-the-united-nations-vienna",
+        "base_path": "/world/organisations/british-embassy-vienna/office/uk-mission-to-the-united-nations-vienna",
+        "document_type": "worldwide_office",
+        "public_updated_at": "2023-05-17T15:29:30Z",
+        "schema_name": "worldwide_office",
+        "withdrawn": false,
+        "details": {
+          "access_and_opening_times": "\u003cdiv class=\"govspeak\"\u003e\u003ch2 id=\"opening-hours\"\u003eOpening hours\u003c/h2\u003e\n\n\u003cp\u003eAs a result of the coronavirus (COVID-19) and subsequent measures in place in Austria, the Consulate is open, but is only able to see customers by appointment.\u003c/p\u003e\n\n\u003cp\u003eTo book a consular appointment please visit the \u003ca href=\"https://www.gov.uk/government/world/organisations/british-embassy-vienna\" class=\"govuk-link\"\u003eOur Services\u003c/a\u003e page and book your appointment for the relevant offered service.  Please note that the Consular Section is not able to offer any advice on Visa enquiries.\u003c/p\u003e\n\n\u003cp\u003eIf you are a British national needing urgent consular assistance when the embassy is closed, please call +43 (1) 716130.\u003c/p\u003e\n\n\u003ch2 id=\"public-holidays\"\u003e2022 public holidays\u003c/h2\u003e\n\n\u003ctable\u003e\n  \u003ctbody\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eMonday 3 January\u003c/td\u003e\n      \u003ctd\u003eNew Year\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eThursday 6 January\u003c/td\u003e\n      \u003ctd\u003eThree Kings Day\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eFriday 15 April\u003c/td\u003e\n      \u003ctd\u003eGood Friday\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eMonday 18 April\u003c/td\u003e\n      \u003ctd\u003eEaster Monday\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eThursday 26 May\u003c/td\u003e\n      \u003ctd\u003eAscension Day\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eMonday 6 June\u003c/td\u003e\n      \u003ctd\u003eWhit Monday\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eThursday 16 June\u003c/td\u003e\n      \u003ctd\u003eCorpus Christi\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eMonday 15 August\u003c/td\u003e\n      \u003ctd\u003eAssumption of Mary\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eWednesday 26 October\u003c/td\u003e\n      \u003ctd\u003eNational Day of Austria\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eTuesday 1 November\u003c/td\u003e\n      \u003ctd\u003eAll Saints’ Day\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eThursday 8 December\u003c/td\u003e\n      \u003ctd\u003eImmaculate Conception\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eMonday 26 December\u003c/td\u003e\n      \u003ctd\u003eBoxing Day\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eTuesday 27 December\u003c/td\u003e\n      \u003ctd\u003eChristmas Day (substitute day)\u003c/td\u003e\n    \u003c/tr\u003e\n  \u003c/tbody\u003e\n\u003c/table\u003e\n\u003c/div\u003e"
+        },
+        "links": {
+          "parent": [
+            {
+              "content_id": "f4c394f9-7a30-11e4-a3cb-005056011aef",
+              "title": "British Embassy Vienna",
+              "locale": "en",
+              "analytics_identifier": "WO26",
+              "api_path": "/api/content/world/organisations/british-embassy-vienna",
+              "base_path": "/world/organisations/british-embassy-vienna",
+              "document_type": "worldwide_organisation",
+              "public_updated_at": "2013-06-28T16:28:46Z",
+              "schema_name": "worldwide_organisation",
+              "withdrawn": false,
+              "description": "The British Embassy in Vienna maintains and develops relations between the UK and Austria.",
+              "details": {
+                "logo": {
+                  "crest": "single-identity",
+                  "formatted_title": "British Embassy \u003cbr/\u003eVienna"
+                },
+                "world_location_names": [
+                  {
+                    "name": "Austria",
+                    "content_id": "5e9ed0c6-7706-11e4-a3cb-005056011aef"
+                  }
+                ]
+              },
+              "links": {}
+            }
+          ]
+        }
+      },
+      {
+        "content_id": "38718716-4295-4a3e-852a-64465ae6b9ff",
+        "title": "British Embassy Vienna",
+        "locale": "en",
+        "analytics_identifier": null,
+        "api_path": "/api/content/world/organisations/british-embassy-vienna/office/british-embassy",
+        "base_path": "/world/organisations/british-embassy-vienna/office/british-embassy",
+        "document_type": "worldwide_office",
+        "public_updated_at": "2023-05-17T15:29:34Z",
+        "schema_name": "worldwide_office",
+        "withdrawn": false,
+        "details": {
+          "access_and_opening_times": "\u003cdiv class=\"govspeak\"\u003e\u003ch2 id=\"opening-hours\"\u003eOpening hours\u003c/h2\u003e\n\n\u003cp\u003eTo book a Consular appointment please visit the \u003ca href=\"https://www.gov.uk/government/world/organisations/british-embassy-vienna\" class=\"govuk-link\"\u003eOur Services\u003c/a\u003e page and book your appointment for the relevant offered service.  Please note that the Consular Section is not able to offer any advice on Visa enquiries.\u003c/p\u003e\n\n\u003cp\u003eIf you are a British national needing urgent consular assistance when the embassy is closed, please call +43 (1) 716130. We are available 24/7 to provide urgent assistance.\u003c/p\u003e\n\n\u003ch2 id=\"privacy-notice\"\u003ePrivacy notice\u003c/h2\u003e\n\n\u003cp\u003eIf you visit the British Embassy, see our \u003ca href=\"https://www.gov.uk/government/publications/fco-privacy-notice-visitors-to-diplomatic-missions-and-residences-during-the-coronavirus-covid-19-pandemic\" class=\"govuk-link\"\u003eprivacy notice for visitors\u003c/a\u003e which explains how we will process your data for security and public health management reasons.\u003c/p\u003e\n\n\u003ch2 id=\"public-holidays\"\u003e2023 public holidays\u003c/h2\u003e\n\n\u003ctable\u003e\n  \u003ctbody\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eFriday 6 January\u003c/td\u003e\n      \u003ctd\u003eEpiphany / Three Kings Day\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eFriday 7 April\u003c/td\u003e\n      \u003ctd\u003eGood Friday\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eMonday 10 April\u003c/td\u003e\n      \u003ctd\u003eEaster Monday\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eMonday 1 May\u003c/td\u003e\n      \u003ctd\u003eEarly May bank holiday and Labour Day in Austria\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eMonday 8 May\u003c/td\u003e\n      \u003ctd\u003eCoronation Day\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eThursday 18 May\u003c/td\u003e\n      \u003ctd\u003eAscension Day\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eMonday 29 May\u003c/td\u003e\n      \u003ctd\u003eSpring bank holiday and Whit Monday in Austria\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eThursday 8 June\u003c/td\u003e\n      \u003ctd\u003eCorpus Christi\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eTuesday 15 August\u003c/td\u003e\n      \u003ctd\u003eAssumption of Mary\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eThursday 26 October\u003c/td\u003e\n      \u003ctd\u003eNational Day\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eWednesday 1 November\u003c/td\u003e\n      \u003ctd\u003eAll Saints’ Day\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eFriday 8 December\u003c/td\u003e\n      \u003ctd\u003eImmaculate Conception\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eMonday 25 December\u003c/td\u003e\n      \u003ctd\u003eChristmas Day\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eTuesday 26 December\u003c/td\u003e\n      \u003ctd\u003eBoxing Day\u003c/td\u003e\n    \u003c/tr\u003e\n  \u003c/tbody\u003e\n\u003c/table\u003e\n\n\u003cp\u003eIf you are a British national needing urgent consular assistance when the Embassy is closed, please call +43 (1) 716130.\u003c/p\u003e\n\n\u003ch2 id=\"visa-services\"\u003eVisa services\u003c/h2\u003e\n\n\u003cp\u003eAll visa enquiries are now provided by an external commercial partner.\u003c/p\u003e\n\n\u003cp\u003eVisa applications to travel to the UK must be made in advance online through the \u003ca rel=\"external\" href=\"https://uk.tlscontact.com/\" class=\"govuk-link\"\u003eTLS Contact website\u003c/a\u003e\u003c/p\u003e\n\n\u003cp\u003eShould you need to contact UK Visas \u0026amp; Immigration (including status updates, supporting documents and guidance) please visit the \u003ca href=\"https://www.gov.uk/contact-ukvi-inside-outside-uk\" class=\"govuk-link\"\u003eUKVI website\u003c/a\u003e\u003c/p\u003e\n\u003c/div\u003e"
+        },
+        "links": {
+          "parent": [
+            {
+              "content_id": "f4c394f9-7a30-11e4-a3cb-005056011aef",
+              "title": "British Embassy Vienna",
+              "locale": "en",
+              "analytics_identifier": "WO26",
+              "api_path": "/api/content/world/organisations/british-embassy-vienna",
+              "base_path": "/world/organisations/british-embassy-vienna",
+              "document_type": "worldwide_organisation",
+              "public_updated_at": "2013-06-28T16:28:46Z",
+              "schema_name": "worldwide_organisation",
+              "withdrawn": false,
+              "description": "The British Embassy in Vienna maintains and develops relations between the UK and Austria.",
+              "details": {
+                "logo": {
+                  "crest": "single-identity",
+                  "formatted_title": "British Embassy \u003cbr/\u003eVienna"
+                },
+                "world_location_names": [
+                  {
+                    "name": "Austria",
+                    "content_id": "5e9ed0c6-7706-11e4-a3cb-005056011aef"
+                  }
+                ]
+              },
+              "links": {}
+            }
+          ]
+        }
+      },
+      {
+        "content_id": "5edb0548-97c9-46ee-afaf-665ee4eec3e5",
+        "title": "British Embassy Vienna",
+        "locale": "en",
+        "analytics_identifier": null,
+        "api_path": "/api/content/world/organisations/british-embassy-vienna/office/british-embassy-vienna-consular-services",
+        "base_path": "/world/organisations/british-embassy-vienna/office/british-embassy-vienna-consular-services",
+        "document_type": "worldwide_office",
+        "public_updated_at": "2023-05-19T09:05:32Z",
+        "schema_name": "worldwide_office",
+        "withdrawn": false,
+        "details": {
+          "access_and_opening_times": "\u003cdiv class=\"govspeak\"\u003e\u003ch2 id=\"opening-hours\"\u003eOpening hours\u003c/h2\u003e\n\n\u003cp\u003eMonday to Friday, 9am to 5pm\u003c/p\u003e\n\n\u003cp\u003eTo book a Consular appointment please visit the \u003ca href=\"https://www.gov.uk/government/world/organisations/british-embassy-vienna\" class=\"govuk-link\"\u003eOur Services\u003c/a\u003e page and book your appointment for the relevant offered service.  Please note that the Consular Section is not able to offer any advice on Visa enquiries.\u003c/p\u003e\n\n\u003cp\u003eIf you visit the consulate, see our \u003ca href=\"https://www.gov.uk/government/publications/fco-privacy-notice-visitors-to-diplomatic-missions-and-residences-during-the-coronavirus-covid-19-pandemic\" class=\"govuk-link\"\u003eprivacy notice for visitors\u003c/a\u003e which explains how we will process your data for security and public health management reasons.\u003c/p\u003e\n\n\u003ch2 id=\"public-holidays\"\u003e2022 public holidays\u003c/h2\u003e\n\n\u003ctable\u003e\n  \u003ctbody\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eMonday 3 January\u003c/td\u003e\n      \u003ctd\u003eNew Year\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eThursday 6 January\u003c/td\u003e\n      \u003ctd\u003eThree Kings Day\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eFriday 15 April\u003c/td\u003e\n      \u003ctd\u003eGood Friday\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eMonday 18 April\u003c/td\u003e\n      \u003ctd\u003eEaster Monday\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eThursday 26 May\u003c/td\u003e\n      \u003ctd\u003eAscension Day\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eMonday 6 June\u003c/td\u003e\n      \u003ctd\u003eWhit Monday\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eThursday 16 June\u003c/td\u003e\n      \u003ctd\u003eCorpus Christi\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eMonday 15 August\u003c/td\u003e\n      \u003ctd\u003eAssumption of Mary\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eWednesday 26 October\u003c/td\u003e\n      \u003ctd\u003eNational Day of Austria\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eTuesday 1 November\u003c/td\u003e\n      \u003ctd\u003eAll Saints’ Day\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eThursday 8 December\u003c/td\u003e\n      \u003ctd\u003eImmaculate Conception\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eMonday 26 December\u003c/td\u003e\n      \u003ctd\u003eBoxing Day\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eTuesday 27 December\u003c/td\u003e\n      \u003ctd\u003eChristmas Day (substitute day)\u003c/td\u003e\n    \u003c/tr\u003e\n  \u003c/tbody\u003e\n\u003c/table\u003e\n\n\u003cp\u003eIf you are a British national needing urgent consular assistance when the embassy is closed, please call +43 (1) 716130.\u003c/p\u003e\n\u003c/div\u003e"
+        },
+        "links": {
+          "parent": [
+            {
+              "content_id": "f4c394f9-7a30-11e4-a3cb-005056011aef",
+              "title": "British Embassy Vienna",
+              "locale": "en",
+              "analytics_identifier": "WO26",
+              "api_path": "/api/content/world/organisations/british-embassy-vienna",
+              "base_path": "/world/organisations/british-embassy-vienna",
+              "document_type": "worldwide_organisation",
+              "public_updated_at": "2013-06-28T16:28:46Z",
+              "schema_name": "worldwide_organisation",
+              "withdrawn": false,
+              "description": "The British Embassy in Vienna maintains and develops relations between the UK and Austria.",
+              "details": {
+                "logo": {
+                  "crest": "single-identity",
+                  "formatted_title": "British Embassy \u003cbr/\u003eVienna"
+                },
+                "world_location_names": [
+                  {
+                    "name": "Austria",
+                    "content_id": "5e9ed0c6-7706-11e4-a3cb-005056011aef"
+                  }
+                ]
+              },
+              "links": {}
+            }
+          ]
+        }
+      },
+      {
+        "content_id": "5f552474-7631-11e4-a3cb-005056011aef",
+        "title": "Complaints procedure",
+        "locale": "en",
+        "analytics_identifier": null,
+        "api_path": "/api/content/world/organisations/british-embassy-vienna/about/complaints-procedure",
+        "base_path": "/world/organisations/british-embassy-vienna/about/complaints-procedure",
+        "document_type": "complaints_procedure",
+        "public_updated_at": "2023-03-23T10:50:17Z",
+        "schema_name": "worldwide_corporate_information_page",
+        "withdrawn": false,
+        "links": {
+          "parent": [
+            {
+              "content_id": "f4c394f9-7a30-11e4-a3cb-005056011aef",
+              "title": "British Embassy Vienna",
+              "locale": "en",
+              "analytics_identifier": "WO26",
+              "api_path": "/api/content/world/organisations/british-embassy-vienna",
+              "base_path": "/world/organisations/british-embassy-vienna",
+              "document_type": "worldwide_organisation",
+              "public_updated_at": "2013-06-28T16:28:46Z",
+              "schema_name": "worldwide_organisation",
+              "withdrawn": false,
+              "description": "The British Embassy in Vienna maintains and develops relations between the UK and Austria.",
+              "details": {
+                "logo": {
+                  "crest": "single-identity",
+                  "formatted_title": "British Embassy \u003cbr/\u003eVienna"
+                },
+                "world_location_names": [
+                  {
+                    "name": "Austria",
+                    "content_id": "5e9ed0c6-7706-11e4-a3cb-005056011aef"
+                  }
+                ]
+              },
+              "links": {}
+            }
+          ]
+        }
+      },
+      {
+        "content_id": "5f5524c0-7631-11e4-a3cb-005056011aef",
+        "title": "Working for British Embassy Vienna",
+        "locale": "en",
+        "analytics_identifier": null,
+        "api_path": "/api/content/world/organisations/british-embassy-vienna/about/recruitment",
+        "base_path": "/world/organisations/british-embassy-vienna/about/recruitment",
+        "document_type": "recruitment",
+        "public_updated_at": "2016-01-19T11:51:24Z",
+        "schema_name": "worldwide_corporate_information_page",
+        "withdrawn": false,
+        "links": {
+          "parent": [
+            {
+              "content_id": "f4c394f9-7a30-11e4-a3cb-005056011aef",
+              "title": "British Embassy Vienna",
+              "locale": "en",
+              "analytics_identifier": "WO26",
+              "api_path": "/api/content/world/organisations/british-embassy-vienna",
+              "base_path": "/world/organisations/british-embassy-vienna",
+              "document_type": "worldwide_organisation",
+              "public_updated_at": "2013-06-28T16:28:46Z",
+              "schema_name": "worldwide_organisation",
+              "withdrawn": false,
+              "description": "The British Embassy in Vienna maintains and develops relations between the UK and Austria.",
+              "details": {
+                "logo": {
+                  "crest": "single-identity",
+                  "formatted_title": "British Embassy \u003cbr/\u003eVienna"
+                },
+                "world_location_names": [
+                  {
+                    "name": "Austria",
+                    "content_id": "5e9ed0c6-7706-11e4-a3cb-005056011aef"
+                  }
+                ]
+              },
+              "links": {}
+            }
+          ]
+        }
+      }
+    ],
+    "corporate_information_pages": [
+      {
+        "content_id": "5f552474-7631-11e4-a3cb-005056011aef",
+        "title": "Complaints procedure",
+        "locale": "en",
+        "analytics_identifier": null,
+        "api_path": "/api/content/world/organisations/british-embassy-vienna/about/complaints-procedure",
+        "base_path": "/world/organisations/british-embassy-vienna/about/complaints-procedure",
+        "document_type": "complaints_procedure",
+        "public_updated_at": "2023-03-23T10:50:17Z",
+        "schema_name": "worldwide_corporate_information_page",
+        "withdrawn": false,
+        "links": {}
+      },
+      {
+        "content_id": "5f5524c0-7631-11e4-a3cb-005056011aef",
+        "title": "Working for British Embassy Vienna",
+        "locale": "en",
+        "analytics_identifier": null,
+        "api_path": "/api/content/world/organisations/british-embassy-vienna/about/recruitment",
+        "base_path": "/world/organisations/british-embassy-vienna/about/recruitment",
+        "document_type": "recruitment",
+        "public_updated_at": "2016-01-19T11:51:24Z",
+        "schema_name": "worldwide_corporate_information_page",
+        "withdrawn": false,
+        "links": {}
+      }
+    ],
+    "home_page_offices": [
+      {
+        "content_id": "4918dc76-c2ab-41eb-a01b-12dc4e68f498",
+        "title": "British Embassy Vienna",
+        "locale": "en",
+        "analytics_identifier": null,
+        "api_path": "/api/content/world/organisations/british-embassy-vienna/office/uk-mission-to-the-united-nations-vienna",
+        "base_path": "/world/organisations/british-embassy-vienna/office/uk-mission-to-the-united-nations-vienna",
+        "document_type": "worldwide_office",
+        "public_updated_at": "2023-05-17T15:29:30Z",
+        "schema_name": "worldwide_office",
+        "withdrawn": false,
+        "details": {
+          "access_and_opening_times": "\u003cdiv class=\"govspeak\"\u003e\u003ch2 id=\"opening-hours\"\u003eOpening hours\u003c/h2\u003e\n\n\u003cp\u003eAs a result of the coronavirus (COVID-19) and subsequent measures in place in Austria, the Consulate is open, but is only able to see customers by appointment.\u003c/p\u003e\n\n\u003cp\u003eTo book a consular appointment please visit the \u003ca href=\"https://www.gov.uk/government/world/organisations/british-embassy-vienna\" class=\"govuk-link\"\u003eOur Services\u003c/a\u003e page and book your appointment for the relevant offered service.  Please note that the Consular Section is not able to offer any advice on Visa enquiries.\u003c/p\u003e\n\n\u003cp\u003eIf you are a British national needing urgent consular assistance when the embassy is closed, please call +43 (1) 716130.\u003c/p\u003e\n\n\u003ch2 id=\"public-holidays\"\u003e2022 public holidays\u003c/h2\u003e\n\n\u003ctable\u003e\n  \u003ctbody\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eMonday 3 January\u003c/td\u003e\n      \u003ctd\u003eNew Year\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eThursday 6 January\u003c/td\u003e\n      \u003ctd\u003eThree Kings Day\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eFriday 15 April\u003c/td\u003e\n      \u003ctd\u003eGood Friday\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eMonday 18 April\u003c/td\u003e\n      \u003ctd\u003eEaster Monday\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eThursday 26 May\u003c/td\u003e\n      \u003ctd\u003eAscension Day\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eMonday 6 June\u003c/td\u003e\n      \u003ctd\u003eWhit Monday\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eThursday 16 June\u003c/td\u003e\n      \u003ctd\u003eCorpus Christi\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eMonday 15 August\u003c/td\u003e\n      \u003ctd\u003eAssumption of Mary\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eWednesday 26 October\u003c/td\u003e\n      \u003ctd\u003eNational Day of Austria\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eTuesday 1 November\u003c/td\u003e\n      \u003ctd\u003eAll Saints’ Day\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eThursday 8 December\u003c/td\u003e\n      \u003ctd\u003eImmaculate Conception\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eMonday 26 December\u003c/td\u003e\n      \u003ctd\u003eBoxing Day\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eTuesday 27 December\u003c/td\u003e\n      \u003ctd\u003eChristmas Day (substitute day)\u003c/td\u003e\n    \u003c/tr\u003e\n  \u003c/tbody\u003e\n\u003c/table\u003e\n\u003c/div\u003e"
+        },
+        "links": {
+          "contact": [
+            {
+              "content_id": "5374dde9-e9b8-41ce-b677-2dcd745f74bf",
+              "title": "UK Mission to the United Nations Vienna",
+              "locale": "en",
+              "analytics_identifier": null,
+              "api_path": null,
+              "base_path": null,
+              "document_type": "contact",
+              "public_updated_at": "2022-02-04T14:49:16Z",
+              "schema_name": "contact",
+              "withdrawn": false,
+              "details": {
+                "description": null,
+                "title": "UK Mission to the United Nations Vienna",
+                "contact_form_links": null,
+                "post_addresses": [
+                  {
+                    "locality": "Vienna",
+                    "postal_code": "1030 ",
+                    "street_address": "Jauresgasse 12",
+                    "world_location": "Austria",
+                    "iso2_country_code": "at"
+                  }
+                ],
+                "email_addresses": [
+                  {
+                    "email": "ukmis.vienna@fcdo.gov.uk"
+                  }
+                ],
+                "phone_numbers": [
+                  {
+                    "title": "Telephone",
+                    "number": "+43 (1) 716130/+44 20 7008 5000"
+                  },
+                  {
+                    "title": "Fax",
+                    "number": "+43 (1) 71613 4900 "
+                  }
+                ]
+              },
+              "links": {}
+            }
+          ]
+        }
+      },
+      {
+        "content_id": "7bbebbc6-9603-4013-aca2-2571fbb858bd",
+        "title": "British Embassy Vienna",
+        "locale": "en",
+        "analytics_identifier": null,
+        "api_path": "/api/content/world/organisations/british-embassy-vienna/office/united-kingdom-delegation-to-the-organization-for-security-and-co-operation-in-europe-osce",
+        "base_path": "/world/organisations/british-embassy-vienna/office/united-kingdom-delegation-to-the-organization-for-security-and-co-operation-in-europe-osce",
+        "document_type": "worldwide_office",
+        "public_updated_at": "2023-05-17T15:29:32Z",
+        "schema_name": "worldwide_office",
+        "withdrawn": false,
+        "details": {
+          "access_and_opening_times": "\u003cdiv class=\"govspeak\"\u003e\u003ch2 id=\"public-holidays\"\u003e2022 public holidays\u003c/h2\u003e\n\n\u003ctable\u003e\n  \u003ctbody\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eMonday 3 January\u003c/td\u003e\n      \u003ctd\u003eNew Year\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eThursday 6 January\u003c/td\u003e\n      \u003ctd\u003eThree Kings Day\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eFriday 15 April\u003c/td\u003e\n      \u003ctd\u003eGood Friday\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eMonday 18 April\u003c/td\u003e\n      \u003ctd\u003eEaster Monday\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eThursday 26 May\u003c/td\u003e\n      \u003ctd\u003eAscension Day\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eMonday 6 June\u003c/td\u003e\n      \u003ctd\u003eWhit Monday\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eThursday 16 June\u003c/td\u003e\n      \u003ctd\u003eCorpus Christi\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eMonday 15 August\u003c/td\u003e\n      \u003ctd\u003eAssumption of Mary\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eWednesday 26 October\u003c/td\u003e\n      \u003ctd\u003eNational Day of Austria\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eTuesday 1 November\u003c/td\u003e\n      \u003ctd\u003eAll Saints’ Day\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eThursday 8 December\u003c/td\u003e\n      \u003ctd\u003eImmaculate Conception\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eMonday 26 December\u003c/td\u003e\n      \u003ctd\u003eBoxing Day\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eTuesday 27 December\u003c/td\u003e\n      \u003ctd\u003eChristmas Day (substitute day)\u003c/td\u003e\n    \u003c/tr\u003e\n  \u003c/tbody\u003e\n\u003c/table\u003e\n\n\u003cp\u003eIf you are a British national needing urgent consular assistance when the Embassy is closed, please call +43 (1) 716130.\u003c/p\u003e\n\u003c/div\u003e"
+        },
+        "links": {
+          "contact": [
+            {
+              "content_id": "deb4d143-aacc-4225-9fe9-a789421eb208",
+              "title": "United Kingdom Delegation to the Organization for Security and Co-operation in Europe (OSCE)",
+              "locale": "en",
+              "analytics_identifier": null,
+              "api_path": null,
+              "base_path": null,
+              "document_type": "contact",
+              "public_updated_at": "2022-02-04T14:49:37Z",
+              "schema_name": "contact",
+              "withdrawn": false,
+              "details": {
+                "description": null,
+                "title": "United Kingdom Delegation to the Organization for Security and Co-operation in Europe (OSCE)",
+                "contact_form_links": null,
+                "post_addresses": [
+                  {
+                    "locality": "Vienna",
+                    "postal_code": "1030 ",
+                    "street_address": "Jauresgasse 12",
+                    "world_location": "Austria",
+                    "iso2_country_code": "at"
+                  }
+                ],
+                "email_addresses": [
+                  {
+                    "email": "ukdel.vienna@fcdo.gov.uk"
+                  }
+                ],
+                "phone_numbers": [
+                  {
+                    "title": "Telephone",
+                    "number": " +43 (1) 716130"
+                  }
+                ]
+              },
+              "links": {}
+            }
+          ]
+        }
+      }
+    ],
+    "main_office": [
+      {
+        "content_id": "38718716-4295-4a3e-852a-64465ae6b9ff",
+        "title": "British Embassy Vienna",
+        "locale": "en",
+        "analytics_identifier": null,
+        "api_path": "/api/content/world/organisations/british-embassy-vienna/office/british-embassy",
+        "base_path": "/world/organisations/british-embassy-vienna/office/british-embassy",
+        "document_type": "worldwide_office",
+        "public_updated_at": "2023-05-17T15:29:34Z",
+        "schema_name": "worldwide_office",
+        "withdrawn": false,
+        "details": {
+          "access_and_opening_times": "\u003cdiv class=\"govspeak\"\u003e\u003ch2 id=\"opening-hours\"\u003eOpening hours\u003c/h2\u003e\n\n\u003cp\u003eTo book a Consular appointment please visit the \u003ca href=\"https://www.gov.uk/government/world/organisations/british-embassy-vienna\" class=\"govuk-link\"\u003eOur Services\u003c/a\u003e page and book your appointment for the relevant offered service.  Please note that the Consular Section is not able to offer any advice on Visa enquiries.\u003c/p\u003e\n\n\u003cp\u003eIf you are a British national needing urgent consular assistance when the embassy is closed, please call +43 (1) 716130. We are available 24/7 to provide urgent assistance.\u003c/p\u003e\n\n\u003ch2 id=\"privacy-notice\"\u003ePrivacy notice\u003c/h2\u003e\n\n\u003cp\u003eIf you visit the British Embassy, see our \u003ca href=\"https://www.gov.uk/government/publications/fco-privacy-notice-visitors-to-diplomatic-missions-and-residences-during-the-coronavirus-covid-19-pandemic\" class=\"govuk-link\"\u003eprivacy notice for visitors\u003c/a\u003e which explains how we will process your data for security and public health management reasons.\u003c/p\u003e\n\n\u003ch2 id=\"public-holidays\"\u003e2023 public holidays\u003c/h2\u003e\n\n\u003ctable\u003e\n  \u003ctbody\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eFriday 6 January\u003c/td\u003e\n      \u003ctd\u003eEpiphany / Three Kings Day\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eFriday 7 April\u003c/td\u003e\n      \u003ctd\u003eGood Friday\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eMonday 10 April\u003c/td\u003e\n      \u003ctd\u003eEaster Monday\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eMonday 1 May\u003c/td\u003e\n      \u003ctd\u003eEarly May bank holiday and Labour Day in Austria\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eMonday 8 May\u003c/td\u003e\n      \u003ctd\u003eCoronation Day\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eThursday 18 May\u003c/td\u003e\n      \u003ctd\u003eAscension Day\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eMonday 29 May\u003c/td\u003e\n      \u003ctd\u003eSpring bank holiday and Whit Monday in Austria\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eThursday 8 June\u003c/td\u003e\n      \u003ctd\u003eCorpus Christi\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eTuesday 15 August\u003c/td\u003e\n      \u003ctd\u003eAssumption of Mary\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eThursday 26 October\u003c/td\u003e\n      \u003ctd\u003eNational Day\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eWednesday 1 November\u003c/td\u003e\n      \u003ctd\u003eAll Saints’ Day\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eFriday 8 December\u003c/td\u003e\n      \u003ctd\u003eImmaculate Conception\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eMonday 25 December\u003c/td\u003e\n      \u003ctd\u003eChristmas Day\u003c/td\u003e\n    \u003c/tr\u003e\n    \u003ctr\u003e\n      \u003ctd\u003eTuesday 26 December\u003c/td\u003e\n      \u003ctd\u003eBoxing Day\u003c/td\u003e\n    \u003c/tr\u003e\n  \u003c/tbody\u003e\n\u003c/table\u003e\n\n\u003cp\u003eIf you are a British national needing urgent consular assistance when the Embassy is closed, please call +43 (1) 716130.\u003c/p\u003e\n\n\u003ch2 id=\"visa-services\"\u003eVisa services\u003c/h2\u003e\n\n\u003cp\u003eAll visa enquiries are now provided by an external commercial partner.\u003c/p\u003e\n\n\u003cp\u003eVisa applications to travel to the UK must be made in advance online through the \u003ca rel=\"external\" href=\"https://uk.tlscontact.com/\" class=\"govuk-link\"\u003eTLS Contact website\u003c/a\u003e\u003c/p\u003e\n\n\u003cp\u003eShould you need to contact UK Visas \u0026amp; Immigration (including status updates, supporting documents and guidance) please visit the \u003ca href=\"https://www.gov.uk/contact-ukvi-inside-outside-uk\" class=\"govuk-link\"\u003eUKVI website\u003c/a\u003e\u003c/p\u003e\n\u003c/div\u003e"
+        },
+        "links": {
+          "contact": [
+            {
+              "content_id": "f39e39ba-1891-435f-abf2-b40b1d45780a",
+              "title": "British Embassy Vienna",
+              "locale": "en",
+              "analytics_identifier": null,
+              "api_path": null,
+              "base_path": null,
+              "document_type": "contact",
+              "public_updated_at": "2023-10-25T14:15:22Z",
+              "schema_name": "contact",
+              "withdrawn": false,
+              "details": {
+                "description": "Visa enquiries:\r\nhttps://www.gov.uk/check-uk-visa\r\n\r\nUse our contact form for consular enquiries:\r\nwww.gov.uk/contact-consulate-vienna\r\n\r\nFor media enquiries: press@britishembassy.at\r\n\r\nFor the Defence Section: defence.vienna@fcdo.gov.uk",
+                "title": "British Embassy Vienna",
+                "contact_form_links": null,
+                "post_addresses": [
+                  {
+                    "locality": "Vienna",
+                    "postal_code": "1030 ",
+                    "street_address": "Jauresgasse 12",
+                    "world_location": "Austria",
+                    "iso2_country_code": "at"
+                  }
+                ],
+                "email_addresses": [
+                  {
+                    "email": "Vienna.Embassy@fcdo.gov.uk"
+                  }
+                ],
+                "phone_numbers": [
+                  {
+                    "title": "Telephone",
+                    "number": "+43 (1) 716130 / +44 20 7008 5000"
+                  },
+                  {
+                    "title": "Fax",
+                    "number": "+(43) (1) 71613 2900"
+                  }
+                ]
+              },
+              "links": {}
+            }
+          ]
+        }
+      }
+    ],
+    "ordered_contacts": [
+      {
+        "content_id": "5374dde9-e9b8-41ce-b677-2dcd745f74bf",
+        "title": "UK Mission to the United Nations Vienna",
+        "locale": "en",
+        "analytics_identifier": null,
+        "api_path": null,
+        "base_path": null,
+        "document_type": "contact",
+        "public_updated_at": "2022-02-04T14:49:16Z",
+        "schema_name": "contact",
+        "withdrawn": false,
+        "details": {
+          "description": null,
+          "title": "UK Mission to the United Nations Vienna",
+          "contact_form_links": null,
+          "post_addresses": [
+            {
+              "locality": "Vienna",
+              "postal_code": "1030 ",
+              "street_address": "Jauresgasse 12",
+              "world_location": "Austria",
+              "iso2_country_code": "at"
+            }
+          ],
+          "email_addresses": [
+            {
+              "email": "ukmis.vienna@fcdo.gov.uk"
+            }
+          ],
+          "phone_numbers": [
+            {
+              "title": "Telephone",
+              "number": "+43 (1) 716130/+44 20 7008 5000"
+            },
+            {
+              "title": "Fax",
+              "number": "+43 (1) 71613 4900 "
+            }
+          ]
+        },
+        "links": {}
+      },
+      {
+        "content_id": "deb4d143-aacc-4225-9fe9-a789421eb208",
+        "title": "United Kingdom Delegation to the Organization for Security and Co-operation in Europe (OSCE)",
+        "locale": "en",
+        "analytics_identifier": null,
+        "api_path": null,
+        "base_path": null,
+        "document_type": "contact",
+        "public_updated_at": "2022-02-04T14:49:37Z",
+        "schema_name": "contact",
+        "withdrawn": false,
+        "details": {
+          "description": null,
+          "title": "United Kingdom Delegation to the Organization for Security and Co-operation in Europe (OSCE)",
+          "contact_form_links": null,
+          "post_addresses": [
+            {
+              "locality": "Vienna",
+              "postal_code": "1030 ",
+              "street_address": "Jauresgasse 12",
+              "world_location": "Austria",
+              "iso2_country_code": "at"
+            }
+          ],
+          "email_addresses": [
+            {
+              "email": "ukdel.vienna@fcdo.gov.uk"
+            }
+          ],
+          "phone_numbers": [
+            {
+              "title": "Telephone",
+              "number": " +43 (1) 716130"
+            }
+          ]
+        },
+        "links": {}
+      },
+      {
+        "content_id": "f39e39ba-1891-435f-abf2-b40b1d45780a",
+        "title": "British Embassy Vienna",
+        "locale": "en",
+        "analytics_identifier": null,
+        "api_path": null,
+        "base_path": null,
+        "document_type": "contact",
+        "public_updated_at": "2023-10-25T14:15:22Z",
+        "schema_name": "contact",
+        "withdrawn": false,
+        "details": {
+          "description": "Visa enquiries:\r\nhttps://www.gov.uk/check-uk-visa\r\n\r\nUse our contact form for consular enquiries:\r\nwww.gov.uk/contact-consulate-vienna\r\n\r\nFor media enquiries: press@britishembassy.at\r\n\r\nFor the Defence Section: defence.vienna@fcdo.gov.uk",
+          "title": "British Embassy Vienna",
+          "contact_form_links": null,
+          "post_addresses": [
+            {
+              "locality": "Vienna",
+              "postal_code": "1030 ",
+              "street_address": "Jauresgasse 12",
+              "world_location": "Austria",
+              "iso2_country_code": "at"
+            }
+          ],
+          "email_addresses": [
+            {
+              "email": "Vienna.Embassy@fcdo.gov.uk"
+            }
+          ],
+          "phone_numbers": [
+            {
+              "title": "Telephone",
+              "number": "+43 (1) 716130 / +44 20 7008 5000"
+            },
+            {
+              "title": "Fax",
+              "number": "+(43) (1) 71613 2900"
+            }
+          ]
+        },
+        "links": {}
+      },
+      {
+        "content_id": "181a649d-7d85-4270-a8c0-bcdce377d597",
+        "title": "British Embassy Vienna - Consular Services",
+        "locale": "en",
+        "analytics_identifier": null,
+        "api_path": null,
+        "base_path": null,
+        "document_type": "contact",
+        "public_updated_at": "2022-07-29T15:01:26Z",
+        "schema_name": "contact",
+        "withdrawn": false,
+        "details": {
+          "description": null,
+          "title": "British Embassy Vienna - Consular Services",
+          "contact_form_links": [
+            {
+              "link": "https://www.contact-embassy.service.gov.uk/?country=Austria\u0026post=British%20Embassy%20Vienna"
+            }
+          ],
+          "post_addresses": [
+            {
+              "locality": "Vienna",
+              "postal_code": "1030",
+              "street_address": "Jauresgasse 12",
+              "world_location": "Austria",
+              "iso2_country_code": "at"
+            }
+          ],
+          "email_addresses": null,
+          "phone_numbers": [
+            {
+              "title": "Telephone",
+              "number": "+43 (1) 716130 / +44 20 7008 5000"
+            }
+          ]
+        },
+        "links": {}
+      }
+    ],
+    "primary_role_person": [
+      {
+        "content_id": "85330cee-c0f1-11e4-8223-005056011aef",
+        "title": "Lindsay Skoll CMG",
+        "locale": "en",
+        "analytics_identifier": null,
+        "api_path": "/api/content/government/people/lindsay-skoll",
+        "base_path": "/government/people/lindsay-skoll",
+        "document_type": "person",
+        "public_updated_at": "2022-09-13T12:56:21Z",
+        "schema_name": "person",
+        "withdrawn": false,
+        "details": {
+          "image": {
+            "url": "https://assets.publishing.service.gov.uk/media/619e133f8fa8f50382034d9c/s465_Lindsay_Skoll_photo.jpg",
+            "alt_text": "Lindsay Skoll CMG"
+          },
+          "privy_counsellor": false
+        },
+        "links": {
+          "role_appointments": [
+            {
+              "content_id": "fcd8efb1-fbe6-445f-951b-980c29961f81",
+              "title": "Lindsay Skoll CMG - British High Commissioner to Seychelles",
+              "locale": "en",
+              "analytics_identifier": null,
+              "api_path": null,
+              "base_path": null,
+              "document_type": "role_appointment",
+              "public_updated_at": "2019-08-23T10:52:43Z",
+              "schema_name": "role_appointment",
+              "withdrawn": false,
+              "details": {
+                "started_on": "2012-08-02T00:00:00+01:00",
+                "ended_on": "2015-08-15T00:00:00+01:00",
+                "current": false,
+                "person_appointment_order": 775
+              },
+              "links": {
+                "role": [
+                  {
+                    "content_id": "8464de61-c0f1-11e4-8223-005056011aef",
+                    "title": "British High Commissioner to Seychelles",
+                    "locale": "en",
+                    "analytics_identifier": null,
+                    "api_path": null,
+                    "base_path": null,
+                    "document_type": "high_commissioner_role",
+                    "public_updated_at": "2013-03-19T15:55:19Z",
+                    "schema_name": "role",
+                    "withdrawn": false,
+                    "details": {
+                      "body": [
+                        {
+                          "content": "The High Commissioner is the UK government’s representative in a Commonwealth nation. They are responsible for the direction and work of the High Commission and its Deputy High Commissions and/or Consulates, including political work, trade and investment, press and cultural relations, and visa and consular services.",
+                          "content_type": "text/govspeak"
+                        },
+                        {
+                          "content_type": "text/html",
+                          "content": "\u003cp\u003eThe High Commissioner is the UK government’s representative in a Commonwealth nation. They are responsible for the direction and work of the High Commission and its Deputy High Commissions and/or Consulates, including political work, trade and investment, press and cultural relations, and visa and consular services.\u003c/p\u003e\n"
+                        }
+                      ],
+                      "role_payment_type": null
+                    },
+                    "links": {}
+                  }
+                ]
+              }
+            },
+            {
+              "content_id": "6127660b-707a-4f98-ae51-2365692f3bea",
+              "title": "Lindsay Skoll CMG - Deputy Head of Mission, British Embassy Democratic People’s Republic of Korea",
+              "locale": "en",
+              "analytics_identifier": null,
+              "api_path": null,
+              "base_path": null,
+              "document_type": "role_appointment",
+              "public_updated_at": "2019-01-08T15:26:33Z",
+              "schema_name": "role_appointment",
+              "withdrawn": false,
+              "details": {
+                "started_on": "2004-03-01T00:00:00+00:00",
+                "ended_on": "2006-11-01T00:00:00+00:00",
+                "current": false,
+                "person_appointment_order": 4883
+              },
+              "links": {
+                "role": [
+                  {
+                    "content_id": "8467b798-c0f1-11e4-8223-005056011aef",
+                    "title": "Deputy Head of Mission to Democratic People’s Republic of Korea",
+                    "locale": "en",
+                    "analytics_identifier": null,
+                    "api_path": null,
+                    "base_path": null,
+                    "document_type": "deputy_head_of_mission_role",
+                    "public_updated_at": "2023-12-08T07:17:22Z",
+                    "schema_name": "role",
+                    "withdrawn": false,
+                    "details": {
+                      "body": [
+                        {
+                          "content": "The Deputy Head of Mission is a senior diplomat and typically a key advisor to the Ambassador or High Commissioner. The Deputy is responsible for the daily management of an overseas Embassy or High Commission. They will represent the UK’s interests in the absence of the Ambassador as Chargé d’Affaires. A senior ranking Deputy may also take the title Minister. Smaller missions may not have a Deputy Head.",
+                          "content_type": "text/govspeak"
+                        },
+                        {
+                          "content_type": "text/html",
+                          "content": "\u003cp\u003eThe Deputy Head of Mission is a senior diplomat and typically a key advisor to the Ambassador or High Commissioner. The Deputy is responsible for the daily management of an overseas Embassy or High Commission. They will represent the UK’s interests in the absence of the Ambassador as Chargé d’Affaires. A senior ranking Deputy may also take the title Minister. Smaller missions may not have a Deputy Head.\u003c/p\u003e\n"
+                        }
+                      ],
+                      "role_payment_type": null
+                    },
+                    "links": {}
+                  }
+                ]
+              }
+            },
+            {
+              "content_id": "86b79e34-bb67-4a60-8fe5-f0e3a128483d",
+              "title": "Lindsay Skoll CMG - Deputy Head of Mission to Russia",
+              "locale": "en",
+              "analytics_identifier": null,
+              "api_path": null,
+              "base_path": null,
+              "document_type": "role_appointment",
+              "public_updated_at": "2020-09-01T07:49:26Z",
+              "schema_name": "role_appointment",
+              "withdrawn": false,
+              "details": {
+                "started_on": "2018-01-01T00:00:00+00:00",
+                "ended_on": "2020-08-20T00:00:00+01:00",
+                "current": false,
+                "person_appointment_order": 4884
+              },
+              "links": {
+                "role": [
+                  {
+                    "content_id": "846db5ea-c0f1-11e4-8223-005056011aef",
+                    "title": "Deputy Head of Mission to Russia",
+                    "locale": "en",
+                    "analytics_identifier": null,
+                    "api_path": null,
+                    "base_path": null,
+                    "document_type": "deputy_head_of_mission_role",
+                    "public_updated_at": "2023-06-22T09:08:22Z",
+                    "schema_name": "role",
+                    "withdrawn": false,
+                    "details": {
+                      "body": [
+                        {
+                          "content": "The Deputy Head of Mission is a senior diplomat and typically a key advisor to the Ambassador or High Commissioner. The Deputy is responsible for the daily management of an overseas Embassy or High Commission. They will represent the UK’s interests in the absence of the Ambassador as Chargé d’Affaires. A senior ranking Deputy may also take the title Minister. Smaller missions may not have a Deputy Head.",
+                          "content_type": "text/govspeak"
+                        },
+                        {
+                          "content_type": "text/html",
+                          "content": "\u003cp\u003eThe Deputy Head of Mission is a senior diplomat and typically a key advisor to the Ambassador or High Commissioner. The Deputy is responsible for the daily management of an overseas Embassy or High Commission. They will represent the UK’s interests in the absence of the Ambassador as Chargé d’Affaires. A senior ranking Deputy may also take the title Minister. Smaller missions may not have a Deputy Head.\u003c/p\u003e\n"
+                        }
+                      ],
+                      "role_payment_type": null
+                    },
+                    "links": {}
+                  }
+                ]
+              }
+            },
+            {
+              "content_id": "4fd9b972-8f22-40bf-a16b-7117fab0cabe",
+              "title": "Lindsay Skoll CMG - Ambassador to Austria and UK Permanent Representative to the United Nations and other International Organisations in Vienna",
+              "locale": "en",
+              "analytics_identifier": null,
+              "api_path": null,
+              "base_path": null,
+              "document_type": "role_appointment",
+              "public_updated_at": "2021-11-23T16:31:29Z",
+              "schema_name": "role_appointment",
+              "withdrawn": false,
+              "details": {
+                "started_on": "2021-11-23T00:00:00+00:00",
+                "ended_on": null,
+                "current": true,
+                "person_appointment_order": 7354
+              },
+              "links": {
+                "role": [
+                  {
+                    "content_id": "8461c054-c0f1-11e4-8223-005056011aef",
+                    "title": "Ambassador to Austria and UK Permanent Representative to the United Nations and other International Organisations in Vienna",
+                    "locale": "en",
+                    "analytics_identifier": null,
+                    "api_path": null,
+                    "base_path": null,
+                    "document_type": "ambassador_role",
+                    "public_updated_at": "2022-09-13T12:54:06Z",
+                    "schema_name": "role",
+                    "withdrawn": false,
+                    "details": {
+                      "body": [
+                        {
+                          "content": "The Ambassador represents His Majesty The King and the UK government in the country to which they are appointed. They are responsible for the direction and work of the embassy and its consulates, including political work, trade and investment, press and cultural relations, and visa and consular services. Ambassadors to multilateral missions are often referred to as ‘Permanent Representatives’.",
+                          "content_type": "text/govspeak"
+                        },
+                        {
+                          "content_type": "text/html",
+                          "content": "\u003cp\u003eThe Ambassador represents His Majesty The King and the UK government in the country to which they are appointed. They are responsible for the direction and work of the embassy and its consulates, including political work, trade and investment, press and cultural relations, and visa and consular services. Ambassadors to multilateral missions are often referred to as ‘Permanent Representatives’.\u003c/p\u003e\n"
+                        }
+                      ],
+                      "role_payment_type": null
+                    },
+                    "links": {}
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "roles": [
+      {
+        "content_id": "8461c054-c0f1-11e4-8223-005056011aef",
+        "title": "Ambassador to Austria and UK Permanent Representative to the United Nations and other International Organisations in Vienna",
+        "locale": "en",
+        "analytics_identifier": null,
+        "api_path": null,
+        "base_path": null,
+        "document_type": "ambassador_role",
+        "public_updated_at": "2022-09-13T12:54:06Z",
+        "schema_name": "role",
+        "withdrawn": false,
+        "details": {
+          "body": [
+            {
+              "content": "The Ambassador represents His Majesty The King and the UK government in the country to which they are appointed. They are responsible for the direction and work of the embassy and its consulates, including political work, trade and investment, press and cultural relations, and visa and consular services. Ambassadors to multilateral missions are often referred to as ‘Permanent Representatives’.",
+              "content_type": "text/govspeak"
+            },
+            {
+              "content_type": "text/html",
+              "content": "\u003cp\u003eThe Ambassador represents His Majesty The King and the UK government in the country to which they are appointed. They are responsible for the direction and work of the embassy and its consulates, including political work, trade and investment, press and cultural relations, and visa and consular services. Ambassadors to multilateral missions are often referred to as ‘Permanent Representatives’.\u003c/p\u003e\n"
+            }
+          ],
+          "role_payment_type": null
+        },
+        "links": {}
+      },
+      {
+        "content_id": "1dd30ef9-699f-42bc-a835-04633ed81abe",
+        "title": "Deputy Head of Mission, Austria",
+        "locale": "en",
+        "analytics_identifier": null,
+        "api_path": null,
+        "base_path": null,
+        "document_type": "deputy_head_of_mission_role",
+        "public_updated_at": "2017-03-31T14:44:08Z",
+        "schema_name": "role",
+        "withdrawn": false,
+        "details": {
+          "body": [
+            {
+              "content": "The Deputy Head of Mission is a senior diplomat and typically a key advisor to the Ambassador or High Commissioner. The Deputy is responsible for the daily management of an overseas Embassy or High Commission. They will represent the UK’s interests in the absence of the Ambassador as Chargé d’Affaires. A senior ranking Deputy may also take the title Minister. Smaller missions may not have a Deputy Head.",
+              "content_type": "text/govspeak"
+            },
+            {
+              "content_type": "text/html",
+              "content": "\u003cp\u003eThe Deputy Head of Mission is a senior diplomat and typically a key advisor to the Ambassador or High Commissioner. The Deputy is responsible for the daily management of an overseas Embassy or High Commission. They will represent the UK’s interests in the absence of the Ambassador as Chargé d’Affaires. A senior ranking Deputy may also take the title Minister. Smaller missions may not have a Deputy Head.\u003c/p\u003e\n"
+            }
+          ],
+          "role_payment_type": null
+        },
+        "links": {}
+      }
+    ],
+    "secondary_role_person": [
+      {
+        "content_id": "d2fbbcbc-bc80-4c94-befe-3b43b9bb270a",
+        "title": "Emma Baines",
+        "locale": "en",
+        "analytics_identifier": null,
+        "api_path": "/api/content/government/people/emma-baines",
+        "base_path": "/government/people/emma-baines",
+        "document_type": "person",
+        "public_updated_at": "2022-04-01T10:39:35Z",
+        "schema_name": "person",
+        "withdrawn": false,
+        "links": {
+          "role_appointments": [
+            {
+              "content_id": "bf2f80d8-75ef-47ff-ba12-39941bb9d778",
+              "title": "Emma Baines - Deputy Head of Mission, Austria",
+              "locale": "en",
+              "analytics_identifier": null,
+              "api_path": null,
+              "base_path": null,
+              "document_type": "role_appointment",
+              "public_updated_at": "2022-04-01T10:40:54Z",
+              "schema_name": "role_appointment",
+              "withdrawn": false,
+              "details": {
+                "started_on": "2022-03-18T00:00:00+00:00",
+                "ended_on": null,
+                "current": true,
+                "person_appointment_order": 7610
+              },
+              "links": {
+                "role": [
+                  {
+                    "content_id": "1dd30ef9-699f-42bc-a835-04633ed81abe",
+                    "title": "Deputy Head of Mission, Austria",
+                    "locale": "en",
+                    "analytics_identifier": null,
+                    "api_path": null,
+                    "base_path": null,
+                    "document_type": "deputy_head_of_mission_role",
+                    "public_updated_at": "2017-03-31T14:44:08Z",
+                    "schema_name": "role",
+                    "withdrawn": false,
+                    "details": {
+                      "body": [
+                        {
+                          "content": "The Deputy Head of Mission is a senior diplomat and typically a key advisor to the Ambassador or High Commissioner. The Deputy is responsible for the daily management of an overseas Embassy or High Commission. They will represent the UK’s interests in the absence of the Ambassador as Chargé d’Affaires. A senior ranking Deputy may also take the title Minister. Smaller missions may not have a Deputy Head.",
+                          "content_type": "text/govspeak"
+                        },
+                        {
+                          "content_type": "text/html",
+                          "content": "\u003cp\u003eThe Deputy Head of Mission is a senior diplomat and typically a key advisor to the Ambassador or High Commissioner. The Deputy is responsible for the daily management of an overseas Embassy or High Commission. They will represent the UK’s interests in the absence of the Ambassador as Chargé d’Affaires. A senior ranking Deputy may also take the title Minister. Smaller missions may not have a Deputy Head.\u003c/p\u003e\n"
+                        }
+                      ],
+                      "role_payment_type": null
+                    },
+                    "links": {}
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "sponsoring_organisations": [
+      {
+        "content_id": "f9fcf3fe-2751-4dca-97ca-becaeceb4b26",
+        "title": "Foreign, Commonwealth \u0026 Development Office",
+        "locale": "en",
+        "analytics_identifier": "D1315",
+        "api_path": "/api/content/government/organisations/foreign-commonwealth-development-office",
+        "base_path": "/government/organisations/foreign-commonwealth-development-office",
+        "document_type": "organisation",
+        "schema_name": "organisation",
+        "withdrawn": false,
+        "details": {
+          "acronym": "FCDO",
+          "logo": {
+            "crest": "single-identity",
+            "formatted_title": "Foreign, Commonwealth\u003cbr/\u003e\u0026amp; Development Office"
+          },
+          "brand": "foreign-commonwealth-development-office",
+          "default_news_image": {
+            "url": "https://assets.publishing.service.gov.uk/media/621e4de48fa8f5490aff83b4/s300_fcdo-main-building.jpg",
+            "high_resolution_url": "https://assets.publishing.service.gov.uk/media/621e4de4e90e0710be0354d7/s960_fcdo-main-building.jpg"
+          },
+          "organisation_govuk_status": {
+            "url": null,
+            "status": "live",
+            "updated_at": null
+          }
+        },
+        "links": {}
+      }
+    ],
+    "taxons": [
+      {
+        "content_id": "f1744c25-bbae-42d5-b0fa-452ccea8f802",
+        "title": "British embassy or high commission",
+        "locale": "en",
+        "analytics_identifier": null,
+        "api_path": "/api/content/world/british-embassy-or-high-commission-austria",
+        "base_path": "/world/british-embassy-or-high-commission-austria",
+        "document_type": "taxon",
+        "public_updated_at": "2017-06-29T08:13:48Z",
+        "schema_name": "taxon",
+        "withdrawn": false,
+        "description": "Includes contact details, opening hours and consular fees and local services.",
+        "details": {
+          "internal_name": "British embassy or high commission (Austria)",
+          "notes_for_editors": "",
+          "visible_to_departmental_editors": true
+        },
+        "phase": "live",
+        "links": {
+          "parent_taxons": [
+            {
+              "content_id": "862fdd81-0b52-41c1-9aa0-e208ac86b763",
+              "title": "UK help and services in Austria",
+              "locale": "en",
+              "analytics_identifier": null,
+              "api_path": "/api/content/world/austria",
+              "base_path": "/world/austria",
+              "document_type": "taxon",
+              "public_updated_at": "2020-02-28T15:43:17Z",
+              "schema_name": "taxon",
+              "withdrawn": false,
+              "description": "Services if you're visiting, studying, working or living in Austria. Includes information about trading with and doing business in the UK and Austria, and your rights after the UK’s exit from the EU.",
+              "details": {
+                "internal_name": "UK help and services in Austria",
+                "notes_for_editors": "",
+                "visible_to_departmental_editors": false
+              },
+              "phase": "live",
+              "links": {
+                "parent_taxons": [
+                  {
+                    "content_id": "91b8ef20-74e7-4552-880c-50e6d73c2ff9",
+                    "title": "Help and services around the world",
+                    "locale": "en",
+                    "analytics_identifier": null,
+                    "api_path": "/api/content/world/all",
+                    "base_path": "/world/all",
+                    "document_type": "taxon",
+                    "public_updated_at": "2021-07-09T10:08:54Z",
+                    "schema_name": "taxon",
+                    "withdrawn": false,
+                    "description": "Help and services in a country",
+                    "details": {
+                      "url_override": "",
+                      "internal_name": "Help and services around the world",
+                      "notes_for_editors": "",
+                      "visible_to_departmental_editors": false
+                    },
+                    "phase": "live",
+                    "links": {}
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "content_id": "ca97c97d-30c3-4c31-86d5-a84fb37f919a",
+        "title": "Emergency help for British nationals",
+        "locale": "en",
+        "analytics_identifier": null,
+        "api_path": "/api/content/world/emergency-help-for-british-nationals-austria",
+        "base_path": "/world/emergency-help-for-british-nationals-austria",
+        "document_type": "taxon",
+        "public_updated_at": "2017-06-29T08:13:46Z",
+        "schema_name": "taxon",
+        "withdrawn": false,
+        "description": "Get help if you're the victim of crime, you've been arrested, or are affected by a crisis abroad.",
+        "details": {
+          "internal_name": "Emergency help for British nationals (Austria)",
+          "notes_for_editors": "",
+          "visible_to_departmental_editors": true
+        },
+        "phase": "live",
+        "links": {
+          "parent_taxons": [
+            {
+              "content_id": "862fdd81-0b52-41c1-9aa0-e208ac86b763",
+              "title": "UK help and services in Austria",
+              "locale": "en",
+              "analytics_identifier": null,
+              "api_path": "/api/content/world/austria",
+              "base_path": "/world/austria",
+              "document_type": "taxon",
+              "public_updated_at": "2020-02-28T15:43:17Z",
+              "schema_name": "taxon",
+              "withdrawn": false,
+              "description": "Services if you're visiting, studying, working or living in Austria. Includes information about trading with and doing business in the UK and Austria, and your rights after the UK’s exit from the EU.",
+              "details": {
+                "internal_name": "UK help and services in Austria",
+                "notes_for_editors": "",
+                "visible_to_departmental_editors": false
+              },
+              "phase": "live",
+              "links": {
+                "parent_taxons": [
+                  {
+                    "content_id": "91b8ef20-74e7-4552-880c-50e6d73c2ff9",
+                    "title": "Help and services around the world",
+                    "locale": "en",
+                    "analytics_identifier": null,
+                    "api_path": "/api/content/world/all",
+                    "base_path": "/world/all",
+                    "document_type": "taxon",
+                    "public_updated_at": "2021-07-09T10:08:54Z",
+                    "schema_name": "taxon",
+                    "withdrawn": false,
+                    "description": "Help and services in a country",
+                    "details": {
+                      "url_override": "",
+                      "internal_name": "Help and services around the world",
+                      "notes_for_editors": "",
+                      "visible_to_departmental_editors": false
+                    },
+                    "phase": "live",
+                    "links": {}
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "world_locations": [
+      {
+        "content_id": "5e9ed0c6-7706-11e4-a3cb-005056011aef",
+        "title": "Austria",
+        "schema_name": "world_location",
+        "locale": "en",
+        "analytics_identifier": "WL9",
+        "links": {}
+      }
+    ],
+    "available_translations": [
+      {
+        "title": "Britische Botschaft Wien",
+        "public_updated_at": "2013-06-28T16:28:46Z",
+        "analytics_identifier": "WO26",
+        "document_type": "worldwide_organisation",
+        "schema_name": "worldwide_organisation",
+        "base_path": "/world/organisations/british-embassy-vienna.de",
+        "api_path": "/api/content/world/organisations/british-embassy-vienna.de",
+        "withdrawn": false,
+        "content_id": "f4c394f9-7a30-11e4-a3cb-005056011aef",
+        "locale": "de"
+      },
+      {
+        "title": "British Embassy Vienna",
+        "public_updated_at": "2013-06-28T16:28:46Z",
+        "analytics_identifier": "WO26",
+        "document_type": "worldwide_organisation",
+        "schema_name": "worldwide_organisation",
+        "base_path": "/world/organisations/british-embassy-vienna",
+        "api_path": "/api/content/world/organisations/british-embassy-vienna",
+        "withdrawn": false,
+        "content_id": "f4c394f9-7a30-11e4-a3cb-005056011aef",
+        "locale": "en"
+      }
+    ]
+  },
+  "user_journey_document_supertype": "thing",
+  "email_document_supertype": "other",
+  "government_document_supertype": "other",
+  "content_purpose_subgroup": "other",
+  "content_purpose_supergroup": "other",
+  "publishing_request_id": "21-1704200581.469-10.13.30.247-698",
+  "govuk_request_id": null,
+  "links": {
+    "corporate_information_pages": [
+      "5f552474-7631-11e4-a3cb-005056011aef",
+      "5f5524c0-7631-11e4-a3cb-005056011aef",
+      "5f5ba3fe-7631-11e4-a3cb-005056011aef"
+    ],
+    "home_page_offices": [
+      "4918dc76-c2ab-41eb-a01b-12dc4e68f498",
+      "7bbebbc6-9603-4013-aca2-2571fbb858bd"
+    ],
+    "main_office": [
+      "38718716-4295-4a3e-852a-64465ae6b9ff"
+    ],
+    "ordered_contacts": [
+      "5374dde9-e9b8-41ce-b677-2dcd745f74bf",
+      "deb4d143-aacc-4225-9fe9-a789421eb208",
+      "f39e39ba-1891-435f-abf2-b40b1d45780a",
+      "181a649d-7d85-4270-a8c0-bcdce377d597"
+    ],
+    "primary_role_person": [
+      "85330cee-c0f1-11e4-8223-005056011aef"
+    ],
+    "roles": [
+      "8461c054-c0f1-11e4-8223-005056011aef",
+      "1dd30ef9-699f-42bc-a835-04633ed81abe"
+    ],
+    "secondary_role_person": [
+      "d2fbbcbc-bc80-4c94-befe-3b43b9bb270a"
+    ],
+    "sponsoring_organisations": [
+      "f9fcf3fe-2751-4dca-97ca-becaeceb4b26"
+    ],
+    "taxons": [
+      "f1744c25-bbae-42d5-b0fa-452ccea8f802",
+      "ca97c97d-30c3-4c31-86d5-a84fb37f919a"
+    ],
+    "world_locations": [
+      "5e9ed0c6-7706-11e4-a3cb-005056011aef"
+    ]
+  },
+  "payload_version": "12345"
+}

--- a/spec/integration/document_synchronization_spec.rb
+++ b/spec/integration/document_synchronization_spec.rb
@@ -172,6 +172,35 @@ RSpec.describe "Document synchronization" do
     end
   end
 
+  describe "for an 'worldwide_organisation' message" do
+    let(:payload) { json_fixture_as_hash("message_queue/worldwide_organisation_message.json") }
+
+    it "is added to Discovery Engine through the Put service" do
+      expect(put_service).to have_received(:call).with(
+        "f4c394f9-7a30-11e4-a3cb-005056011aef",
+        {
+          content_id: "f4c394f9-7a30-11e4-a3cb-005056011aef",
+          title: "British Embassy Vienna",
+          description: "The British Embassy in Vienna maintains and develops relations between the UK and Austria.",
+          link: "/world/organisations/british-embassy-vienna",
+          url: "https://www.gov.uk/world/organisations/british-embassy-vienna",
+          public_timestamp: 1_372_436_926,
+          document_type: "worldwide_organisation",
+          is_historic: 0,
+          part_of_taxonomy_tree: %w[
+            f1744c25-bbae-42d5-b0fa-452ccea8f802
+            ca97c97d-30c3-4c31-86d5-a84fb37f919a
+          ],
+          world_locations: %w[austria],
+          content_purpose_supergroup: "other",
+          locale: "en",
+        },
+        content: a_string_including("maintains and develops relations between the UK and Austria"),
+        payload_version: 12_345,
+      )
+    end
+  end
+
   describe "for an 'independent_report' message" do
     let(:payload) { json_fixture_as_hash("message_queue/independent_report_message.json") }
 

--- a/spec/models/concerns/publishing_api/metadata_spec.rb
+++ b/spec/models/concerns/publishing_api/metadata_spec.rb
@@ -215,6 +215,29 @@ RSpec.describe PublishingApi::Metadata do
       it { is_expected.to eq("en") }
     end
 
+    describe "world_locations" do
+      subject(:extracted_world_locations) { extracted_metadata[:world_locations] }
+
+      let(:document_hash) { { expanded_links: { world_locations: } } }
+
+      context "without world locations" do
+        let(:world_locations) { nil }
+
+        it { is_expected.to be_nil }
+      end
+
+      context "with world locations" do
+        let(:world_locations) do
+          [
+            { title: "World Location 1" },
+            { title: "World Location 2" },
+          ]
+        end
+
+        it { is_expected.to eq(%w[world-location-1 world-location-2]) }
+      end
+    end
+
     describe "parts" do
       subject(:extracted_parts) { extracted_metadata[:parts] }
 


### PR DESCRIPTION
This is used by Finder Frontend's "secret" query param filters.

- Add logic for extracting field from `publishing-api` documents
- Add `worldwide_organisation` example message and integration test