### PR TITLE
Include `manual` field in synced documents

### DIFF
--- a/app/models/concerns/publishing_api/metadata.rb
+++ b/app/models/concerns/publishing_api/metadata.rb
@@ -22,6 +22,7 @@ module PublishingApi
         world_locations:,
         organisations:,
         topical_events:,
+        manual:,
         parts:,
       }.compact_blank
     end
@@ -99,6 +100,13 @@ module PublishingApi
       document_hash
         .dig(:expanded_links, :topical_events)
         &.map { _1[:base_path].split("/").last }
+    end
+
+    def manual
+      document_hash
+        .dig(:expanded_links, :manual)
+        &.first
+        &.dig(:base_path)
     end
 
     def parts

--- a/spec/integration/document_synchronization_spec.rb
+++ b/spec/integration/document_synchronization_spec.rb
@@ -143,6 +143,7 @@ RSpec.describe "Document synchronization" do
           is_historic: 0,
           content_purpose_supergroup: "guidance_and_regulation",
           organisations: %w[driver-and-vehicle-standards-agency],
+          manual: "/guidance/mot-inspection-manual-for-private-passenger-and-light-commercial-vehicles",
           locale: "en",
         },
         content: a_string_matching(/<h2 id="section-6-1">6\.1\. Structure.+<\/table>\n\n/m),

--- a/spec/models/concerns/publishing_api/metadata_spec.rb
+++ b/spec/models/concerns/publishing_api/metadata_spec.rb
@@ -290,6 +290,24 @@ RSpec.describe PublishingApi::Metadata do
       end
     end
 
+    describe "manual" do
+      subject(:extracted_manual) { extracted_metadata[:manual] }
+
+      let(:document_hash) { { expanded_links: { manual: } } }
+
+      context "without a manual" do
+        let(:manual) { nil }
+
+        it { is_expected.to be_nil }
+      end
+
+      context "with a manual" do
+        let(:manual) { [{ base_path: "/guidance/reticulating-splines" }] }
+
+        it { is_expected.to eq("/guidance/reticulating-splines") }
+      end
+    end
+
     describe "parts" do
       subject(:extracted_parts) { extracted_metadata[:parts] }
 


### PR DESCRIPTION
This is used by Finder Frontend's "secret" query param filters.

- Add logic for extracting field from `publishing-api` documents