### PR TITLE
Include `topical_events` field in synced documents

### DIFF
--- a/app/models/concerns/publishing_api/metadata.rb
+++ b/app/models/concerns/publishing_api/metadata.rb
@@ -21,6 +21,7 @@ module PublishingApi
         locale: document_hash[:locale],
         world_locations:,
         organisations:,
+        topical_events:,
         parts:,
       }.compact_blank
     end
@@ -89,6 +90,15 @@ module PublishingApi
             links << document_hash[:base_path].split("/").last
           end
         end
+    end
+
+    def topical_events
+      # This isn't great, but there is no slug coming through from publishing-api and the v1
+      # search-api also manually generates slugs for topical events by taking the last part of the
+      # base_path.
+      document_hash
+        .dig(:expanded_links, :topical_events)
+        &.map { _1[:base_path].split("/").last }
     end
 
     def parts

--- a/docs/development_tips.md
+++ b/docs/development_tips.md
@@ -7,5 +7,5 @@ to add a new integration test JSON fixture.
 ```ruby
 edition = Document.find_by(content_id: "<CONTENT-UUID>").live
 payload = DownstreamPayload.new(edition, "12345").message_queue_payload # "12345" is the payload ID
-payload.to_json
+puts payload.to_json
 ```

--- a/spec/fixtures/files/message_queue/speech_message.json
+++ b/spec/fixtures/files/message_queue/speech_message.json
@@ -1,0 +1,350 @@
+{
+  "title": "Service of thanksgiving for the life of Her Majesty Queen Elizabeth II at the Washington National Cathedral",
+  "public_updated_at": "2022-09-21T21:15:00Z",
+  "publishing_app": "whitehall",
+  "rendering_app": "government-frontend",
+  "update_type": "republish",
+  "phase": "live",
+  "analytics_identifier": null,
+  "document_type": "speech",
+  "schema_name": "speech",
+  "first_published_at": "2022-09-21T21:15:00Z",
+  "base_path": "/government/speeches/a-service-of-thanksgiving-for-the-life-of-her-majesty-queen-elizabeth-ii-at-the-washington-national-cathedral",
+  "description": "British Ambassador to the USA Dame Karen Pierce DCMG, spoke at the service of thanksgiving for the life of Her Majesty Queen Elizabeth II.",
+  "details": {
+    "body": "\u003cdiv class=\"govspeak\"\u003e\u003cp\u003eMadam Vice President; Madame Speaker; Leader McCarthy; Governors; Senators; Justices; esteemed colleagues from Realms and the Commonwealth; and the Diplomatic Corps, welcome and thank you all for joining us today.\u003c/p\u003e\n\n\u003cp\u003eI would also like to thank Dean Randolph Hollerith and the Washington National Cathedral, the Bishop and Presiding Bishop, for holding this service in honour of Her Late Majesty The Queen. Their consideration and efforts in a short space of time have been outstanding. We salute too and thank the wonderful Colour Guards and musicians.\u003c/p\u003e\n\n\u003cp\u003eThe Queen was a great friend and admirer of the United States. She paid some 6 official visits in total – many more to the Kentucky stables – addressing Congress as well as speaking to Presidents and attending football and baseball games and commemorative events such as America’s Bicentennial and the 400th anniversary of the Jamestown settlement. She well understood the affinity between the US and the UK stressing not just out common heritage and kinship but our common values. To Congress she said that “some people believe that power grows from the barrel of a gun. We have gone a better way; our societies rest on mutual agreement, on contract and on consensus.”\u003c/p\u003e\n\n\u003cp\u003eThe values she personified and the traditions she upheld are fundamentally in their essence the same that underpin America and her institutions, indeed guide the Commonwealth and all those who cherish democracy. She was proud that the values begun by the Magna Carta had their vivid restatement through the Founding Fathers.\u003c/p\u003e\n\n\u003cp\u003eThat is why, I think, her death has touched so many people round the world and especially here. As America celebrated with us The Queen’s 70 years on the throne earlier this year, so America has mourned in solidarity. We have been humbled and honoured by the immense number of tributes – from the President and First Lady  and you Madam Vice President being some of the first world leaders to  come in person to sign the condolence book,  through to the 2 House and Senate Resolutions and the presentation by you Madam Speaker of the Stars and Stripes that flew at half-mast over the Capitol, to the many tributes from governors and mayors, the Empire State lit in purple and silver;  the Union Jack flag lowered to half-mast at the site of the battle of New Orleans – the last time US and UK militaries fought as enemies – with her deep sense of history I think she would have liked – to the flowers and messages from ordinary Americans some of whom queued for hours at the Embassy.\u003c/p\u003e\n\n\u003cp\u003eThis affinity was exemplified by The Queen’s ordering - after 9/11, whose anniversary we commemorated recently – the Star Spangled Banner to be played at Buckingham Palace and the Star and Stripes to be flown on the 10 and 20th anniversaries at half-mast.\u003c/p\u003e\n\n\u003cp\u003eIn a moving reciprocal gesture Mayor Bowser ordered Union Jacks to fly at half-mast along Pennsylvania Avenue. We thank you from King Charles and The Royal Family down for these amazing tributes. That the President was the first sitting President we believe to attend a State Funeral is another deep honour. The tributes from all former Presidents have been very moving.\u003c/p\u003e\n\n\u003cp\u003eThis is a service of thanksgiving. There have been plenty of lively and happy stories about The Queen. Many people in this Cathedral today have met her whether in America, in the Realms and Commonwealth and other countries or in the UK. You know her dignity, her warmth and kindnesses but also her quick-wittedness, her mischievous smile. My favourite story out of so many concerns an agricultural show in the east of the UK. One of the exhibitors went up to a middle-aged lady in a headscarf and tweeds. “Excuse me”, said the exhibitor, “but you do look an awful lot like The Queen”. “How very reassuring”, The Queen replied.\u003c/p\u003e\n\n\u003cp\u003eShe sought to move with the times. She was the archetypal Bond Girl, parachuting into the London Olympics; she poured tea for Paddington Bear as well as heads of state, and here in the US she was honoured to receive the Ruth Bader Ginsburg award for Women in Leadership – one of the very few times, we believe, that she accepted a non-State award – you can check it out on the Buckingham Palace YouTube entry.\u003c/p\u003e\n\n\u003cp\u003ePresident Biden said that The Queen defined an era. I think that nails it. She was a remarkable woman – coming to the throne at 25; she saw decades of history and met hundreds of world leaders including 13 of 14 US Presidents during her reign;  she was present at the opening of the United Nations in London. She was very proud to head the Commonwealth. Whenever I met The Queen or even saw her on TV she seemed to embody the whole nation and its long history. The human and the heroic coming together in one extraordinary person, exemplified so well by the majesty and history of Monday’s State Funeral.\u003c/p\u003e\n\n\u003cp\u003eI would like to close by remarking on that duty and public service. Her now famous pledge at the age of  21 to devote her whole life “whether it be long or short ..to your service”  still  has the power to animate us today and has been clearly restated by the new King Charles III. We are grateful for her long life and, as King Charles said, “we draw strength from the light of her example”.\u003c/p\u003e\n\n\u003cp\u003eFor me personally, it has been an immense honour to serve as Her Majesty’s Ambassador from Afghanistan to America, and points in-between. The Embassy and I are now very proud to serve our new King.\u003c/p\u003e\n\n\u003cp\u003eThank you.\u003c/p\u003e\n\n\u003ch2 id=\"full-service-of-thanksgiving-on-the-washington-national-cathedrals-youtube-channel\"\u003eFull service of thanksgiving on The Washington National Cathedral’s YouTube channel\u003c/h2\u003e\n\n\u003cp\u003e\u003ca rel=\"external\" href=\"https://www.youtube.com/watch?v=GgJz0FVaLXc\" class=\"govuk-link\"\u003eService of thanksgiving for the life of Her Majesty Queen Elizabeth II at the Washington National Cathedral\u003c/a\u003e.\u003c/p\u003e\n\u003c/div\u003e",
+    "image": {
+      "url": "https://assets.publishing.service.gov.uk/media/632c32f2d3bf7f75c989d93d/hma_hmtq_service_thanksgiving.jpg",
+      "alt_text": ""
+    },
+    "location": "The Washington National Cathedral, Washington, DC",
+    "political": true,
+    "delivered_on": "2022-09-21T00:00:00+01:00",
+    "change_history": [
+      {
+        "note": "First published.",
+        "public_timestamp": "2022-09-21T22:15:00.000+01:00"
+      }
+    ],
+    "first_public_at": "2022-09-21T22:15:00.000+01:00",
+    "speech_type_explanation": "Transcript of the speech, exactly as it was delivered"
+  },
+  "routes": [
+    {
+      "path": "/government/speeches/a-service-of-thanksgiving-for-the-life-of-her-majesty-queen-elizabeth-ii-at-the-washington-national-cathedral",
+      "type": "exact"
+    }
+  ],
+  "redirects": [],
+  "content_id": "5fac6be0-146e-40ea-a899-c3299f62eff9",
+  "locale": "en",
+  "expanded_links": {
+    "government": [
+      {
+        "content_id": "d4fbc1b9-d47d-4386-af04-ac909f868f92",
+        "title": "2015 Conservative government",
+        "locale": "en",
+        "api_path": "/api/content/government/2015-conservative-government",
+        "base_path": "/government/2015-conservative-government",
+        "document_type": "government",
+        "details": {
+          "started_on": "2015-05-08T00:00:00+00:00",
+          "ended_on": null,
+          "current": true
+        },
+        "links": {}
+      }
+    ],
+    "organisations": [
+      {
+        "content_id": "f9fcf3fe-2751-4dca-97ca-becaeceb4b26",
+        "title": "Foreign, Commonwealth \u0026 Development Office",
+        "locale": "en",
+        "analytics_identifier": "D1315",
+        "api_path": "/api/content/government/organisations/foreign-commonwealth-development-office",
+        "base_path": "/government/organisations/foreign-commonwealth-development-office",
+        "document_type": "organisation",
+        "schema_name": "organisation",
+        "withdrawn": false,
+        "details": {
+          "acronym": "FCDO",
+          "logo": {
+            "crest": "single-identity",
+            "formatted_title": "Foreign, Commonwealth\u003cbr/\u003e\u0026amp; Development Office"
+          },
+          "brand": "foreign-commonwealth-development-office",
+          "default_news_image": {
+            "url": "https://assets.publishing.service.gov.uk/media/621e4de48fa8f5490aff83b4/s300_fcdo-main-building.jpg",
+            "high_resolution_url": "https://assets.publishing.service.gov.uk/media/621e4de4e90e0710be0354d7/s960_fcdo-main-building.jpg"
+          },
+          "organisation_govuk_status": {
+            "url": null,
+            "status": "live",
+            "updated_at": null
+          }
+        },
+        "links": {}
+      }
+    ],
+    "original_primary_publishing_organisation": [
+      {
+        "content_id": "f9fcf3fe-2751-4dca-97ca-becaeceb4b26",
+        "title": "Foreign, Commonwealth \u0026 Development Office",
+        "locale": "en",
+        "analytics_identifier": "D1315",
+        "api_path": "/api/content/government/organisations/foreign-commonwealth-development-office",
+        "base_path": "/government/organisations/foreign-commonwealth-development-office",
+        "document_type": "organisation",
+        "schema_name": "organisation",
+        "withdrawn": false,
+        "details": {
+          "acronym": "FCDO",
+          "logo": {
+            "crest": "single-identity",
+            "formatted_title": "Foreign, Commonwealth\u003cbr/\u003e\u0026amp; Development Office"
+          },
+          "brand": "foreign-commonwealth-development-office",
+          "default_news_image": {
+            "url": "https://assets.publishing.service.gov.uk/media/621e4de48fa8f5490aff83b4/s300_fcdo-main-building.jpg",
+            "high_resolution_url": "https://assets.publishing.service.gov.uk/media/621e4de4e90e0710be0354d7/s960_fcdo-main-building.jpg"
+          },
+          "organisation_govuk_status": {
+            "url": null,
+            "status": "live",
+            "updated_at": null
+          }
+        },
+        "links": {}
+      }
+    ],
+    "people": [
+      {
+        "content_id": "8532daf3-c0f1-11e4-8223-005056011aef",
+        "title": "Karen Pierce DCMG",
+        "locale": "en",
+        "analytics_identifier": null,
+        "api_path": "/api/content/government/people/karen-pierce",
+        "base_path": "/government/people/karen-pierce",
+        "document_type": "person",
+        "public_updated_at": "2020-08-18T13:40:05Z",
+        "schema_name": "person",
+        "withdrawn": false,
+        "links": {}
+      }
+    ],
+    "primary_publishing_organisation": [
+      {
+        "content_id": "f9fcf3fe-2751-4dca-97ca-becaeceb4b26",
+        "title": "Foreign, Commonwealth \u0026 Development Office",
+        "locale": "en",
+        "analytics_identifier": "D1315",
+        "api_path": "/api/content/government/organisations/foreign-commonwealth-development-office",
+        "base_path": "/government/organisations/foreign-commonwealth-development-office",
+        "document_type": "organisation",
+        "schema_name": "organisation",
+        "withdrawn": false,
+        "details": {
+          "acronym": "FCDO",
+          "logo": {
+            "crest": "single-identity",
+            "formatted_title": "Foreign, Commonwealth\u003cbr/\u003e\u0026amp; Development Office"
+          },
+          "brand": "foreign-commonwealth-development-office",
+          "default_news_image": {
+            "url": "https://assets.publishing.service.gov.uk/media/621e4de48fa8f5490aff83b4/s300_fcdo-main-building.jpg",
+            "high_resolution_url": "https://assets.publishing.service.gov.uk/media/621e4de4e90e0710be0354d7/s960_fcdo-main-building.jpg"
+          },
+          "organisation_govuk_status": {
+            "url": null,
+            "status": "live",
+            "updated_at": null
+          }
+        },
+        "links": {}
+      }
+    ],
+    "roles": [
+      {
+        "content_id": "8464e2a4-c0f1-11e4-8223-005056011aef",
+        "title": "British Ambassador to the USA",
+        "locale": "en",
+        "analytics_identifier": null,
+        "api_path": null,
+        "base_path": null,
+        "document_type": "ambassador_role",
+        "public_updated_at": "2022-09-13T18:43:23Z",
+        "schema_name": "role",
+        "withdrawn": false,
+        "details": {
+          "body": [
+            {
+              "content": "The Ambassador represents His Majesty The King and the UK government in the country to which they are appointed. They are responsible for the direction and work of the Embassy and its Consulates, including political work, trade and investment, press and cultural relations, and visa and consular services.",
+              "content_type": "text/govspeak"
+            },
+            {
+              "content_type": "text/html",
+              "content": "\u003cp\u003eThe Ambassador represents His Majesty The King and the UK government in the country to which they are appointed. They are responsible for the direction and work of the Embassy and its Consulates, including political work, trade and investment, press and cultural relations, and visa and consular services.\u003c/p\u003e\n"
+            }
+          ],
+          "role_payment_type": null
+        },
+        "links": {}
+      }
+    ],
+    "speaker": [
+      {
+        "content_id": "8532daf3-c0f1-11e4-8223-005056011aef",
+        "title": "Karen Pierce DCMG",
+        "locale": "en",
+        "analytics_identifier": null,
+        "api_path": "/api/content/government/people/karen-pierce",
+        "base_path": "/government/people/karen-pierce",
+        "document_type": "person",
+        "public_updated_at": "2020-08-18T13:40:05Z",
+        "schema_name": "person",
+        "withdrawn": false,
+        "links": {}
+      }
+    ],
+    "taxons": [
+      {
+        "content_id": "d6dba75a-42bd-4e1e-984c-2bddb6b41951",
+        "title": "Foreign affairs",
+        "locale": "en",
+        "analytics_identifier": null,
+        "api_path": "/api/content/international/foreign-affairs",
+        "base_path": "/international/foreign-affairs",
+        "document_type": "taxon",
+        "public_updated_at": "2018-09-05T16:14:19Z",
+        "schema_name": "taxon",
+        "withdrawn": false,
+        "description": null,
+        "details": {
+          "internal_name": "Foreign affairs [P]",
+          "notes_for_editors": "",
+          "visible_to_departmental_editors": false
+        },
+        "phase": "live",
+        "links": {
+          "parent_taxons": [
+            {
+              "content_id": "37d0fa26-abed-4c74-8835-b3b51ae1c8b2",
+              "title": "International",
+              "locale": "en",
+              "analytics_identifier": null,
+              "api_path": "/api/content/international",
+              "base_path": "/international",
+              "document_type": "taxon",
+              "public_updated_at": "2018-09-16T20:30:28Z",
+              "schema_name": "taxon",
+              "withdrawn": false,
+              "description": "",
+              "details": {
+                "internal_name": "International",
+                "notes_for_editors": "",
+                "visible_to_departmental_editors": true
+              },
+              "phase": "live",
+              "links": {
+                "root_taxon": [
+                  {
+                    "content_id": "f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a",
+                    "title": "GOV.UK homepage",
+                    "locale": "en",
+                    "analytics_identifier": null,
+                    "api_path": "/api/content/",
+                    "base_path": "/",
+                    "document_type": "homepage",
+                    "public_updated_at": "2023-06-28T09:32:34Z",
+                    "schema_name": "homepage",
+                    "withdrawn": false,
+                    "links": {}
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "topical_events": [
+      {
+        "content_id": "7feaef73-a6a8-484a-8915-6efbbe4a8269",
+        "title": "Her Majesty Queen Elizabeth II",
+        "locale": "en",
+        "analytics_identifier": null,
+        "api_path": "/api/content/government/topical-events/her-majesty-queen-elizabeth-ii",
+        "base_path": "/government/topical-events/her-majesty-queen-elizabeth-ii",
+        "document_type": "topical_event",
+        "public_updated_at": "2022-09-20T12:52:47Z",
+        "schema_name": "topical_event",
+        "withdrawn": false,
+        "links": {}
+      }
+    ],
+    "world_locations": [
+      {
+        "content_id": "5e9f2825-7706-11e4-a3cb-005056011aef",
+        "title": "USA",
+        "schema_name": "world_location",
+        "locale": "en",
+        "analytics_identifier": "WL157",
+        "links": {}
+      }
+    ],
+    "available_translations": [
+      {
+        "title": "Service of thanksgiving for the life of Her Majesty Queen Elizabeth II at the Washington National Cathedral",
+        "public_updated_at": "2022-09-21T21:15:00Z",
+        "analytics_identifier": null,
+        "document_type": "speech",
+        "schema_name": "speech",
+        "base_path": "/government/speeches/a-service-of-thanksgiving-for-the-life-of-her-majesty-queen-elizabeth-ii-at-the-washington-national-cathedral",
+        "api_path": "/api/content/government/speeches/a-service-of-thanksgiving-for-the-life-of-her-majesty-queen-elizabeth-ii-at-the-washington-national-cathedral",
+        "withdrawn": false,
+        "content_id": "5fac6be0-146e-40ea-a899-c3299f62eff9",
+        "locale": "en"
+      }
+    ]
+  },
+  "user_journey_document_supertype": "thing",
+  "email_document_supertype": "announcements",
+  "government_document_supertype": "speeches",
+  "content_purpose_subgroup": "speeches_and_statements",
+  "content_purpose_supergroup": "news_and_communications",
+  "publishing_request_id": "21-1701445948.256-10.13.34.39-698",
+  "govuk_request_id": null,
+  "links": {
+    "government": [
+      "d4fbc1b9-d47d-4386-af04-ac909f868f92"
+    ],
+    "organisations": [
+      "f9fcf3fe-2751-4dca-97ca-becaeceb4b26"
+    ],
+    "original_primary_publishing_organisation": [
+      "f9fcf3fe-2751-4dca-97ca-becaeceb4b26"
+    ],
+    "people": [
+      "8532daf3-c0f1-11e4-8223-005056011aef"
+    ],
+    "primary_publishing_organisation": [
+      "f9fcf3fe-2751-4dca-97ca-becaeceb4b26"
+    ],
+    "roles": [
+      "8464e2a4-c0f1-11e4-8223-005056011aef"
+    ],
+    "speaker": [
+      "8532daf3-c0f1-11e4-8223-005056011aef"
+    ],
+    "taxons": [
+      "d6dba75a-42bd-4e1e-984c-2bddb6b41951"
+    ],
+    "topical_events": [
+      "7feaef73-a6a8-484a-8915-6efbbe4a8269"
+    ],
+    "world_locations": [
+      "5e9f2825-7706-11e4-a3cb-005056011aef"
+    ]
+  },
+  "payload_version": "12345"
+}

--- a/spec/integration/document_synchronization_spec.rb
+++ b/spec/integration/document_synchronization_spec.rb
@@ -267,6 +267,35 @@ RSpec.describe "Document synchronization" do
     end
   end
 
+  describe "for a 'speech' message" do
+    let(:payload) { json_fixture_as_hash("message_queue/speech_message.json") }
+
+    it "is added to Discovery Engine through the Put service" do
+      expect(put_service).to have_received(:call).with(
+        "5fac6be0-146e-40ea-a899-c3299f62eff9",
+        {
+          content_id: "5fac6be0-146e-40ea-a899-c3299f62eff9",
+          title: "Service of thanksgiving for the life of Her Majesty Queen Elizabeth II at the Washington National Cathedral",
+          description: "British Ambassador to the USA Dame Karen Pierce DCMG, spoke at the service of thanksgiving for the life of Her Majesty Queen Elizabeth II.",
+          link: "/government/speeches/a-service-of-thanksgiving-for-the-life-of-her-majesty-queen-elizabeth-ii-at-the-washington-national-cathedral",
+          url: "https://www.gov.uk/government/speeches/a-service-of-thanksgiving-for-the-life-of-her-majesty-queen-elizabeth-ii-at-the-washington-national-cathedral",
+          public_timestamp: 1_663_794_900,
+          government_name: "2015 Conservative government",
+          organisations: %w[foreign-commonwealth-development-office],
+          document_type: "speech",
+          is_historic: 0,
+          part_of_taxonomy_tree: %w[d6dba75a-42bd-4e1e-984c-2bddb6b41951],
+          world_locations: %w[usa],
+          topical_events: %w[her-majesty-queen-elizabeth-ii],
+          content_purpose_supergroup: "news_and_communications",
+          locale: "en",
+        },
+        content: a_string_including("Service of thanksgiving for the life of Her Majesty Queen Elizabeth II"),
+        payload_version: 12_345,
+      )
+    end
+  end
+
   describe "for an 'external_content' message" do
     let(:payload) { json_fixture_as_hash("message_queue/external_content_message.json") }
 

--- a/spec/models/concerns/publishing_api/metadata_spec.rb
+++ b/spec/models/concerns/publishing_api/metadata_spec.rb
@@ -267,6 +267,29 @@ RSpec.describe PublishingApi::Metadata do
       end
     end
 
+    describe "topical_events" do
+      subject(:extracted_topical_events) { extracted_metadata[:topical_events] }
+
+      let(:document_hash) { { expanded_links: { topical_events: } } }
+
+      context "without topical events" do
+        let(:topical_events) { nil }
+
+        it { is_expected.to be_nil }
+      end
+
+      context "with topical events" do
+        let(:topical_events) do
+          [
+            { base_path: "/government/topical-events/harry-potter-convention" },
+            { base_path: "/government/topical-events/eras-tour" },
+          ]
+        end
+
+        it { is_expected.to eq(%w[harry-potter-convention eras-tour]) }
+      end
+    end
+
     describe "parts" do
       subject(:extracted_parts) { extracted_metadata[:parts] }
 


### PR DESCRIPTION
This is used by Finder Frontend's "secret" query param filters.

- Add logic for extracting field from publishing-api documents
- Add speech example message and integration test