### PR TITLE
Include `organisations` field in synced documents

### DIFF
--- a/app/models/concerns/publishing_api/metadata.rb
+++ b/app/models/concerns/publishing_api/metadata.rb
@@ -20,6 +20,7 @@ module PublishingApi
         organisation_state:,
         locale: document_hash[:locale],
         world_locations:,
+        organisations:,
         parts:,
       }.compact_blank
     end
@@ -73,6 +74,21 @@ module PublishingApi
       document_hash
         .dig(:expanded_links, :world_locations)
         &.map { _1[:title].parameterize }
+    end
+
+    def organisations
+      # This isn't great, but it replicates the behaviour of the v1 search-api which also takes the
+      # last part of the slug and adds in an organisation value if the document itself represents an
+      # organisation.
+      organisation_links = document_hash.dig(:expanded_links, :organisations) || []
+
+      organisation_links
+        .map { _1[:base_path].split("/").last }
+        .tap do |links|
+          if document_hash[:document_type] == "organisation"
+            links << document_hash[:base_path].split("/").last
+          end
+        end
     end
 
     def parts

--- a/spec/integration/document_synchronization_spec.rb
+++ b/spec/integration/document_synchronization_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe "Document synchronization" do
           government_name: "2015 Conservative government",
           content_purpose_supergroup: "news_and_communications",
           part_of_taxonomy_tree: %w[37d0fa26-abed-4c74-8835-b3b51ae1c8b2],
+          organisations: %w[government-digital-service],
           locale: "en",
         },
         content: a_string_including("<div class=\"govspeak\"><p>The UK was represented remotely"),
@@ -58,6 +59,7 @@ RSpec.describe "Document synchronization" do
           part_of_taxonomy_tree: %w[
             8f78544f-a4ed-46b4-8163-889679d119b9 71cd9f51-f492-4c3f-91ca-5ad694c26592
           ],
+          organisations: %w[foreign-commonwealth-development-office],
           locale: "en",
           parts: [
             {
@@ -115,6 +117,7 @@ RSpec.describe "Document synchronization" do
             ce9e9802-6138-4fe9-9f33-045ef213be29
             3dbeb4a3-33c0-4bda-bd21-b721b0f8736f
           ],
+          organisations: %w[foreign-commonwealth-office],
           locale: "en",
         },
         content: a_string_including("<div class=\"govspeak\"><p>In the UEFA Champions"),
@@ -139,6 +142,7 @@ RSpec.describe "Document synchronization" do
           document_type: "manual_section",
           is_historic: 0,
           content_purpose_supergroup: "guidance_and_regulation",
+          organisations: %w[driver-and-vehicle-standards-agency],
           locale: "en",
         },
         content: a_string_matching(/<h2 id="section-6-1">6\.1\. Structure.+<\/table>\n\n/m),
@@ -164,6 +168,7 @@ RSpec.describe "Document synchronization" do
           is_historic: 0,
           organisation_state: "live",
           content_purpose_supergroup: "other",
+          organisations: %w[legal-aid-agency],
           locale: "en",
         },
         content: a_string_including("LAA\n<div class=\"govspeak\"><p>We provide civil"),
@@ -219,6 +224,7 @@ RSpec.describe "Document synchronization" do
           government_name: "2010 to 2015 Conservative and Liberal Democrat coalition government",
           content_purpose_supergroup: "research_and_statistics",
           part_of_taxonomy_tree: %w[f3caf326-fe33-410f-b7f4-553f4011c81e],
+          organisations: %w[cabinet-office efficiency-and-reform-group government-digital-service],
           locale: "en",
         },
         content: a_string_including(<<~TEXT.chomp),

--- a/spec/models/concerns/publishing_api/metadata_spec.rb
+++ b/spec/models/concerns/publishing_api/metadata_spec.rb
@@ -238,6 +238,35 @@ RSpec.describe PublishingApi::Metadata do
       end
     end
 
+    describe "organisations" do
+      subject(:extracted_organisations) { extracted_metadata[:organisations] }
+
+      let(:document_hash) { { expanded_links: { organisations: } } }
+
+      context "without organisations" do
+        let(:organisations) { nil }
+
+        it { is_expected.to be_nil }
+      end
+
+      context "with organisations" do
+        let(:organisations) do
+          [
+            { base_path: "/government/organisations/ministry-of-magic" },
+            { base_path: "/government/organisations/ministry-of-silly-walks" },
+          ]
+        end
+
+        it { is_expected.to eq(%w[ministry-of-magic ministry-of-silly-walks]) }
+      end
+
+      context "when the document itself is an organisation" do
+        let(:document_hash) { { document_type: "organisation", base_path: "/government/foo/ministry-of-sound" } }
+
+        it { is_expected.to eq(%w[ministry-of-sound]) }
+      end
+    end
+
     describe "parts" do
       subject(:extracted_parts) { extracted_metadata[:parts] }
 


### PR DESCRIPTION
This is used by Finder Frontend's "secret" query param filters.

- Add logic for extracting field from publishing-api documents