### PR TITLE
Turn `attachments` into `parts`

### DIFF
--- a/app/models/concerns/publishing_api/metadata.rb
+++ b/app/models/concerns/publishing_api/metadata.rb
@@ -114,6 +114,10 @@ module PublishingApi
     end
 
     def parts
+      parts_from_parts || parts_from_attachments
+    end
+
+    def parts_from_parts
       document_hash
         .dig(:details, :parts)
         &.map do
@@ -123,6 +127,30 @@ module PublishingApi
             body: BodyContent.new(_1[:body]).summarized_text_content,
           }
         end
+    end
+
+    def parts_from_attachments
+      document_hash
+        .dig(:details, :attachments)
+        &.map {
+          # Skip any attachments that aren't directly nested underneath this document
+          #
+          # This is replicated from v1 search-api behaviour, and is a workaround for the fact that
+          # the consumers always expect a slug rather than a URL, so parts cannot have a URL that
+          # doesn't match the document's base path.
+          next unless _1[:url].start_with?(document_hash[:base_path])
+
+          # The slug for a part from an attachment is the part of the URL that comes after the
+          # parent document's base path.
+          slug = _1[:url].sub(document_hash[:base_path], "").sub(%r{^/}, "").sub(%r{/$}, "")
+          {
+            slug:,
+            title: _1[:title],
+            # TODO: We don't receive any body content for attachments as part of the message from
+            # publishing-api. This needs to be fetched from publishing-api separately.
+            body: "",
+          }
+        }&.compact_blank
     end
   end
 end

--- a/spec/fixtures/files/message_queue/guidance_message.json
+++ b/spec/fixtures/files/message_queue/guidance_message.json
@@ -1,0 +1,963 @@
+{
+  "title": "Equality Act 2010: how it might affect you",
+  "public_updated_at": "2013-03-08T11:45:45Z",
+  "publishing_app": "whitehall",
+  "rendering_app": "government-frontend",
+  "update_type": "minor",
+  "phase": "live",
+  "analytics_identifier": null,
+  "document_type": "guidance",
+  "schema_name": "publication",
+  "first_published_at": "2011-06-21T23:00:00Z",
+  "base_path": "/government/publications/equality-act-guidance",
+  "description": "How the Equality Act 2010 defines disability, and what law changes mean for the public, businesses, and the public and voluntary sectors.",
+  "details": {
+    "body": "\u003cdiv class=\"govspeak\"\u003e\u003cp\u003eThese guides explain the main changes in the law as a result of the Equality Act 2010.\u003c/p\u003e\n\n\u003cdiv class=\"call-to-action\"\u003e\n  \u003ch3 id=\"positive-action-guidance\"\u003ePositive action guidance\u003c/h3\u003e\n\n  \u003cp\u003eUpdated guidance for employers on \u003ca href=\"https://www.gov.uk/government/publications/positive-action-in-the-workplace-guidance-for-employers\" class=\"govuk-link\"\u003epositive action in the workplace\u003c/a\u003e was published in April 2023.\u003c/p\u003e\n\u003c/div\u003e\n\u003c/div\u003e",
+    "tags": {
+      "topics": [],
+      "browse_pages": []
+    },
+    "documents": [
+      "\u003csection class=\"gem-c-attachment govuk-!-display-none-print govuk-!-margin-bottom-6\" data-module=\"ga4-link-tracker\"\u003e\n  \u003cdiv class=\"gem-c-attachment__thumbnail\"\u003e\n    \u003ca class=\"govuk-link\" target=\"_self\" tabindex=\"-1\" aria-hidden=\"true\" data-ga4-link=\"{\u0026quot;event_name\u0026quot;:\u0026quot;navigation\u0026quot;,\u0026quot;type\u0026quot;:\u0026quot;attachment\u0026quot;}\" href=\"/government/publications/equality-act-guidance/disability-equality-act-2010-guidance-on-matters-to-be-taken-into-account-in-determining-questions-relating-to-the-definition-of-disability-html\"\u003e\n        \u003csvg class=\"gem-c-attachment__thumbnail-image gem-c-attachment__thumbnail-image--html\" version=\"1.1\" viewBox=\"0 0 99 140\" width=\"99\" height=\"140\" aria-hidden=\"true\"\u003e\n  \u003cpath d=\"M30,95h57v9H30V95z M30,77v9h39v-9H30z M30,122h48v-9H30V122z M12,68h9v-9h-9V68z M12,104h9v-9h-9V104z M12,86h9v-9h-9V86z M12,122h9v-9h-9V122z M87,12v27H12V12H87z M33,17h-4v8h-6v-8h-4v18h4v-7l6,0v7l4,0V17z M49,17H35l0,3h5v15h4V20l5,0V17z M68,17h-4 l-5,6l-5-6h-4v18h4l0-12l5,6l5-6l0,12h4V17z M81,32h-6V17h-4v18h10V32z M30,68h57v-9H30V68z\" stroke-width=\"0\"/\u003e\n\u003c/svg\u003e\n\n\u003c/a\u003e\u003c/div\u003e\n  \u003cdiv class=\"gem-c-attachment__details\"\u003e\n    \u003ch2 class=\"gem-c-attachment__title\"\u003e\n      \u003ca class=\"govuk-link gem-c-attachment__link\" target=\"_self\" data-ga4-link=\"{\u0026quot;event_name\u0026quot;:\u0026quot;navigation\u0026quot;,\u0026quot;type\u0026quot;:\u0026quot;attachment\u0026quot;}\" href=\"/government/publications/equality-act-guidance/disability-equality-act-2010-guidance-on-matters-to-be-taken-into-account-in-determining-questions-relating-to-the-definition-of-disability-html\"\u003eDisability: Equality Act 2010 - Guidance on matters to be taken into account in determining questions relating to the definition of disability (HTML)\u003c/a\u003e\n\u003c/h2\u003e\n\n\n      \u003cp class=\"gem-c-attachment__metadata\"\u003e\u003cspan class=\"gem-c-attachment__attribute\"\u003eHTML\u003c/span\u003e\u003c/p\u003e\n\n\n\n\n\u003c/div\u003e\u003c/section\u003e",
+      "\u003csection class=\"gem-c-attachment govuk-!-display-none-print govuk-!-margin-bottom-6\" data-module=\"ga4-link-tracker\"\u003e\n  \u003cdiv class=\"gem-c-attachment__thumbnail\"\u003e\n    \u003ca class=\"govuk-link\" target=\"_self\" tabindex=\"-1\" aria-hidden=\"true\" data-ga4-link=\"{\u0026quot;event_name\u0026quot;:\u0026quot;file_download\u0026quot;,\u0026quot;type\u0026quot;:\u0026quot;attachment\u0026quot;}\" href=\"https://assets.publishing.service.gov.uk/media/5a80dcc8ed915d74e6230df4/Equality_Act_2010-disability_definition.pdf\"\u003e\u003cimg alt=\"\" class=\"gem-c-attachment__thumbnail-image gem-c-attachment__thumbnail-image--custom\" src=\"https://assets.publishing.service.gov.uk/media/5a80dcc9e5274a2e87dbc3c2/thumbnail_Equality_Act_2010-disability_definition.pdf.png\" /\u003e\u003c/a\u003e\u003c/div\u003e\n  \u003cdiv class=\"gem-c-attachment__details\"\u003e\n    \u003ch2 class=\"gem-c-attachment__title\"\u003e\n      \u003ca class=\"govuk-link gem-c-attachment__link\" target=\"_self\" data-ga4-link=\"{\u0026quot;event_name\u0026quot;:\u0026quot;file_download\u0026quot;,\u0026quot;type\u0026quot;:\u0026quot;attachment\u0026quot;}\" href=\"https://assets.publishing.service.gov.uk/media/5a80dcc8ed915d74e6230df4/Equality_Act_2010-disability_definition.pdf\"\u003eDisability: Equality Act 2010 - Guidance on matters to be taken into account in determining questions relating to the definition of disability (PDF)\u003c/a\u003e\n\u003c/h2\u003e\n\n\n      \u003cp class=\"gem-c-attachment__metadata\"\u003e\u003cspan class=\"gem-c-attachment__attribute\"\u003e\u003cabbr title=\"Portable Document Format\" class=\"gem-c-attachment__abbr\"\u003ePDF\u003c/abbr\u003e\u003c/span\u003e, \u003cspan class=\"gem-c-attachment__attribute\"\u003e693 KB\u003c/span\u003e, \u003cspan class=\"gem-c-attachment__attribute\"\u003e60 pages\u003c/span\u003e\u003c/p\u003e\n\n\n\n\n\u003c/div\u003e\u003c/section\u003e",
+      "\u003csection class=\"gem-c-attachment govuk-!-display-none-print govuk-!-margin-bottom-6\" data-module=\"ga4-link-tracker\"\u003e\n  \u003cdiv class=\"gem-c-attachment__thumbnail\"\u003e\n    \u003ca class=\"govuk-link\" target=\"_self\" tabindex=\"-1\" aria-hidden=\"true\" data-ga4-link=\"{\u0026quot;event_name\u0026quot;:\u0026quot;navigation\u0026quot;,\u0026quot;type\u0026quot;:\u0026quot;attachment\u0026quot;}\" href=\"/government/publications/equality-act-guidance/individuals-a-summary-guide-to-your-rights-html\"\u003e\n        \u003csvg class=\"gem-c-attachment__thumbnail-image gem-c-attachment__thumbnail-image--html\" version=\"1.1\" viewBox=\"0 0 99 140\" width=\"99\" height=\"140\" aria-hidden=\"true\"\u003e\n  \u003cpath d=\"M30,95h57v9H30V95z M30,77v9h39v-9H30z M30,122h48v-9H30V122z M12,68h9v-9h-9V68z M12,104h9v-9h-9V104z M12,86h9v-9h-9V86z M12,122h9v-9h-9V122z M87,12v27H12V12H87z M33,17h-4v8h-6v-8h-4v18h4v-7l6,0v7l4,0V17z M49,17H35l0,3h5v15h4V20l5,0V17z M68,17h-4 l-5,6l-5-6h-4v18h4l0-12l5,6l5-6l0,12h4V17z M81,32h-6V17h-4v18h10V32z M30,68h57v-9H30V68z\" stroke-width=\"0\"/\u003e\n\u003c/svg\u003e\n\n\u003c/a\u003e\u003c/div\u003e\n  \u003cdiv class=\"gem-c-attachment__details\"\u003e\n    \u003ch2 class=\"gem-c-attachment__title\"\u003e\n      \u003ca class=\"govuk-link gem-c-attachment__link\" target=\"_self\" data-ga4-link=\"{\u0026quot;event_name\u0026quot;:\u0026quot;navigation\u0026quot;,\u0026quot;type\u0026quot;:\u0026quot;attachment\u0026quot;}\" href=\"/government/publications/equality-act-guidance/individuals-a-summary-guide-to-your-rights-html\"\u003eIndividuals: a summary guide to your rights (HTML)\u003c/a\u003e\n\u003c/h2\u003e\n\n\n      \u003cp class=\"gem-c-attachment__metadata\"\u003e\u003cspan class=\"gem-c-attachment__attribute\"\u003eHTML\u003c/span\u003e\u003c/p\u003e\n\n\n\n\n\u003c/div\u003e\u003c/section\u003e",
+      "\u003csection class=\"gem-c-attachment govuk-!-display-none-print govuk-!-margin-bottom-6\" data-module=\"ga4-link-tracker\"\u003e\n  \u003cdiv class=\"gem-c-attachment__thumbnail\"\u003e\n    \u003ca class=\"govuk-link\" target=\"_self\" tabindex=\"-1\" aria-hidden=\"true\" data-ga4-link=\"{\u0026quot;event_name\u0026quot;:\u0026quot;file_download\u0026quot;,\u0026quot;type\u0026quot;:\u0026quot;attachment\u0026quot;}\" href=\"https://assets.publishing.service.gov.uk/media/5a78ff28ed915d0422066fb6/individual-rights1.pdf\"\u003e\u003cimg alt=\"\" class=\"gem-c-attachment__thumbnail-image gem-c-attachment__thumbnail-image--custom\" src=\"https://assets.publishing.service.gov.uk/media/5a78ff27ed915d0422066fb5/thumbnail_individual-rights1.pdf.png\" /\u003e\u003c/a\u003e\u003c/div\u003e\n  \u003cdiv class=\"gem-c-attachment__details\"\u003e\n    \u003ch2 class=\"gem-c-attachment__title\"\u003e\n      \u003ca class=\"govuk-link gem-c-attachment__link\" target=\"_self\" data-ga4-link=\"{\u0026quot;event_name\u0026quot;:\u0026quot;file_download\u0026quot;,\u0026quot;type\u0026quot;:\u0026quot;attachment\u0026quot;}\" href=\"https://assets.publishing.service.gov.uk/media/5a78ff28ed915d0422066fb6/individual-rights1.pdf\"\u003eIndividuals: a summary guide to your rights (PDF)\u003c/a\u003e\n\u003c/h2\u003e\n\n\n      \u003cp class=\"gem-c-attachment__metadata\"\u003e\u003cspan class=\"gem-c-attachment__attribute\"\u003e\u003cabbr title=\"Portable Document Format\" class=\"gem-c-attachment__abbr\"\u003ePDF\u003c/abbr\u003e\u003c/span\u003e, \u003cspan class=\"gem-c-attachment__attribute\"\u003e212 KB\u003c/span\u003e, \u003cspan class=\"gem-c-attachment__attribute\"\u003e8 pages\u003c/span\u003e\u003c/p\u003e\n\n\n\n\n      \u003cp class=\"gem-c-attachment__metadata\"\u003eThis file may not be suitable for users of assistive technology.\u003c/p\u003e\n      \u003cdetails class=\"gem-c-details govuk-details govuk-!-margin-bottom-3\" data-module=\"govuk-details gem-details\"\u003e\n  \u003csummary class=\"govuk-details__summary\" data-details-track-click=\"\"\u003e\n    \u003cspan class=\"govuk-details__summary-text\"\u003e\n      Request an accessible format.\n    \u003c/span\u003e\n\u003c/summary\u003e  \u003cdiv class=\"govuk-details__text\"\u003e\n    \n        If you use assistive technology (such as a screen reader) and need a version of this document in a more accessible format, please email \u003ca href='mailto:accessible.formats@cabinetoffice.gov.uk' target='_blank' class='govuk-link'\u003eaccessible.formats@cabinetoffice.gov.uk\u003c/a\u003e. Please tell us what format you need. It will help us if you say what assistive technology you use.\n\n  \u003c/div\u003e\n\u003c/details\u003e\u003c/div\u003e\u003c/section\u003e",
+      "\u003csection class=\"gem-c-attachment govuk-!-display-none-print govuk-!-margin-bottom-6\" data-module=\"ga4-link-tracker\"\u003e\n  \u003cdiv class=\"gem-c-attachment__thumbnail\"\u003e\n    \u003ca class=\"govuk-link\" target=\"_self\" tabindex=\"-1\" aria-hidden=\"true\" data-ga4-link=\"{\u0026quot;event_name\u0026quot;:\u0026quot;navigation\u0026quot;,\u0026quot;type\u0026quot;:\u0026quot;attachment\u0026quot;}\" href=\"/government/publications/equality-act-guidance/disability-quick-start-guide-for-service-providers-html\"\u003e\n        \u003csvg class=\"gem-c-attachment__thumbnail-image gem-c-attachment__thumbnail-image--html\" version=\"1.1\" viewBox=\"0 0 99 140\" width=\"99\" height=\"140\" aria-hidden=\"true\"\u003e\n  \u003cpath d=\"M30,95h57v9H30V95z M30,77v9h39v-9H30z M30,122h48v-9H30V122z M12,68h9v-9h-9V68z M12,104h9v-9h-9V104z M12,86h9v-9h-9V86z M12,122h9v-9h-9V122z M87,12v27H12V12H87z M33,17h-4v8h-6v-8h-4v18h4v-7l6,0v7l4,0V17z M49,17H35l0,3h5v15h4V20l5,0V17z M68,17h-4 l-5,6l-5-6h-4v18h4l0-12l5,6l5-6l0,12h4V17z M81,32h-6V17h-4v18h10V32z M30,68h57v-9H30V68z\" stroke-width=\"0\"/\u003e\n\u003c/svg\u003e\n\n\u003c/a\u003e\u003c/div\u003e\n  \u003cdiv class=\"gem-c-attachment__details\"\u003e\n    \u003ch2 class=\"gem-c-attachment__title\"\u003e\n      \u003ca class=\"govuk-link gem-c-attachment__link\" target=\"_self\" data-ga4-link=\"{\u0026quot;event_name\u0026quot;:\u0026quot;navigation\u0026quot;,\u0026quot;type\u0026quot;:\u0026quot;attachment\u0026quot;}\" href=\"/government/publications/equality-act-guidance/disability-quick-start-guide-for-service-providers-html\"\u003eDisability: quick start guide for service providers (HTML)\u003c/a\u003e\n\u003c/h2\u003e\n\n\n      \u003cp class=\"gem-c-attachment__metadata\"\u003e\u003cspan class=\"gem-c-attachment__attribute\"\u003eHTML\u003c/span\u003e\u003c/p\u003e\n\n\n\n\n\u003c/div\u003e\u003c/section\u003e",
+      "\u003csection class=\"gem-c-attachment govuk-!-display-none-print govuk-!-margin-bottom-6\" data-module=\"ga4-link-tracker\"\u003e\n  \u003cdiv class=\"gem-c-attachment__thumbnail\"\u003e\n    \u003ca class=\"govuk-link\" target=\"_self\" tabindex=\"-1\" aria-hidden=\"true\" data-ga4-link=\"{\u0026quot;event_name\u0026quot;:\u0026quot;file_download\u0026quot;,\u0026quot;type\u0026quot;:\u0026quot;attachment\u0026quot;}\" href=\"https://assets.publishing.service.gov.uk/media/5a79c79940f0b66d161ae174/disability.pdf\"\u003e\u003cimg alt=\"\" class=\"gem-c-attachment__thumbnail-image gem-c-attachment__thumbnail-image--custom\" src=\"https://assets.publishing.service.gov.uk/media/5a79c79aed915d07d35b80a8/thumbnail_disability.pdf.png\" /\u003e\u003c/a\u003e\u003c/div\u003e\n  \u003cdiv class=\"gem-c-attachment__details\"\u003e\n    \u003ch2 class=\"gem-c-attachment__title\"\u003e\n      \u003ca class=\"govuk-link gem-c-attachment__link\" target=\"_self\" data-ga4-link=\"{\u0026quot;event_name\u0026quot;:\u0026quot;file_download\u0026quot;,\u0026quot;type\u0026quot;:\u0026quot;attachment\u0026quot;}\" href=\"https://assets.publishing.service.gov.uk/media/5a79c79940f0b66d161ae174/disability.pdf\"\u003eDisability: quick start guide for service providers (PDF)\u003c/a\u003e\n\u003c/h2\u003e\n\n\n      \u003cp class=\"gem-c-attachment__metadata\"\u003e\u003cspan class=\"gem-c-attachment__attribute\"\u003e\u003cabbr title=\"Portable Document Format\" class=\"gem-c-attachment__abbr\"\u003ePDF\u003c/abbr\u003e\u003c/span\u003e, \u003cspan class=\"gem-c-attachment__attribute\"\u003e310 KB\u003c/span\u003e, \u003cspan class=\"gem-c-attachment__attribute\"\u003e12 pages\u003c/span\u003e\u003c/p\u003e\n\n\n\n\n      \u003cp class=\"gem-c-attachment__metadata\"\u003eThis file may not be suitable for users of assistive technology.\u003c/p\u003e\n      \u003cdetails class=\"gem-c-details govuk-details govuk-!-margin-bottom-3\" data-module=\"govuk-details gem-details\"\u003e\n  \u003csummary class=\"govuk-details__summary\" data-details-track-click=\"\"\u003e\n    \u003cspan class=\"govuk-details__summary-text\"\u003e\n      Request an accessible format.\n    \u003c/span\u003e\n\u003c/summary\u003e  \u003cdiv class=\"govuk-details__text\"\u003e\n    \n        If you use assistive technology (such as a screen reader) and need a version of this document in a more accessible format, please email \u003ca href='mailto:accessible.formats@cabinetoffice.gov.uk' target='_blank' class='govuk-link'\u003eaccessible.formats@cabinetoffice.gov.uk\u003c/a\u003e. Please tell us what format you need. It will help us if you say what assistive technology you use.\n\n  \u003c/div\u003e\n\u003c/details\u003e\u003c/div\u003e\u003c/section\u003e",
+      "\u003csection class=\"gem-c-attachment govuk-!-display-none-print govuk-!-margin-bottom-6\" data-module=\"ga4-link-tracker\"\u003e\n  \u003cdiv class=\"gem-c-attachment__thumbnail\"\u003e\n    \u003ca class=\"govuk-link\" target=\"_self\" tabindex=\"-1\" aria-hidden=\"true\" data-ga4-link=\"{\u0026quot;event_name\u0026quot;:\u0026quot;file_download\u0026quot;,\u0026quot;type\u0026quot;:\u0026quot;attachment\u0026quot;}\" href=\"https://assets.publishing.service.gov.uk/media/5a7970a640f0b642860d81bc/age-discrimination-ban.pdf\"\u003e\u003cimg alt=\"\" class=\"gem-c-attachment__thumbnail-image gem-c-attachment__thumbnail-image--custom\" src=\"https://assets.publishing.service.gov.uk/media/5a7970a7e5274a2acd18cd8d/thumbnail_age-discrimination-ban.pdf.png\" /\u003e\u003c/a\u003e\u003c/div\u003e\n  \u003cdiv class=\"gem-c-attachment__details\"\u003e\n    \u003ch2 class=\"gem-c-attachment__title\"\u003e\n      \u003ca class=\"govuk-link gem-c-attachment__link\" target=\"_self\" data-ga4-link=\"{\u0026quot;event_name\u0026quot;:\u0026quot;file_download\u0026quot;,\u0026quot;type\u0026quot;:\u0026quot;attachment\u0026quot;}\" href=\"https://assets.publishing.service.gov.uk/media/5a7970a640f0b642860d81bc/age-discrimination-ban.pdf\"\u003eAge discrimination ban in services and public functions: An overview for service providers and customers. (PDF file - 162kb)\u003c/a\u003e\n\u003c/h2\u003e\n\n\n      \u003cp class=\"gem-c-attachment__metadata\"\u003e\u003cspan class=\"gem-c-attachment__attribute\"\u003e\u003cabbr title=\"Portable Document Format\" class=\"gem-c-attachment__abbr\"\u003ePDF\u003c/abbr\u003e\u003c/span\u003e, \u003cspan class=\"gem-c-attachment__attribute\"\u003e159 KB\u003c/span\u003e, \u003cspan class=\"gem-c-attachment__attribute\"\u003e13 pages\u003c/span\u003e\u003c/p\u003e\n\n\n\n\n      \u003cp class=\"gem-c-attachment__metadata\"\u003eThis file may not be suitable for users of assistive technology.\u003c/p\u003e\n      \u003cdetails class=\"gem-c-details govuk-details govuk-!-margin-bottom-3\" data-module=\"govuk-details gem-details\"\u003e\n  \u003csummary class=\"govuk-details__summary\" data-details-track-click=\"\"\u003e\n    \u003cspan class=\"govuk-details__summary-text\"\u003e\n      Request an accessible format.\n    \u003c/span\u003e\n\u003c/summary\u003e  \u003cdiv class=\"govuk-details__text\"\u003e\n    \n        If you use assistive technology (such as a screen reader) and need a version of this document in a more accessible format, please email \u003ca href='mailto:accessible.formats@cabinetoffice.gov.uk' target='_blank' class='govuk-link'\u003eaccessible.formats@cabinetoffice.gov.uk\u003c/a\u003e. Please tell us what format you need. It will help us if you say what assistive technology you use.\n\n  \u003c/div\u003e\n\u003c/details\u003e\u003c/div\u003e\u003c/section\u003e",
+      "\u003csection class=\"gem-c-attachment govuk-!-display-none-print govuk-!-margin-bottom-6\" data-module=\"ga4-link-tracker\"\u003e\n  \u003cdiv class=\"gem-c-attachment__thumbnail\"\u003e\n    \u003ca class=\"govuk-link\" target=\"_self\" tabindex=\"-1\" aria-hidden=\"true\" data-ga4-link=\"{\u0026quot;event_name\u0026quot;:\u0026quot;file_download\u0026quot;,\u0026quot;type\u0026quot;:\u0026quot;attachment\u0026quot;}\" href=\"https://assets.publishing.service.gov.uk/media/5a78ca86e5274a2acd189d0f/age-discrimination-guide-clubs.pdf\"\u003e\u003cimg alt=\"\" class=\"gem-c-attachment__thumbnail-image gem-c-attachment__thumbnail-image--custom\" src=\"https://assets.publishing.service.gov.uk/media/5a78ca87ed915d04220655f1/thumbnail_age-discrimination-guide-clubs.pdf.png\" /\u003e\u003c/a\u003e\u003c/div\u003e\n  \u003cdiv class=\"gem-c-attachment__details\"\u003e\n    \u003ch2 class=\"gem-c-attachment__title\"\u003e\n      \u003ca class=\"govuk-link gem-c-attachment__link\" target=\"_self\" data-ga4-link=\"{\u0026quot;event_name\u0026quot;:\u0026quot;file_download\u0026quot;,\u0026quot;type\u0026quot;:\u0026quot;attachment\u0026quot;}\" href=\"https://assets.publishing.service.gov.uk/media/5a78ca86e5274a2acd189d0f/age-discrimination-guide-clubs.pdf\"\u003eAge discrimination ban in services and public functions: A guide for private clubs (PDF file - 129kb)\u003c/a\u003e\n\u003c/h2\u003e\n\n\n      \u003cp class=\"gem-c-attachment__metadata\"\u003e\u003cspan class=\"gem-c-attachment__attribute\"\u003e\u003cabbr title=\"Portable Document Format\" class=\"gem-c-attachment__abbr\"\u003ePDF\u003c/abbr\u003e\u003c/span\u003e, \u003cspan class=\"gem-c-attachment__attribute\"\u003e127 KB\u003c/span\u003e, \u003cspan class=\"gem-c-attachment__attribute\"\u003e4 pages\u003c/span\u003e\u003c/p\u003e\n\n\n\n\n      \u003cp class=\"gem-c-attachment__metadata\"\u003eThis file may not be suitable for users of assistive technology.\u003c/p\u003e\n      \u003cdetails class=\"gem-c-details govuk-details govuk-!-margin-bottom-3\" data-module=\"govuk-details gem-details\"\u003e\n  \u003csummary class=\"govuk-details__summary\" data-details-track-click=\"\"\u003e\n    \u003cspan class=\"govuk-details__summary-text\"\u003e\n      Request an accessible format.\n    \u003c/span\u003e\n\u003c/summary\u003e  \u003cdiv class=\"govuk-details__text\"\u003e\n    \n        If you use assistive technology (such as a screen reader) and need a version of this document in a more accessible format, please email \u003ca href='mailto:accessible.formats@cabinetoffice.gov.uk' target='_blank' class='govuk-link'\u003eaccessible.formats@cabinetoffice.gov.uk\u003c/a\u003e. Please tell us what format you need. It will help us if you say what assistive technology you use.\n\n  \u003c/div\u003e\n\u003c/details\u003e\u003c/div\u003e\u003c/section\u003e",
+      "\u003csection class=\"gem-c-attachment govuk-!-display-none-print govuk-!-margin-bottom-6\" data-module=\"ga4-link-tracker\"\u003e\n  \u003cdiv class=\"gem-c-attachment__thumbnail\"\u003e\n    \u003ca class=\"govuk-link\" target=\"_self\" tabindex=\"-1\" aria-hidden=\"true\" data-ga4-link=\"{\u0026quot;event_name\u0026quot;:\u0026quot;file_download\u0026quot;,\u0026quot;type\u0026quot;:\u0026quot;attachment\u0026quot;}\" href=\"https://assets.publishing.service.gov.uk/media/5a78cddb40f0b62b22cbced3/age-discrimination-guide-sme.pdf\"\u003e\u003cimg alt=\"\" class=\"gem-c-attachment__thumbnail-image gem-c-attachment__thumbnail-image--custom\" src=\"https://assets.publishing.service.gov.uk/media/5a78cddbe5274a277e68f973/thumbnail_age-discrimination-guide-sme.pdf.png\" /\u003e\u003c/a\u003e\u003c/div\u003e\n  \u003cdiv class=\"gem-c-attachment__details\"\u003e\n    \u003ch2 class=\"gem-c-attachment__title\"\u003e\n      \u003ca class=\"govuk-link gem-c-attachment__link\" target=\"_self\" data-ga4-link=\"{\u0026quot;event_name\u0026quot;:\u0026quot;file_download\u0026quot;,\u0026quot;type\u0026quot;:\u0026quot;attachment\u0026quot;}\" href=\"https://assets.publishing.service.gov.uk/media/5a78cddb40f0b62b22cbced3/age-discrimination-guide-sme.pdf\"\u003eAge discrimination ban in services and public functions: A guide for small businesses (PDF file - 129kb)\u003c/a\u003e\n\u003c/h2\u003e\n\n\n      \u003cp class=\"gem-c-attachment__metadata\"\u003e\u003cspan class=\"gem-c-attachment__attribute\"\u003e\u003cabbr title=\"Portable Document Format\" class=\"gem-c-attachment__abbr\"\u003ePDF\u003c/abbr\u003e\u003c/span\u003e, \u003cspan class=\"gem-c-attachment__attribute\"\u003e127 KB\u003c/span\u003e, \u003cspan class=\"gem-c-attachment__attribute\"\u003e4 pages\u003c/span\u003e\u003c/p\u003e\n\n\n\n\n      \u003cp class=\"gem-c-attachment__metadata\"\u003eThis file may not be suitable for users of assistive technology.\u003c/p\u003e\n      \u003cdetails class=\"gem-c-details govuk-details govuk-!-margin-bottom-3\" data-module=\"govuk-details gem-details\"\u003e\n  \u003csummary class=\"govuk-details__summary\" data-details-track-click=\"\"\u003e\n    \u003cspan class=\"govuk-details__summary-text\"\u003e\n      Request an accessible format.\n    \u003c/span\u003e\n\u003c/summary\u003e  \u003cdiv class=\"govuk-details__text\"\u003e\n    \n        If you use assistive technology (such as a screen reader) and need a version of this document in a more accessible format, please email \u003ca href='mailto:accessible.formats@cabinetoffice.gov.uk' target='_blank' class='govuk-link'\u003eaccessible.formats@cabinetoffice.gov.uk\u003c/a\u003e. Please tell us what format you need. It will help us if you say what assistive technology you use.\n\n  \u003c/div\u003e\n\u003c/details\u003e\u003c/div\u003e\u003c/section\u003e",
+      "\u003csection class=\"gem-c-attachment govuk-!-display-none-print govuk-!-margin-bottom-6\" data-module=\"ga4-link-tracker\"\u003e\n  \u003cdiv class=\"gem-c-attachment__thumbnail\"\u003e\n    \u003ca class=\"govuk-link\" target=\"_self\" tabindex=\"-1\" aria-hidden=\"true\" data-ga4-link=\"{\u0026quot;event_name\u0026quot;:\u0026quot;file_download\u0026quot;,\u0026quot;type\u0026quot;:\u0026quot;attachment\u0026quot;}\" href=\"https://assets.publishing.service.gov.uk/media/5a78cde5ed915d0422065783/holiday-discrimination-age.pdf\"\u003e\u003cimg alt=\"\" class=\"gem-c-attachment__thumbnail-image gem-c-attachment__thumbnail-image--custom\" src=\"https://assets.publishing.service.gov.uk/media/5a78cde5e5274a2acd189ea7/thumbnail_holiday-discrimination-age.pdf.png\" /\u003e\u003c/a\u003e\u003c/div\u003e\n  \u003cdiv class=\"gem-c-attachment__details\"\u003e\n    \u003ch2 class=\"gem-c-attachment__title\"\u003e\n      \u003ca class=\"govuk-link gem-c-attachment__link\" target=\"_self\" data-ga4-link=\"{\u0026quot;event_name\u0026quot;:\u0026quot;file_download\u0026quot;,\u0026quot;type\u0026quot;:\u0026quot;attachment\u0026quot;}\" href=\"https://assets.publishing.service.gov.uk/media/5a78cde5ed915d0422065783/holiday-discrimination-age.pdf\"\u003eAge discrimination ban in services and public functions: A guide for holiday providers, hotels and those letting holiday properties. (PDF file - 780kb)\u003c/a\u003e\n\u003c/h2\u003e\n\n\n      \u003cp class=\"gem-c-attachment__metadata\"\u003e\u003cspan class=\"gem-c-attachment__attribute\"\u003e\u003cabbr title=\"Portable Document Format\" class=\"gem-c-attachment__abbr\"\u003ePDF\u003c/abbr\u003e\u003c/span\u003e, \u003cspan class=\"gem-c-attachment__attribute\"\u003e762 KB\u003c/span\u003e, \u003cspan class=\"gem-c-attachment__attribute\"\u003e6 pages\u003c/span\u003e\u003c/p\u003e\n\n\n\n\n      \u003cp class=\"gem-c-attachment__metadata\"\u003eThis file may not be suitable for users of assistive technology.\u003c/p\u003e\n      \u003cdetails class=\"gem-c-details govuk-details govuk-!-margin-bottom-3\" data-module=\"govuk-details gem-details\"\u003e\n  \u003csummary class=\"govuk-details__summary\" data-details-track-click=\"\"\u003e\n    \u003cspan class=\"govuk-details__summary-text\"\u003e\n      Request an accessible format.\n    \u003c/span\u003e\n\u003c/summary\u003e  \u003cdiv class=\"govuk-details__text\"\u003e\n    \n        If you use assistive technology (such as a screen reader) and need a version of this document in a more accessible format, please email \u003ca href='mailto:accessible.formats@cabinetoffice.gov.uk' target='_blank' class='govuk-link'\u003eaccessible.formats@cabinetoffice.gov.uk\u003c/a\u003e. Please tell us what format you need. It will help us if you say what assistive technology you use.\n\n  \u003c/div\u003e\n\u003c/details\u003e\u003c/div\u003e\u003c/section\u003e",
+      "\u003csection class=\"gem-c-attachment govuk-!-display-none-print govuk-!-margin-bottom-6\" data-module=\"ga4-link-tracker\"\u003e\n  \u003cdiv class=\"gem-c-attachment__thumbnail\"\u003e\n    \u003ca class=\"govuk-link\" target=\"_self\" tabindex=\"-1\" aria-hidden=\"true\" data-ga4-link=\"{\u0026quot;event_name\u0026quot;:\u0026quot;file_download\u0026quot;,\u0026quot;type\u0026quot;:\u0026quot;attachment\u0026quot;}\" href=\"https://assets.publishing.service.gov.uk/media/5a79906f40f0b63d72fc6ced/business-quickstart.pdf\"\u003e\u003cimg alt=\"\" class=\"gem-c-attachment__thumbnail-image gem-c-attachment__thumbnail-image--custom\" src=\"https://assets.publishing.service.gov.uk/media/5a79906c40f0b642860d913a/thumbnail_business-quickstart.pdf.png\" /\u003e\u003c/a\u003e\u003c/div\u003e\n  \u003cdiv class=\"gem-c-attachment__details\"\u003e\n    \u003ch2 class=\"gem-c-attachment__title\"\u003e\n      \u003ca class=\"govuk-link gem-c-attachment__link\" target=\"_self\" data-ga4-link=\"{\u0026quot;event_name\u0026quot;:\u0026quot;file_download\u0026quot;,\u0026quot;type\u0026quot;:\u0026quot;attachment\u0026quot;}\" href=\"https://assets.publishing.service.gov.uk/media/5a79906f40f0b63d72fc6ced/business-quickstart.pdf\"\u003eBusiness: quick start guide for providing goods and services (PDF file - 340kb)\u003c/a\u003e\n\u003c/h2\u003e\n\n\n      \u003cp class=\"gem-c-attachment__metadata\"\u003e\u003cspan class=\"gem-c-attachment__attribute\"\u003e\u003cabbr title=\"Portable Document Format\" class=\"gem-c-attachment__abbr\"\u003ePDF\u003c/abbr\u003e\u003c/span\u003e, \u003cspan class=\"gem-c-attachment__attribute\"\u003e332 KB\u003c/span\u003e, \u003cspan class=\"gem-c-attachment__attribute\"\u003e20 pages\u003c/span\u003e\u003c/p\u003e\n\n\n\n\n      \u003cp class=\"gem-c-attachment__metadata\"\u003eThis file may not be suitable for users of assistive technology.\u003c/p\u003e\n      \u003cdetails class=\"gem-c-details govuk-details govuk-!-margin-bottom-3\" data-module=\"govuk-details gem-details\"\u003e\n  \u003csummary class=\"govuk-details__summary\" data-details-track-click=\"\"\u003e\n    \u003cspan class=\"govuk-details__summary-text\"\u003e\n      Request an accessible format.\n    \u003c/span\u003e\n\u003c/summary\u003e  \u003cdiv class=\"govuk-details__text\"\u003e\n    \n        If you use assistive technology (such as a screen reader) and need a version of this document in a more accessible format, please email \u003ca href='mailto:accessible.formats@cabinetoffice.gov.uk' target='_blank' class='govuk-link'\u003eaccessible.formats@cabinetoffice.gov.uk\u003c/a\u003e. Please tell us what format you need. It will help us if you say what assistive technology you use.\n\n  \u003c/div\u003e\n\u003c/details\u003e\u003c/div\u003e\u003c/section\u003e",
+      "\u003csection class=\"gem-c-attachment govuk-!-display-none-print govuk-!-margin-bottom-6\" data-module=\"ga4-link-tracker\"\u003e\n  \u003cdiv class=\"gem-c-attachment__thumbnail\"\u003e\n    \u003ca class=\"govuk-link\" target=\"_self\" tabindex=\"-1\" aria-hidden=\"true\" data-ga4-link=\"{\u0026quot;event_name\u0026quot;:\u0026quot;file_download\u0026quot;,\u0026quot;type\u0026quot;:\u0026quot;attachment\u0026quot;}\" href=\"https://assets.publishing.service.gov.uk/media/5a78dbdae5274a277e690056/business-summary.pdf\"\u003e\u003cimg alt=\"\" class=\"gem-c-attachment__thumbnail-image gem-c-attachment__thumbnail-image--custom\" src=\"https://assets.publishing.service.gov.uk/media/5a78dbdb40f0b62b22cbd5c3/thumbnail_business-summary.pdf.png\" /\u003e\u003c/a\u003e\u003c/div\u003e\n  \u003cdiv class=\"gem-c-attachment__details\"\u003e\n    \u003ch2 class=\"gem-c-attachment__title\"\u003e\n      \u003ca class=\"govuk-link gem-c-attachment__link\" target=\"_self\" data-ga4-link=\"{\u0026quot;event_name\u0026quot;:\u0026quot;file_download\u0026quot;,\u0026quot;type\u0026quot;:\u0026quot;attachment\u0026quot;}\" href=\"https://assets.publishing.service.gov.uk/media/5a78dbdae5274a277e690056/business-summary.pdf\"\u003eBusiness: summary guide for providing goods and services (PDF file - 280kb)\u003c/a\u003e\n\u003c/h2\u003e\n\n\n      \u003cp class=\"gem-c-attachment__metadata\"\u003e\u003cspan class=\"gem-c-attachment__attribute\"\u003e\u003cabbr title=\"Portable Document Format\" class=\"gem-c-attachment__abbr\"\u003ePDF\u003c/abbr\u003e\u003c/span\u003e, \u003cspan class=\"gem-c-attachment__attribute\"\u003e274 KB\u003c/span\u003e, \u003cspan class=\"gem-c-attachment__attribute\"\u003e8 pages\u003c/span\u003e\u003c/p\u003e\n\n\n\n\n      \u003cp class=\"gem-c-attachment__metadata\"\u003eThis file may not be suitable for users of assistive technology.\u003c/p\u003e\n      \u003cdetails class=\"gem-c-details govuk-details govuk-!-margin-bottom-3\" data-module=\"govuk-details gem-details\"\u003e\n  \u003csummary class=\"govuk-details__summary\" data-details-track-click=\"\"\u003e\n    \u003cspan class=\"govuk-details__summary-text\"\u003e\n      Request an accessible format.\n    \u003c/span\u003e\n\u003c/summary\u003e  \u003cdiv class=\"govuk-details__text\"\u003e\n    \n        If you use assistive technology (such as a screen reader) and need a version of this document in a more accessible format, please email \u003ca href='mailto:accessible.formats@cabinetoffice.gov.uk' target='_blank' class='govuk-link'\u003eaccessible.formats@cabinetoffice.gov.uk\u003c/a\u003e. Please tell us what format you need. It will help us if you say what assistive technology you use.\n\n  \u003c/div\u003e\n\u003c/details\u003e\u003c/div\u003e\u003c/section\u003e",
+      "\u003csection class=\"gem-c-attachment govuk-!-display-none-print govuk-!-margin-bottom-6\" data-module=\"ga4-link-tracker\"\u003e\n  \u003cdiv class=\"gem-c-attachment__thumbnail\"\u003e\n    \u003ca class=\"govuk-link\" target=\"_self\" tabindex=\"-1\" aria-hidden=\"true\" data-ga4-link=\"{\u0026quot;event_name\u0026quot;:\u0026quot;file_download\u0026quot;,\u0026quot;type\u0026quot;:\u0026quot;attachment\u0026quot;}\" href=\"https://assets.publishing.service.gov.uk/media/5a79c91ced915d07d35b8159/easy-read.pdf\"\u003e\u003cimg alt=\"\" class=\"gem-c-attachment__thumbnail-image gem-c-attachment__thumbnail-image--custom\" src=\"https://assets.publishing.service.gov.uk/media/5a79c919e5274a684690c17e/thumbnail_easy-read.pdf.png\" /\u003e\u003c/a\u003e\u003c/div\u003e\n  \u003cdiv class=\"gem-c-attachment__details\"\u003e\n    \u003ch2 class=\"gem-c-attachment__title\"\u003e\n      \u003ca class=\"govuk-link gem-c-attachment__link\" target=\"_self\" data-ga4-link=\"{\u0026quot;event_name\u0026quot;:\u0026quot;file_download\u0026quot;,\u0026quot;type\u0026quot;:\u0026quot;attachment\u0026quot;}\" href=\"https://assets.publishing.service.gov.uk/media/5a79c91ced915d07d35b8159/easy-read.pdf\"\u003eEasy Read: The Equality Act - making equality real (PDF file - 2mb - Warning: large file)\u003c/a\u003e\n\u003c/h2\u003e\n\n\n      \u003cp class=\"gem-c-attachment__metadata\"\u003e\u003cspan class=\"gem-c-attachment__attribute\"\u003e\u003cabbr title=\"Portable Document Format\" class=\"gem-c-attachment__abbr\"\u003ePDF\u003c/abbr\u003e\u003c/span\u003e, \u003cspan class=\"gem-c-attachment__attribute\"\u003e2.3 MB\u003c/span\u003e, \u003cspan class=\"gem-c-attachment__attribute\"\u003e38 pages\u003c/span\u003e\u003c/p\u003e\n\n\n\n\n      \u003cp class=\"gem-c-attachment__metadata\"\u003eThis file may not be suitable for users of assistive technology.\u003c/p\u003e\n      \u003cdetails class=\"gem-c-details govuk-details govuk-!-margin-bottom-3\" data-module=\"govuk-details gem-details\"\u003e\n  \u003csummary class=\"govuk-details__summary\" data-details-track-click=\"\"\u003e\n    \u003cspan class=\"govuk-details__summary-text\"\u003e\n      Request an accessible format.\n    \u003c/span\u003e\n\u003c/summary\u003e  \u003cdiv class=\"govuk-details__text\"\u003e\n    \n        If you use assistive technology (such as a screen reader) and need a version of this document in a more accessible format, please email \u003ca href='mailto:accessible.formats@cabinetoffice.gov.uk' target='_blank' class='govuk-link'\u003eaccessible.formats@cabinetoffice.gov.uk\u003c/a\u003e. Please tell us what format you need. It will help us if you say what assistive technology you use.\n\n  \u003c/div\u003e\n\u003c/details\u003e\u003c/div\u003e\u003c/section\u003e",
+      "\u003csection class=\"gem-c-attachment govuk-!-display-none-print govuk-!-margin-bottom-6\" data-module=\"ga4-link-tracker\"\u003e\n  \u003cdiv class=\"gem-c-attachment__thumbnail\"\u003e\n    \u003ca class=\"govuk-link\" target=\"_self\" tabindex=\"-1\" aria-hidden=\"true\" data-ga4-link=\"{\u0026quot;event_name\u0026quot;:\u0026quot;file_download\u0026quot;,\u0026quot;type\u0026quot;:\u0026quot;attachment\u0026quot;}\" href=\"https://assets.publishing.service.gov.uk/media/5a79b5d440f0b642860da26f/employment-health-questions.pdf\"\u003e\u003cimg alt=\"\" class=\"gem-c-attachment__thumbnail-image gem-c-attachment__thumbnail-image--custom\" src=\"https://assets.publishing.service.gov.uk/media/5a79b5d5e5274a18ba50e40f/thumbnail_employment-health-questions.pdf.png\" /\u003e\u003c/a\u003e\u003c/div\u003e\n  \u003cdiv class=\"gem-c-attachment__details\"\u003e\n    \u003ch2 class=\"gem-c-attachment__title\"\u003e\n      \u003ca class=\"govuk-link gem-c-attachment__link\" target=\"_self\" data-ga4-link=\"{\u0026quot;event_name\u0026quot;:\u0026quot;file_download\u0026quot;,\u0026quot;type\u0026quot;:\u0026quot;attachment\u0026quot;}\" href=\"https://assets.publishing.service.gov.uk/media/5a79b5d440f0b642860da26f/employment-health-questions.pdf\"\u003eEmployers: quick start guide to the ban on questions about health and disability during recruitment (PDF file - 333kb)\u003c/a\u003e\n\u003c/h2\u003e\n\n\n      \u003cp class=\"gem-c-attachment__metadata\"\u003e\u003cspan class=\"gem-c-attachment__attribute\"\u003e\u003cabbr title=\"Portable Document Format\" class=\"gem-c-attachment__abbr\"\u003ePDF\u003c/abbr\u003e\u003c/span\u003e, \u003cspan class=\"gem-c-attachment__attribute\"\u003e326 KB\u003c/span\u003e, \u003cspan class=\"gem-c-attachment__attribute\"\u003e8 pages\u003c/span\u003e\u003c/p\u003e\n\n\n\n\n      \u003cp class=\"gem-c-attachment__metadata\"\u003eThis file may not be suitable for users of assistive technology.\u003c/p\u003e\n      \u003cdetails class=\"gem-c-details govuk-details govuk-!-margin-bottom-3\" data-module=\"govuk-details gem-details\"\u003e\n  \u003csummary class=\"govuk-details__summary\" data-details-track-click=\"\"\u003e\n    \u003cspan class=\"govuk-details__summary-text\"\u003e\n      Request an accessible format.\n    \u003c/span\u003e\n\u003c/summary\u003e  \u003cdiv class=\"govuk-details__text\"\u003e\n    \n        If you use assistive technology (such as a screen reader) and need a version of this document in a more accessible format, please email \u003ca href='mailto:accessible.formats@cabinetoffice.gov.uk' target='_blank' class='govuk-link'\u003eaccessible.formats@cabinetoffice.gov.uk\u003c/a\u003e. Please tell us what format you need. It will help us if you say what assistive technology you use.\n\n  \u003c/div\u003e\n\u003c/details\u003e\u003c/div\u003e\u003c/section\u003e",
+      "\u003csection class=\"gem-c-attachment govuk-!-display-none-print govuk-!-margin-bottom-6\" data-module=\"ga4-link-tracker\"\u003e\n  \u003cdiv class=\"gem-c-attachment__thumbnail\"\u003e\n    \u003ca class=\"govuk-link\" target=\"_self\" tabindex=\"-1\" aria-hidden=\"true\" data-ga4-link=\"{\u0026quot;event_name\u0026quot;:\u0026quot;file_download\u0026quot;,\u0026quot;type\u0026quot;:\u0026quot;attachment\u0026quot;}\" href=\"https://assets.publishing.service.gov.uk/media/5a78ec44ed915d0422066689/carers.pdf\"\u003e\u003cimg alt=\"\" class=\"gem-c-attachment__thumbnail-image gem-c-attachment__thumbnail-image--custom\" src=\"https://assets.publishing.service.gov.uk/media/5a78ec44e5274a2acd18ad4c/thumbnail_carers.pdf.png\" /\u003e\u003c/a\u003e\u003c/div\u003e\n  \u003cdiv class=\"gem-c-attachment__details\"\u003e\n    \u003ch2 class=\"gem-c-attachment__title\"\u003e\n      \u003ca class=\"govuk-link gem-c-attachment__link\" target=\"_self\" data-ga4-link=\"{\u0026quot;event_name\u0026quot;:\u0026quot;file_download\u0026quot;,\u0026quot;type\u0026quot;:\u0026quot;attachment\u0026quot;}\" href=\"https://assets.publishing.service.gov.uk/media/5a78ec44ed915d0422066689/carers.pdf\"\u003eIndividuals: what do I need to know as a carer? (PDF file - 237kb)\u003c/a\u003e\n\u003c/h2\u003e\n\n\n      \u003cp class=\"gem-c-attachment__metadata\"\u003e\u003cspan class=\"gem-c-attachment__attribute\"\u003e\u003cabbr title=\"Portable Document Format\" class=\"gem-c-attachment__abbr\"\u003ePDF\u003c/abbr\u003e\u003c/span\u003e, \u003cspan class=\"gem-c-attachment__attribute\"\u003e232 KB\u003c/span\u003e, \u003cspan class=\"gem-c-attachment__attribute\"\u003e6 pages\u003c/span\u003e\u003c/p\u003e\n\n\n\n\n      \u003cp class=\"gem-c-attachment__metadata\"\u003eThis file may not be suitable for users of assistive technology.\u003c/p\u003e\n      \u003cdetails class=\"gem-c-details govuk-details govuk-!-margin-bottom-3\" data-module=\"govuk-details gem-details\"\u003e\n  \u003csummary class=\"govuk-details__summary\" data-details-track-click=\"\"\u003e\n    \u003cspan class=\"govuk-details__summary-text\"\u003e\n      Request an accessible format.\n    \u003c/span\u003e\n\u003c/summary\u003e  \u003cdiv class=\"govuk-details__text\"\u003e\n    \n        If you use assistive technology (such as a screen reader) and need a version of this document in a more accessible format, please email \u003ca href='mailto:accessible.formats@cabinetoffice.gov.uk' target='_blank' class='govuk-link'\u003eaccessible.formats@cabinetoffice.gov.uk\u003c/a\u003e. Please tell us what format you need. It will help us if you say what assistive technology you use.\n\n  \u003c/div\u003e\n\u003c/details\u003e\u003c/div\u003e\u003c/section\u003e",
+      "\u003csection class=\"gem-c-attachment govuk-!-display-none-print govuk-!-margin-bottom-6\" data-module=\"ga4-link-tracker\"\u003e\n  \u003cdiv class=\"gem-c-attachment__thumbnail\"\u003e\n    \u003ca class=\"govuk-link\" target=\"_self\" tabindex=\"-1\" aria-hidden=\"true\" data-ga4-link=\"{\u0026quot;event_name\u0026quot;:\u0026quot;file_download\u0026quot;,\u0026quot;type\u0026quot;:\u0026quot;attachment\u0026quot;}\" href=\"https://assets.publishing.service.gov.uk/media/5a78f58340f0b62b22cbe26d/private-clubs.pdf\"\u003e\u003cimg alt=\"\" class=\"gem-c-attachment__thumbnail-image gem-c-attachment__thumbnail-image--custom\" src=\"https://assets.publishing.service.gov.uk/media/5a78f585e5274a277e690cc3/thumbnail_private-clubs.pdf.png\" /\u003e\u003c/a\u003e\u003c/div\u003e\n  \u003cdiv class=\"gem-c-attachment__details\"\u003e\n    \u003ch2 class=\"gem-c-attachment__title\"\u003e\n      \u003ca class=\"govuk-link gem-c-attachment__link\" target=\"_self\" data-ga4-link=\"{\u0026quot;event_name\u0026quot;:\u0026quot;file_download\u0026quot;,\u0026quot;type\u0026quot;:\u0026quot;attachment\u0026quot;}\" href=\"https://assets.publishing.service.gov.uk/media/5a78f58340f0b62b22cbe26d/private-clubs.pdf\"\u003ePrivate clubs and associations: quick start guide (PDF file - 289kb)\u003c/a\u003e\n\u003c/h2\u003e\n\n\n      \u003cp class=\"gem-c-attachment__metadata\"\u003e\u003cspan class=\"gem-c-attachment__attribute\"\u003e\u003cabbr title=\"Portable Document Format\" class=\"gem-c-attachment__abbr\"\u003ePDF\u003c/abbr\u003e\u003c/span\u003e, \u003cspan class=\"gem-c-attachment__attribute\"\u003e283 KB\u003c/span\u003e, \u003cspan class=\"gem-c-attachment__attribute\"\u003e12 pages\u003c/span\u003e\u003c/p\u003e\n\n\n\n\n      \u003cp class=\"gem-c-attachment__metadata\"\u003eThis file may not be suitable for users of assistive technology.\u003c/p\u003e\n      \u003cdetails class=\"gem-c-details govuk-details govuk-!-margin-bottom-3\" data-module=\"govuk-details gem-details\"\u003e\n  \u003csummary class=\"govuk-details__summary\" data-details-track-click=\"\"\u003e\n    \u003cspan class=\"govuk-details__summary-text\"\u003e\n      Request an accessible format.\n    \u003c/span\u003e\n\u003c/summary\u003e  \u003cdiv class=\"govuk-details__text\"\u003e\n    \n        If you use assistive technology (such as a screen reader) and need a version of this document in a more accessible format, please email \u003ca href='mailto:accessible.formats@cabinetoffice.gov.uk' target='_blank' class='govuk-link'\u003eaccessible.formats@cabinetoffice.gov.uk\u003c/a\u003e. Please tell us what format you need. It will help us if you say what assistive technology you use.\n\n  \u003c/div\u003e\n\u003c/details\u003e\u003c/div\u003e\u003c/section\u003e",
+      "\u003csection class=\"gem-c-attachment govuk-!-display-none-print govuk-!-margin-bottom-6\" data-module=\"ga4-link-tracker\"\u003e\n  \u003cdiv class=\"gem-c-attachment__thumbnail\"\u003e\n    \u003ca class=\"govuk-link\" target=\"_self\" tabindex=\"-1\" aria-hidden=\"true\" data-ga4-link=\"{\u0026quot;event_name\u0026quot;:\u0026quot;file_download\u0026quot;,\u0026quot;type\u0026quot;:\u0026quot;attachment\u0026quot;}\" href=\"https://assets.publishing.service.gov.uk/media/5a78fdcaed915d07d35b4036/public-sector.pdf\"\u003e\u003cimg alt=\"\" class=\"gem-c-attachment__thumbnail-image gem-c-attachment__thumbnail-image--custom\" src=\"https://assets.publishing.service.gov.uk/media/5a78fdcce5274a277e69109f/thumbnail_public-sector.pdf.png\" /\u003e\u003c/a\u003e\u003c/div\u003e\n  \u003cdiv class=\"gem-c-attachment__details\"\u003e\n    \u003ch2 class=\"gem-c-attachment__title\"\u003e\n      \u003ca class=\"govuk-link gem-c-attachment__link\" target=\"_self\" data-ga4-link=\"{\u0026quot;event_name\u0026quot;:\u0026quot;file_download\u0026quot;,\u0026quot;type\u0026quot;:\u0026quot;attachment\u0026quot;}\" href=\"https://assets.publishing.service.gov.uk/media/5a78fdcaed915d07d35b4036/public-sector.pdf\"\u003ePublic sector: summary guide for public sector organisations (PDF file - 308kb)\u003c/a\u003e\n\u003c/h2\u003e\n\n\n      \u003cp class=\"gem-c-attachment__metadata\"\u003e\u003cspan class=\"gem-c-attachment__attribute\"\u003e\u003cabbr title=\"Portable Document Format\" class=\"gem-c-attachment__abbr\"\u003ePDF\u003c/abbr\u003e\u003c/span\u003e, \u003cspan class=\"gem-c-attachment__attribute\"\u003e301 KB\u003c/span\u003e, \u003cspan class=\"gem-c-attachment__attribute\"\u003e12 pages\u003c/span\u003e\u003c/p\u003e\n\n\n\n\n      \u003cp class=\"gem-c-attachment__metadata\"\u003eThis file may not be suitable for users of assistive technology.\u003c/p\u003e\n      \u003cdetails class=\"gem-c-details govuk-details govuk-!-margin-bottom-3\" data-module=\"govuk-details gem-details\"\u003e\n  \u003csummary class=\"govuk-details__summary\" data-details-track-click=\"\"\u003e\n    \u003cspan class=\"govuk-details__summary-text\"\u003e\n      Request an accessible format.\n    \u003c/span\u003e\n\u003c/summary\u003e  \u003cdiv class=\"govuk-details__text\"\u003e\n    \n        If you use assistive technology (such as a screen reader) and need a version of this document in a more accessible format, please email \u003ca href='mailto:accessible.formats@cabinetoffice.gov.uk' target='_blank' class='govuk-link'\u003eaccessible.formats@cabinetoffice.gov.uk\u003c/a\u003e. Please tell us what format you need. It will help us if you say what assistive technology you use.\n\n  \u003c/div\u003e\n\u003c/details\u003e\u003c/div\u003e\u003c/section\u003e",
+      "\u003csection class=\"gem-c-attachment govuk-!-display-none-print govuk-!-margin-bottom-6\" data-module=\"ga4-link-tracker\"\u003e\n  \u003cdiv class=\"gem-c-attachment__thumbnail\"\u003e\n    \u003ca class=\"govuk-link\" target=\"_self\" tabindex=\"-1\" aria-hidden=\"true\" data-ga4-link=\"{\u0026quot;event_name\u0026quot;:\u0026quot;file_download\u0026quot;,\u0026quot;type\u0026quot;:\u0026quot;attachment\u0026quot;}\" href=\"https://assets.publishing.service.gov.uk/media/5a78b9ae40f0b62b22cbc4b4/vcs-association-perception.pdf\"\u003e\u003cimg alt=\"\" class=\"gem-c-attachment__thumbnail-image gem-c-attachment__thumbnail-image--custom\" src=\"https://assets.publishing.service.gov.uk/media/5a78b9ad40f0b62b22cbc4b3/thumbnail_vcs-association-perception.pdf.png\" /\u003e\u003c/a\u003e\u003c/div\u003e\n  \u003cdiv class=\"gem-c-attachment__details\"\u003e\n    \u003ch2 class=\"gem-c-attachment__title\"\u003e\n      \u003ca class=\"govuk-link gem-c-attachment__link\" target=\"_self\" data-ga4-link=\"{\u0026quot;event_name\u0026quot;:\u0026quot;file_download\u0026quot;,\u0026quot;type\u0026quot;:\u0026quot;attachment\u0026quot;}\" href=\"https://assets.publishing.service.gov.uk/media/5a78b9ae40f0b62b22cbc4b4/vcs-association-perception.pdf\"\u003eVoluntary and community sector: quick start guide to discrimination by association and perception for service providers (PDF file - 281kb)\u003c/a\u003e\n\u003c/h2\u003e\n\n\n      \u003cp class=\"gem-c-attachment__metadata\"\u003e\u003cspan class=\"gem-c-attachment__attribute\"\u003e\u003cabbr title=\"Portable Document Format\" class=\"gem-c-attachment__abbr\"\u003ePDF\u003c/abbr\u003e\u003c/span\u003e, \u003cspan class=\"gem-c-attachment__attribute\"\u003e274 KB\u003c/span\u003e, \u003cspan class=\"gem-c-attachment__attribute\"\u003e6 pages\u003c/span\u003e\u003c/p\u003e\n\n\n\n\n      \u003cp class=\"gem-c-attachment__metadata\"\u003eThis file may not be suitable for users of assistive technology.\u003c/p\u003e\n      \u003cdetails class=\"gem-c-details govuk-details govuk-!-margin-bottom-3\" data-module=\"govuk-details gem-details\"\u003e\n  \u003csummary class=\"govuk-details__summary\" data-details-track-click=\"\"\u003e\n    \u003cspan class=\"govuk-details__summary-text\"\u003e\n      Request an accessible format.\n    \u003c/span\u003e\n\u003c/summary\u003e  \u003cdiv class=\"govuk-details__text\"\u003e\n    \n        If you use assistive technology (such as a screen reader) and need a version of this document in a more accessible format, please email \u003ca href='mailto:accessible.formats@cabinetoffice.gov.uk' target='_blank' class='govuk-link'\u003eaccessible.formats@cabinetoffice.gov.uk\u003c/a\u003e. Please tell us what format you need. It will help us if you say what assistive technology you use.\n\n  \u003c/div\u003e\n\u003c/details\u003e\u003c/div\u003e\u003c/section\u003e",
+      "\u003csection class=\"gem-c-attachment govuk-!-display-none-print govuk-!-margin-bottom-6\" data-module=\"ga4-link-tracker\"\u003e\n  \u003cdiv class=\"gem-c-attachment__thumbnail\"\u003e\n    \u003ca class=\"govuk-link\" target=\"_self\" tabindex=\"-1\" aria-hidden=\"true\" data-ga4-link=\"{\u0026quot;event_name\u0026quot;:\u0026quot;file_download\u0026quot;,\u0026quot;type\u0026quot;:\u0026quot;attachment\u0026quot;}\" href=\"https://assets.publishing.service.gov.uk/media/5a74c502ed915d4d83b5ed12/vcs-associations.pdf\"\u003e\u003cimg alt=\"\" class=\"gem-c-attachment__thumbnail-image gem-c-attachment__thumbnail-image--custom\" src=\"https://assets.publishing.service.gov.uk/media/5a74c50140f0b61df47785a0/thumbnail_vcs-associations.pdf.png\" /\u003e\u003c/a\u003e\u003c/div\u003e\n  \u003cdiv class=\"gem-c-attachment__details\"\u003e\n    \u003ch2 class=\"gem-c-attachment__title\"\u003e\n      \u003ca class=\"govuk-link gem-c-attachment__link\" target=\"_self\" data-ga4-link=\"{\u0026quot;event_name\u0026quot;:\u0026quot;file_download\u0026quot;,\u0026quot;type\u0026quot;:\u0026quot;attachment\u0026quot;}\" href=\"https://assets.publishing.service.gov.uk/media/5a74c502ed915d4d83b5ed12/vcs-associations.pdf\"\u003eVoluntary and community sector: quick start guide for associations (PDF file - 301kb)\u003c/a\u003e\n\u003c/h2\u003e\n\n\n      \u003cp class=\"gem-c-attachment__metadata\"\u003e\u003cspan class=\"gem-c-attachment__attribute\"\u003e\u003cabbr title=\"Portable Document Format\" class=\"gem-c-attachment__abbr\"\u003ePDF\u003c/abbr\u003e\u003c/span\u003e, \u003cspan class=\"gem-c-attachment__attribute\"\u003e294 KB\u003c/span\u003e, \u003cspan class=\"gem-c-attachment__attribute\"\u003e6 pages\u003c/span\u003e\u003c/p\u003e\n\n\n\n\n      \u003cp class=\"gem-c-attachment__metadata\"\u003eThis file may not be suitable for users of assistive technology.\u003c/p\u003e\n      \u003cdetails class=\"gem-c-details govuk-details govuk-!-margin-bottom-3\" data-module=\"govuk-details gem-details\"\u003e\n  \u003csummary class=\"govuk-details__summary\" data-details-track-click=\"\"\u003e\n    \u003cspan class=\"govuk-details__summary-text\"\u003e\n      Request an accessible format.\n    \u003c/span\u003e\n\u003c/summary\u003e  \u003cdiv class=\"govuk-details__text\"\u003e\n    \n        If you use assistive technology (such as a screen reader) and need a version of this document in a more accessible format, please email \u003ca href='mailto:accessible.formats@cabinetoffice.gov.uk' target='_blank' class='govuk-link'\u003eaccessible.formats@cabinetoffice.gov.uk\u003c/a\u003e. Please tell us what format you need. It will help us if you say what assistive technology you use.\n\n  \u003c/div\u003e\n\u003c/details\u003e\u003c/div\u003e\u003c/section\u003e",
+      "\u003csection class=\"gem-c-attachment govuk-!-display-none-print govuk-!-margin-bottom-6\" data-module=\"ga4-link-tracker\"\u003e\n  \u003cdiv class=\"gem-c-attachment__thumbnail\"\u003e\n    \u003ca class=\"govuk-link\" target=\"_self\" tabindex=\"-1\" aria-hidden=\"true\" data-ga4-link=\"{\u0026quot;event_name\u0026quot;:\u0026quot;file_download\u0026quot;,\u0026quot;type\u0026quot;:\u0026quot;attachment\u0026quot;}\" href=\"https://assets.publishing.service.gov.uk/media/5a79007540f0b679c0a07c24/vcs-gender-reassignment.pdf\"\u003e\u003cimg alt=\"\" class=\"gem-c-attachment__thumbnail-image gem-c-attachment__thumbnail-image--custom\" src=\"https://assets.publishing.service.gov.uk/media/5a79007440f0b676f4a7d166/thumbnail_vcs-gender-reassignment.pdf.png\" /\u003e\u003c/a\u003e\u003c/div\u003e\n  \u003cdiv class=\"gem-c-attachment__details\"\u003e\n    \u003ch2 class=\"gem-c-attachment__title\"\u003e\n      \u003ca class=\"govuk-link gem-c-attachment__link\" target=\"_self\" data-ga4-link=\"{\u0026quot;event_name\u0026quot;:\u0026quot;file_download\u0026quot;,\u0026quot;type\u0026quot;:\u0026quot;attachment\u0026quot;}\" href=\"https://assets.publishing.service.gov.uk/media/5a79007540f0b679c0a07c24/vcs-gender-reassignment.pdf\"\u003eVoluntary and community sector: quick start guide to gender reassignment for service providers (PDF file - 329kb)\u003c/a\u003e\n\u003c/h2\u003e\n\n\n      \u003cp class=\"gem-c-attachment__metadata\"\u003e\u003cspan class=\"gem-c-attachment__attribute\"\u003e\u003cabbr title=\"Portable Document Format\" class=\"gem-c-attachment__abbr\"\u003ePDF\u003c/abbr\u003e\u003c/span\u003e, \u003cspan class=\"gem-c-attachment__attribute\"\u003e322 KB\u003c/span\u003e, \u003cspan class=\"gem-c-attachment__attribute\"\u003e12 pages\u003c/span\u003e\u003c/p\u003e\n\n\n\n\n      \u003cp class=\"gem-c-attachment__metadata\"\u003eThis file may not be suitable for users of assistive technology.\u003c/p\u003e\n      \u003cdetails class=\"gem-c-details govuk-details govuk-!-margin-bottom-3\" data-module=\"govuk-details gem-details\"\u003e\n  \u003csummary class=\"govuk-details__summary\" data-details-track-click=\"\"\u003e\n    \u003cspan class=\"govuk-details__summary-text\"\u003e\n      Request an accessible format.\n    \u003c/span\u003e\n\u003c/summary\u003e  \u003cdiv class=\"govuk-details__text\"\u003e\n    \n        If you use assistive technology (such as a screen reader) and need a version of this document in a more accessible format, please email \u003ca href='mailto:accessible.formats@cabinetoffice.gov.uk' target='_blank' class='govuk-link'\u003eaccessible.formats@cabinetoffice.gov.uk\u003c/a\u003e. Please tell us what format you need. It will help us if you say what assistive technology you use.\n\n  \u003c/div\u003e\n\u003c/details\u003e\u003c/div\u003e\u003c/section\u003e",
+      "\u003csection class=\"gem-c-attachment govuk-!-display-none-print govuk-!-margin-bottom-6\" data-module=\"ga4-link-tracker\"\u003e\n  \u003cdiv class=\"gem-c-attachment__thumbnail\"\u003e\n    \u003ca class=\"govuk-link\" target=\"_self\" tabindex=\"-1\" aria-hidden=\"true\" data-ga4-link=\"{\u0026quot;event_name\u0026quot;:\u0026quot;file_download\u0026quot;,\u0026quot;type\u0026quot;:\u0026quot;attachment\u0026quot;}\" href=\"https://assets.publishing.service.gov.uk/media/5a78fe0a40f0b679c0a07b00/vcs-service-provision-harassment.pdf\"\u003e\u003cimg alt=\"\" class=\"gem-c-attachment__thumbnail-image gem-c-attachment__thumbnail-image--custom\" src=\"https://assets.publishing.service.gov.uk/media/5a78fe0aed915d0422066f3c/thumbnail_vcs-service-provision-harassment.pdf.png\" /\u003e\u003c/a\u003e\u003c/div\u003e\n  \u003cdiv class=\"gem-c-attachment__details\"\u003e\n    \u003ch2 class=\"gem-c-attachment__title\"\u003e\n      \u003ca class=\"govuk-link gem-c-attachment__link\" target=\"_self\" data-ga4-link=\"{\u0026quot;event_name\u0026quot;:\u0026quot;file_download\u0026quot;,\u0026quot;type\u0026quot;:\u0026quot;attachment\u0026quot;}\" href=\"https://assets.publishing.service.gov.uk/media/5a78fe0a40f0b679c0a07b00/vcs-service-provision-harassment.pdf\"\u003eVoluntary and community sector: quick start guide to harassment for service providers (PDF file - 314kb)\u003c/a\u003e\n\u003c/h2\u003e\n\n\n      \u003cp class=\"gem-c-attachment__metadata\"\u003e\u003cspan class=\"gem-c-attachment__attribute\"\u003e\u003cabbr title=\"Portable Document Format\" class=\"gem-c-attachment__abbr\"\u003ePDF\u003c/abbr\u003e\u003c/span\u003e, \u003cspan class=\"gem-c-attachment__attribute\"\u003e307 KB\u003c/span\u003e, \u003cspan class=\"gem-c-attachment__attribute\"\u003e6 pages\u003c/span\u003e\u003c/p\u003e\n\n\n\n\n      \u003cp class=\"gem-c-attachment__metadata\"\u003eThis file may not be suitable for users of assistive technology.\u003c/p\u003e\n      \u003cdetails class=\"gem-c-details govuk-details govuk-!-margin-bottom-3\" data-module=\"govuk-details gem-details\"\u003e\n  \u003csummary class=\"govuk-details__summary\" data-details-track-click=\"\"\u003e\n    \u003cspan class=\"govuk-details__summary-text\"\u003e\n      Request an accessible format.\n    \u003c/span\u003e\n\u003c/summary\u003e  \u003cdiv class=\"govuk-details__text\"\u003e\n    \n        If you use assistive technology (such as a screen reader) and need a version of this document in a more accessible format, please email \u003ca href='mailto:accessible.formats@cabinetoffice.gov.uk' target='_blank' class='govuk-link'\u003eaccessible.formats@cabinetoffice.gov.uk\u003c/a\u003e. Please tell us what format you need. It will help us if you say what assistive technology you use.\n\n  \u003c/div\u003e\n\u003c/details\u003e\u003c/div\u003e\u003c/section\u003e",
+      "\u003csection class=\"gem-c-attachment govuk-!-display-none-print govuk-!-margin-bottom-6\" data-module=\"ga4-link-tracker\"\u003e\n  \u003cdiv class=\"gem-c-attachment__thumbnail\"\u003e\n    \u003ca class=\"govuk-link\" target=\"_self\" tabindex=\"-1\" aria-hidden=\"true\" data-ga4-link=\"{\u0026quot;event_name\u0026quot;:\u0026quot;file_download\u0026quot;,\u0026quot;type\u0026quot;:\u0026quot;attachment\u0026quot;}\" href=\"https://assets.publishing.service.gov.uk/media/5a79bdcced915d07d35b7c2a/vcs-positive-action.pdf\"\u003e\u003cimg alt=\"\" class=\"gem-c-attachment__thumbnail-image gem-c-attachment__thumbnail-image--custom\" src=\"https://assets.publishing.service.gov.uk/media/5a79bdce40f0b66d161adce9/thumbnail_vcs-positive-action.pdf.png\" /\u003e\u003c/a\u003e\u003c/div\u003e\n  \u003cdiv class=\"gem-c-attachment__details\"\u003e\n    \u003ch2 class=\"gem-c-attachment__title\"\u003e\n      \u003ca class=\"govuk-link gem-c-attachment__link\" target=\"_self\" data-ga4-link=\"{\u0026quot;event_name\u0026quot;:\u0026quot;file_download\u0026quot;,\u0026quot;type\u0026quot;:\u0026quot;attachment\u0026quot;}\" href=\"https://assets.publishing.service.gov.uk/media/5a79bdcced915d07d35b7c2a/vcs-positive-action.pdf\"\u003eVoluntary and community sector: quick start guide to positive action for service providers (PDF file - 301kb)\u003c/a\u003e\n\u003c/h2\u003e\n\n\n      \u003cp class=\"gem-c-attachment__metadata\"\u003e\u003cspan class=\"gem-c-attachment__attribute\"\u003e\u003cabbr title=\"Portable Document Format\" class=\"gem-c-attachment__abbr\"\u003ePDF\u003c/abbr\u003e\u003c/span\u003e, \u003cspan class=\"gem-c-attachment__attribute\"\u003e295 KB\u003c/span\u003e, \u003cspan class=\"gem-c-attachment__attribute\"\u003e6 pages\u003c/span\u003e\u003c/p\u003e\n\n\n\n\n      \u003cp class=\"gem-c-attachment__metadata\"\u003eThis file may not be suitable for users of assistive technology.\u003c/p\u003e\n      \u003cdetails class=\"gem-c-details govuk-details govuk-!-margin-bottom-3\" data-module=\"govuk-details gem-details\"\u003e\n  \u003csummary class=\"govuk-details__summary\" data-details-track-click=\"\"\u003e\n    \u003cspan class=\"govuk-details__summary-text\"\u003e\n      Request an accessible format.\n    \u003c/span\u003e\n\u003c/summary\u003e  \u003cdiv class=\"govuk-details__text\"\u003e\n    \n        If you use assistive technology (such as a screen reader) and need a version of this document in a more accessible format, please email \u003ca href='mailto:accessible.formats@cabinetoffice.gov.uk' target='_blank' class='govuk-link'\u003eaccessible.formats@cabinetoffice.gov.uk\u003c/a\u003e. Please tell us what format you need. It will help us if you say what assistive technology you use.\n\n  \u003c/div\u003e\n\u003c/details\u003e\u003c/div\u003e\u003c/section\u003e",
+      "\u003csection class=\"gem-c-attachment govuk-!-display-none-print govuk-!-margin-bottom-6\" data-module=\"ga4-link-tracker\"\u003e\n  \u003cdiv class=\"gem-c-attachment__thumbnail\"\u003e\n    \u003ca class=\"govuk-link\" target=\"_self\" tabindex=\"-1\" aria-hidden=\"true\" data-ga4-link=\"{\u0026quot;event_name\u0026quot;:\u0026quot;file_download\u0026quot;,\u0026quot;type\u0026quot;:\u0026quot;attachment\u0026quot;}\" href=\"https://assets.publishing.service.gov.uk/media/5a78f2f740f0b62b22cbe12b/vcs-religion-belief.pdf\"\u003e\u003cimg alt=\"\" class=\"gem-c-attachment__thumbnail-image gem-c-attachment__thumbnail-image--custom\" src=\"https://assets.publishing.service.gov.uk/media/5a78f2f940f0b6324769b6cb/thumbnail_vcs-religion-belief.pdf.png\" /\u003e\u003c/a\u003e\u003c/div\u003e\n  \u003cdiv class=\"gem-c-attachment__details\"\u003e\n    \u003ch2 class=\"gem-c-attachment__title\"\u003e\n      \u003ca class=\"govuk-link gem-c-attachment__link\" target=\"_self\" data-ga4-link=\"{\u0026quot;event_name\u0026quot;:\u0026quot;file_download\u0026quot;,\u0026quot;type\u0026quot;:\u0026quot;attachment\u0026quot;}\" href=\"https://assets.publishing.service.gov.uk/media/5a78f2f740f0b62b22cbe12b/vcs-religion-belief.pdf\"\u003eVoluntary and community sector: quick start guide to religion or belief discrimination in service provision (PDF file - 426kb)\u003c/a\u003e\n\u003c/h2\u003e\n\n\n      \u003cp class=\"gem-c-attachment__metadata\"\u003e\u003cspan class=\"gem-c-attachment__attribute\"\u003e\u003cabbr title=\"Portable Document Format\" class=\"gem-c-attachment__abbr\"\u003ePDF\u003c/abbr\u003e\u003c/span\u003e, \u003cspan class=\"gem-c-attachment__attribute\"\u003e417 KB\u003c/span\u003e, \u003cspan class=\"gem-c-attachment__attribute\"\u003e12 pages\u003c/span\u003e\u003c/p\u003e\n\n\n\n\n      \u003cp class=\"gem-c-attachment__metadata\"\u003eThis file may not be suitable for users of assistive technology.\u003c/p\u003e\n      \u003cdetails class=\"gem-c-details govuk-details govuk-!-margin-bottom-3\" data-module=\"govuk-details gem-details\"\u003e\n  \u003csummary class=\"govuk-details__summary\" data-details-track-click=\"\"\u003e\n    \u003cspan class=\"govuk-details__summary-text\"\u003e\n      Request an accessible format.\n    \u003c/span\u003e\n\u003c/summary\u003e  \u003cdiv class=\"govuk-details__text\"\u003e\n    \n        If you use assistive technology (such as a screen reader) and need a version of this document in a more accessible format, please email \u003ca href='mailto:accessible.formats@cabinetoffice.gov.uk' target='_blank' class='govuk-link'\u003eaccessible.formats@cabinetoffice.gov.uk\u003c/a\u003e. Please tell us what format you need. It will help us if you say what assistive technology you use.\n\n  \u003c/div\u003e\n\u003c/details\u003e\u003c/div\u003e\u003c/section\u003e",
+      "\u003csection class=\"gem-c-attachment govuk-!-display-none-print govuk-!-margin-bottom-6\" data-module=\"ga4-link-tracker\"\u003e\n  \u003cdiv class=\"gem-c-attachment__thumbnail\"\u003e\n    \u003ca class=\"govuk-link\" target=\"_self\" tabindex=\"-1\" aria-hidden=\"true\" data-ga4-link=\"{\u0026quot;event_name\u0026quot;:\u0026quot;file_download\u0026quot;,\u0026quot;type\u0026quot;:\u0026quot;attachment\u0026quot;}\" href=\"https://assets.publishing.service.gov.uk/media/5a7963cced915d04220680c7/vcs-service-providers.pdf\"\u003e\u003cimg alt=\"\" class=\"gem-c-attachment__thumbnail-image gem-c-attachment__thumbnail-image--custom\" src=\"https://assets.publishing.service.gov.uk/media/5a7963cded915d07d35b51c6/thumbnail_vcs-service-providers.pdf.png\" /\u003e\u003c/a\u003e\u003c/div\u003e\n  \u003cdiv class=\"gem-c-attachment__details\"\u003e\n    \u003ch2 class=\"gem-c-attachment__title\"\u003e\n      \u003ca class=\"govuk-link gem-c-attachment__link\" target=\"_self\" data-ga4-link=\"{\u0026quot;event_name\u0026quot;:\u0026quot;file_download\u0026quot;,\u0026quot;type\u0026quot;:\u0026quot;attachment\u0026quot;}\" href=\"https://assets.publishing.service.gov.uk/media/5a7963cced915d04220680c7/vcs-service-providers.pdf\"\u003eVoluntary and community sector: summary guide for service providers (PDF file - 643kb)\u003c/a\u003e\n\u003c/h2\u003e\n\n\n      \u003cp class=\"gem-c-attachment__metadata\"\u003e\u003cspan class=\"gem-c-attachment__attribute\"\u003e\u003cabbr title=\"Portable Document Format\" class=\"gem-c-attachment__abbr\"\u003ePDF\u003c/abbr\u003e\u003c/span\u003e, \u003cspan class=\"gem-c-attachment__attribute\"\u003e628 KB\u003c/span\u003e, \u003cspan class=\"gem-c-attachment__attribute\"\u003e12 pages\u003c/span\u003e\u003c/p\u003e\n\n\n\n\n      \u003cp class=\"gem-c-attachment__metadata\"\u003eThis file may not be suitable for users of assistive technology.\u003c/p\u003e\n      \u003cdetails class=\"gem-c-details govuk-details govuk-!-margin-bottom-3\" data-module=\"govuk-details gem-details\"\u003e\n  \u003csummary class=\"govuk-details__summary\" data-details-track-click=\"\"\u003e\n    \u003cspan class=\"govuk-details__summary-text\"\u003e\n      Request an accessible format.\n    \u003c/span\u003e\n\u003c/summary\u003e  \u003cdiv class=\"govuk-details__text\"\u003e\n    \n        If you use assistive technology (such as a screen reader) and need a version of this document in a more accessible format, please email \u003ca href='mailto:accessible.formats@cabinetoffice.gov.uk' target='_blank' class='govuk-link'\u003eaccessible.formats@cabinetoffice.gov.uk\u003c/a\u003e. Please tell us what format you need. It will help us if you say what assistive technology you use.\n\n  \u003c/div\u003e\n\u003c/details\u003e\u003c/div\u003e\u003c/section\u003e",
+      "\u003csection class=\"gem-c-attachment govuk-!-display-none-print govuk-!-margin-bottom-6\" data-module=\"ga4-link-tracker\"\u003e\n  \u003cdiv class=\"gem-c-attachment__thumbnail\"\u003e\n    \u003ca class=\"govuk-link\" target=\"_self\" tabindex=\"-1\" aria-hidden=\"true\" data-ga4-link=\"{\u0026quot;event_name\u0026quot;:\u0026quot;file_download\u0026quot;,\u0026quot;type\u0026quot;:\u0026quot;attachment\u0026quot;}\" href=\"https://assets.publishing.service.gov.uk/media/5a79d58ded915d042206b5fd/welsh-carers.pdf\"\u003e\u003cimg alt=\"\" class=\"gem-c-attachment__thumbnail-image gem-c-attachment__thumbnail-image--custom\" src=\"https://assets.publishing.service.gov.uk/media/5a79d58ced915d6b1deb3af8/thumbnail_welsh-carers.pdf.png\" /\u003e\u003c/a\u003e\u003c/div\u003e\n  \u003cdiv class=\"gem-c-attachment__details\"\u003e\n    \u003ch2 class=\"gem-c-attachment__title\"\u003e\n      \u003ca class=\"govuk-link gem-c-attachment__link\" target=\"_self\" data-ga4-link=\"{\u0026quot;event_name\u0026quot;:\u0026quot;file_download\u0026quot;,\u0026quot;type\u0026quot;:\u0026quot;attachment\u0026quot;}\" href=\"https://assets.publishing.service.gov.uk/media/5a79d58ded915d042206b5fd/welsh-carers.pdf\"\u003eWelsh language guide: Deddf Cydraddoldeb 2010: Beth sydd angen i mi ei wybod fel gofalwr? (PDF file - 266kb)\u003c/a\u003e\n\u003c/h2\u003e\n\n\n      \u003cp class=\"gem-c-attachment__metadata\"\u003e\u003cspan class=\"gem-c-attachment__attribute\"\u003e\u003cabbr title=\"Portable Document Format\" class=\"gem-c-attachment__abbr\"\u003ePDF\u003c/abbr\u003e\u003c/span\u003e, \u003cspan class=\"gem-c-attachment__attribute\"\u003e260 KB\u003c/span\u003e, \u003cspan class=\"gem-c-attachment__attribute\"\u003e2 pages\u003c/span\u003e\u003c/p\u003e\n\n\n\n\n      \u003cp class=\"gem-c-attachment__metadata\"\u003eThis file may not be suitable for users of assistive technology.\u003c/p\u003e\n      \u003cdetails class=\"gem-c-details govuk-details govuk-!-margin-bottom-3\" data-module=\"govuk-details gem-details\"\u003e\n  \u003csummary class=\"govuk-details__summary\" data-details-track-click=\"\"\u003e\n    \u003cspan class=\"govuk-details__summary-text\"\u003e\n      Request an accessible format.\n    \u003c/span\u003e\n\u003c/summary\u003e  \u003cdiv class=\"govuk-details__text\"\u003e\n    \n        If you use assistive technology (such as a screen reader) and need a version of this document in a more accessible format, please email \u003ca href='mailto:accessible.formats@cabinetoffice.gov.uk' target='_blank' class='govuk-link'\u003eaccessible.formats@cabinetoffice.gov.uk\u003c/a\u003e. Please tell us what format you need. It will help us if you say what assistive technology you use.\n\n  \u003c/div\u003e\n\u003c/details\u003e\u003c/div\u003e\u003c/section\u003e",
+      "\u003csection class=\"gem-c-attachment govuk-!-display-none-print govuk-!-margin-bottom-6\" data-module=\"ga4-link-tracker\"\u003e\n  \u003cdiv class=\"gem-c-attachment__thumbnail\"\u003e\n    \u003ca class=\"govuk-link\" target=\"_self\" tabindex=\"-1\" aria-hidden=\"true\" data-ga4-link=\"{\u0026quot;event_name\u0026quot;:\u0026quot;file_download\u0026quot;,\u0026quot;type\u0026quot;:\u0026quot;attachment\u0026quot;}\" href=\"https://assets.publishing.service.gov.uk/media/5a75767940f0b6397f35e9e1/welsh-your-rights.pdf\"\u003e\u003cimg alt=\"\" class=\"gem-c-attachment__thumbnail-image gem-c-attachment__thumbnail-image--custom\" src=\"https://assets.publishing.service.gov.uk/media/5a757677e5274a1622e21fb6/thumbnail_welsh-your-rights.pdf.png\" /\u003e\u003c/a\u003e\u003c/div\u003e\n  \u003cdiv class=\"gem-c-attachment__details\"\u003e\n    \u003ch2 class=\"gem-c-attachment__title\"\u003e\n      \u003ca class=\"govuk-link gem-c-attachment__link\" target=\"_self\" data-ga4-link=\"{\u0026quot;event_name\u0026quot;:\u0026quot;file_download\u0026quot;,\u0026quot;type\u0026quot;:\u0026quot;attachment\u0026quot;}\" href=\"https://assets.publishing.service.gov.uk/media/5a75767940f0b6397f35e9e1/welsh-your-rights.pdf\"\u003eWelsh language guide: Deddf Cydraddoldeb 2010: Beth sydd angen i mi ei wybod? Canllaw cryno i\u0026#39;ch hawliau (PDF file - 310kb)\u003c/a\u003e\n\u003c/h2\u003e\n\n\n      \u003cp class=\"gem-c-attachment__metadata\"\u003e\u003cspan class=\"gem-c-attachment__attribute\"\u003e\u003cabbr title=\"Portable Document Format\" class=\"gem-c-attachment__abbr\"\u003ePDF\u003c/abbr\u003e\u003c/span\u003e, \u003cspan class=\"gem-c-attachment__attribute\"\u003e303 KB\u003c/span\u003e, \u003cspan class=\"gem-c-attachment__attribute\"\u003e8 pages\u003c/span\u003e\u003c/p\u003e\n\n\n\n\n      \u003cp class=\"gem-c-attachment__metadata\"\u003eThis file may not be suitable for users of assistive technology.\u003c/p\u003e\n      \u003cdetails class=\"gem-c-details govuk-details govuk-!-margin-bottom-3\" data-module=\"govuk-details gem-details\"\u003e\n  \u003csummary class=\"govuk-details__summary\" data-details-track-click=\"\"\u003e\n    \u003cspan class=\"govuk-details__summary-text\"\u003e\n      Request an accessible format.\n    \u003c/span\u003e\n\u003c/summary\u003e  \u003cdiv class=\"govuk-details__text\"\u003e\n    \n        If you use assistive technology (such as a screen reader) and need a version of this document in a more accessible format, please email \u003ca href='mailto:accessible.formats@cabinetoffice.gov.uk' target='_blank' class='govuk-link'\u003eaccessible.formats@cabinetoffice.gov.uk\u003c/a\u003e. Please tell us what format you need. It will help us if you say what assistive technology you use.\n\n  \u003c/div\u003e\n\u003c/details\u003e\u003c/div\u003e\u003c/section\u003e",
+      "\u003csection class=\"gem-c-attachment govuk-!-display-none-print govuk-!-margin-bottom-6\" data-module=\"ga4-link-tracker\"\u003e\n  \u003cdiv class=\"gem-c-attachment__thumbnail\"\u003e\n    \u003ca class=\"govuk-link\" target=\"_self\" tabindex=\"-1\" aria-hidden=\"true\" data-ga4-link=\"{\u0026quot;event_name\u0026quot;:\u0026quot;file_download\u0026quot;,\u0026quot;type\u0026quot;:\u0026quot;attachment\u0026quot;}\" href=\"https://assets.publishing.service.gov.uk/media/5a7ab206e5274a34770e67a3/small-business-guidance.pdf\"\u003e\u003cimg alt=\"\" class=\"gem-c-attachment__thumbnail-image gem-c-attachment__thumbnail-image--custom\" src=\"https://assets.publishing.service.gov.uk/media/5a7ab20840f0b66a2fc02273/thumbnail_small-business-guidance.pdf.png\" /\u003e\u003c/a\u003e\u003c/div\u003e\n  \u003cdiv class=\"gem-c-attachment__details\"\u003e\n    \u003ch2 class=\"gem-c-attachment__title\"\u003e\n      \u003ca class=\"govuk-link gem-c-attachment__link\" target=\"_self\" data-ga4-link=\"{\u0026quot;event_name\u0026quot;:\u0026quot;file_download\u0026quot;,\u0026quot;type\u0026quot;:\u0026quot;attachment\u0026quot;}\" href=\"https://assets.publishing.service.gov.uk/media/5a7ab206e5274a34770e67a3/small-business-guidance.pdf\"\u003eEquality Act 2010 Recruitment – asking questions about disability and health\u003c/a\u003e\n\u003c/h2\u003e\n\n\n      \u003cp class=\"gem-c-attachment__metadata\"\u003e\u003cspan class=\"gem-c-attachment__attribute\"\u003e\u003cabbr title=\"Portable Document Format\" class=\"gem-c-attachment__abbr\"\u003ePDF\u003c/abbr\u003e\u003c/span\u003e, \u003cspan class=\"gem-c-attachment__attribute\"\u003e129 KB\u003c/span\u003e, \u003cspan class=\"gem-c-attachment__attribute\"\u003e4 pages\u003c/span\u003e\u003c/p\u003e\n\n\n\n\n      \u003cp class=\"gem-c-attachment__metadata\"\u003eThis file may not be suitable for users of assistive technology.\u003c/p\u003e\n      \u003cdetails class=\"gem-c-details govuk-details govuk-!-margin-bottom-3\" data-module=\"govuk-details gem-details\"\u003e\n  \u003csummary class=\"govuk-details__summary\" data-details-track-click=\"\"\u003e\n    \u003cspan class=\"govuk-details__summary-text\"\u003e\n      Request an accessible format.\n    \u003c/span\u003e\n\u003c/summary\u003e  \u003cdiv class=\"govuk-details__text\"\u003e\n    \n        If you use assistive technology (such as a screen reader) and need a version of this document in a more accessible format, please email \u003ca href='mailto:accessible.formats@cabinetoffice.gov.uk' target='_blank' class='govuk-link'\u003eaccessible.formats@cabinetoffice.gov.uk\u003c/a\u003e. Please tell us what format you need. It will help us if you say what assistive technology you use.\n\n  \u003c/div\u003e\n\u003c/details\u003e\u003c/div\u003e\u003c/section\u003e",
+      "\u003csection class=\"gem-c-attachment govuk-!-display-none-print govuk-!-margin-bottom-6\" data-module=\"ga4-link-tracker\"\u003e\n  \u003cdiv class=\"gem-c-attachment__thumbnail\"\u003e\n    \u003ca class=\"govuk-link\" target=\"_self\" tabindex=\"-1\" aria-hidden=\"true\" data-ga4-link=\"{\u0026quot;event_name\u0026quot;:\u0026quot;file_download\u0026quot;,\u0026quot;type\u0026quot;:\u0026quot;attachment\u0026quot;}\" href=\"https://assets.publishing.service.gov.uk/media/5a7b346d40f0b66a2fc05dc5/Equality_Act_2010_-_Duty_on_employers_to_make_reasonable_adjustments_for....pdf\"\u003e\u003cimg alt=\"\" class=\"gem-c-attachment__thumbnail-image gem-c-attachment__thumbnail-image--custom\" src=\"https://assets.publishing.service.gov.uk/media/5a7b346ce5274a34770ea20e/thumbnail_Equality_Act_2010_-_Duty_on_employers_to_make_reasonable_adjustments_for....pdf.png\" /\u003e\u003c/a\u003e\u003c/div\u003e\n  \u003cdiv class=\"gem-c-attachment__details\"\u003e\n    \u003ch2 class=\"gem-c-attachment__title\"\u003e\n      \u003ca class=\"govuk-link gem-c-attachment__link\" target=\"_self\" data-ga4-link=\"{\u0026quot;event_name\u0026quot;:\u0026quot;file_download\u0026quot;,\u0026quot;type\u0026quot;:\u0026quot;attachment\u0026quot;}\" href=\"https://assets.publishing.service.gov.uk/media/5a7b346d40f0b66a2fc05dc5/Equality_Act_2010_-_Duty_on_employers_to_make_reasonable_adjustments_for....pdf\"\u003eEquality Act 2010 Duty on employers to make reasonable adjustments for their staff\u003c/a\u003e\n\u003c/h2\u003e\n\n\n      \u003cp class=\"gem-c-attachment__metadata\"\u003e\u003cspan class=\"gem-c-attachment__attribute\"\u003e\u003cabbr title=\"Portable Document Format\" class=\"gem-c-attachment__abbr\"\u003ePDF\u003c/abbr\u003e\u003c/span\u003e, \u003cspan class=\"gem-c-attachment__attribute\"\u003e147 KB\u003c/span\u003e, \u003cspan class=\"gem-c-attachment__attribute\"\u003e6 pages\u003c/span\u003e\u003c/p\u003e\n\n\n\n\n      \u003cp class=\"gem-c-attachment__metadata\"\u003eThis file may not be suitable for users of assistive technology.\u003c/p\u003e\n      \u003cdetails class=\"gem-c-details govuk-details govuk-!-margin-bottom-3\" data-module=\"govuk-details gem-details\"\u003e\n  \u003csummary class=\"govuk-details__summary\" data-details-track-click=\"\"\u003e\n    \u003cspan class=\"govuk-details__summary-text\"\u003e\n      Request an accessible format.\n    \u003c/span\u003e\n\u003c/summary\u003e  \u003cdiv class=\"govuk-details__text\"\u003e\n    \n        If you use assistive technology (such as a screen reader) and need a version of this document in a more accessible format, please email \u003ca href='mailto:accessible.formats@cabinetoffice.gov.uk' target='_blank' class='govuk-link'\u003eaccessible.formats@cabinetoffice.gov.uk\u003c/a\u003e. Please tell us what format you need. It will help us if you say what assistive technology you use.\n\n  \u003c/div\u003e\n\u003c/details\u003e\u003c/div\u003e\u003c/section\u003e"
+    ],
+    "political": false,
+    "attachments": [
+      {
+        "id": "7726810",
+        "url": "/government/publications/equality-act-guidance/disability-equality-act-2010-guidance-on-matters-to-be-taken-into-account-in-determining-questions-relating-to-the-definition-of-disability-html",
+        "isbn": "",
+        "title": "Disability: Equality Act 2010 - Guidance on matters to be taken into account in determining questions relating to the definition of disability (HTML)",
+        "attachment_type": "html",
+        "hoc_paper_number": "",
+        "unique_reference": "",
+        "command_paper_number": "",
+        "unnumbered_hoc_paper": false,
+        "unnumbered_command_paper": false
+      },
+      {
+        "id": "7726811",
+        "url": "https://assets.publishing.service.gov.uk/media/5a80dcc8ed915d74e6230df4/Equality_Act_2010-disability_definition.pdf",
+        "isbn": "",
+        "title": "Disability: Equality Act 2010 - Guidance on matters to be taken into account in determining questions relating to the definition of disability (PDF)",
+        "filename": "Equality_Act_2010-disability_definition.pdf",
+        "file_size": 709794,
+        "accessible": true,
+        "content_type": "application/pdf",
+        "attachment_type": "file",
+        "number_of_pages": 60,
+        "hoc_paper_number": "",
+        "unique_reference": "",
+        "command_paper_number": "",
+        "unnumbered_hoc_paper": false,
+        "unnumbered_command_paper": false,
+        "alternative_format_contact_email": "accessible.formats@cabinetoffice.gov.uk"
+      },
+      {
+        "id": "7726812",
+        "url": "/government/publications/equality-act-guidance/individuals-a-summary-guide-to-your-rights-html",
+        "isbn": "",
+        "title": "Individuals: a summary guide to your rights (HTML)",
+        "attachment_type": "html",
+        "hoc_paper_number": "",
+        "unique_reference": "",
+        "command_paper_number": "",
+        "unnumbered_hoc_paper": false,
+        "unnumbered_command_paper": false
+      },
+      {
+        "id": "7726813",
+        "url": "https://assets.publishing.service.gov.uk/media/5a78ff28ed915d0422066fb6/individual-rights1.pdf",
+        "isbn": "",
+        "title": "Individuals: a summary guide to your rights (PDF)",
+        "filename": "individual-rights1.pdf",
+        "file_size": 216634,
+        "accessible": false,
+        "content_type": "application/pdf",
+        "attachment_type": "file",
+        "number_of_pages": 8,
+        "hoc_paper_number": "",
+        "unique_reference": "",
+        "command_paper_number": "",
+        "unnumbered_hoc_paper": false,
+        "unnumbered_command_paper": false,
+        "alternative_format_contact_email": "accessible.formats@cabinetoffice.gov.uk"
+      },
+      {
+        "id": "7726814",
+        "url": "/government/publications/equality-act-guidance/disability-quick-start-guide-for-service-providers-html",
+        "isbn": "",
+        "title": "Disability: quick start guide for service providers (HTML)",
+        "attachment_type": "html",
+        "hoc_paper_number": "",
+        "unique_reference": "",
+        "command_paper_number": "",
+        "unnumbered_hoc_paper": false,
+        "unnumbered_command_paper": false
+      },
+      {
+        "id": "7726815",
+        "url": "https://assets.publishing.service.gov.uk/media/5a79c79940f0b66d161ae174/disability.pdf",
+        "isbn": "",
+        "title": "Disability: quick start guide for service providers (PDF)",
+        "filename": "disability.pdf",
+        "file_size": 317256,
+        "accessible": false,
+        "content_type": "application/pdf",
+        "attachment_type": "file",
+        "number_of_pages": 12,
+        "hoc_paper_number": "",
+        "unique_reference": "",
+        "command_paper_number": "",
+        "unnumbered_hoc_paper": false,
+        "unnumbered_command_paper": false,
+        "alternative_format_contact_email": "accessible.formats@cabinetoffice.gov.uk"
+      },
+      {
+        "id": "7726816",
+        "url": "https://assets.publishing.service.gov.uk/media/5a7970a640f0b642860d81bc/age-discrimination-ban.pdf",
+        "isbn": "",
+        "title": "Age discrimination ban in services and public functions: An overview for service providers and customers. (PDF file - 162kb)",
+        "filename": "age-discrimination-ban.pdf",
+        "file_size": 162844,
+        "accessible": false,
+        "content_type": "application/pdf",
+        "attachment_type": "file",
+        "number_of_pages": 13,
+        "unique_reference": "",
+        "command_paper_number": "",
+        "unnumbered_hoc_paper": false,
+        "unnumbered_command_paper": false,
+        "alternative_format_contact_email": "accessible.formats@cabinetoffice.gov.uk"
+      },
+      {
+        "id": "7726817",
+        "url": "https://assets.publishing.service.gov.uk/media/5a78ca86e5274a2acd189d0f/age-discrimination-guide-clubs.pdf",
+        "isbn": "",
+        "title": "Age discrimination ban in services and public functions: A guide for private clubs (PDF file - 129kb)",
+        "filename": "age-discrimination-guide-clubs.pdf",
+        "file_size": 129607,
+        "accessible": false,
+        "content_type": "application/pdf",
+        "attachment_type": "file",
+        "number_of_pages": 4,
+        "unique_reference": "",
+        "command_paper_number": "",
+        "unnumbered_hoc_paper": false,
+        "unnumbered_command_paper": false,
+        "alternative_format_contact_email": "accessible.formats@cabinetoffice.gov.uk"
+      },
+      {
+        "id": "7726818",
+        "url": "https://assets.publishing.service.gov.uk/media/5a78cddb40f0b62b22cbced3/age-discrimination-guide-sme.pdf",
+        "isbn": "",
+        "title": "Age discrimination ban in services and public functions: A guide for small businesses (PDF file - 129kb)",
+        "filename": "age-discrimination-guide-sme.pdf",
+        "file_size": 129807,
+        "accessible": false,
+        "content_type": "application/pdf",
+        "attachment_type": "file",
+        "number_of_pages": 4,
+        "unique_reference": "",
+        "command_paper_number": "",
+        "unnumbered_hoc_paper": false,
+        "unnumbered_command_paper": false,
+        "alternative_format_contact_email": "accessible.formats@cabinetoffice.gov.uk"
+      },
+      {
+        "id": "7726819",
+        "url": "https://assets.publishing.service.gov.uk/media/5a78cde5ed915d0422065783/holiday-discrimination-age.pdf",
+        "isbn": "",
+        "title": "Age discrimination ban in services and public functions: A guide for holiday providers, hotels and those letting holiday properties. (PDF file - 780kb)",
+        "filename": "holiday-discrimination-age.pdf",
+        "file_size": 780790,
+        "accessible": false,
+        "content_type": "application/pdf",
+        "attachment_type": "file",
+        "number_of_pages": 6,
+        "unique_reference": "",
+        "command_paper_number": "",
+        "unnumbered_hoc_paper": false,
+        "unnumbered_command_paper": false,
+        "alternative_format_contact_email": "accessible.formats@cabinetoffice.gov.uk"
+      },
+      {
+        "id": "7726820",
+        "url": "https://assets.publishing.service.gov.uk/media/5a79906f40f0b63d72fc6ced/business-quickstart.pdf",
+        "isbn": "",
+        "title": "Business: quick start guide for providing goods and services (PDF file - 340kb)",
+        "filename": "business-quickstart.pdf",
+        "file_size": 340039,
+        "accessible": false,
+        "content_type": "application/pdf",
+        "attachment_type": "file",
+        "number_of_pages": 20,
+        "unique_reference": "",
+        "command_paper_number": "",
+        "unnumbered_hoc_paper": false,
+        "unnumbered_command_paper": false,
+        "alternative_format_contact_email": "accessible.formats@cabinetoffice.gov.uk"
+      },
+      {
+        "id": "7726821",
+        "url": "https://assets.publishing.service.gov.uk/media/5a78dbdae5274a277e690056/business-summary.pdf",
+        "isbn": "",
+        "title": "Business: summary guide for providing goods and services (PDF file - 280kb)",
+        "filename": "business-summary.pdf",
+        "file_size": 280514,
+        "accessible": false,
+        "content_type": "application/pdf",
+        "attachment_type": "file",
+        "number_of_pages": 8,
+        "unique_reference": "",
+        "command_paper_number": "",
+        "unnumbered_hoc_paper": false,
+        "unnumbered_command_paper": false,
+        "alternative_format_contact_email": "accessible.formats@cabinetoffice.gov.uk"
+      },
+      {
+        "id": "7726822",
+        "url": "https://assets.publishing.service.gov.uk/media/5a79c91ced915d07d35b8159/easy-read.pdf",
+        "isbn": "",
+        "title": "Easy Read: The Equality Act - making equality real (PDF file - 2mb - Warning: large file)",
+        "filename": "easy-read.pdf",
+        "file_size": 2414441,
+        "accessible": false,
+        "content_type": "application/pdf",
+        "attachment_type": "file",
+        "number_of_pages": 38,
+        "unique_reference": "",
+        "command_paper_number": "",
+        "unnumbered_hoc_paper": false,
+        "unnumbered_command_paper": false,
+        "alternative_format_contact_email": "accessible.formats@cabinetoffice.gov.uk"
+      },
+      {
+        "id": "7726823",
+        "url": "https://assets.publishing.service.gov.uk/media/5a79b5d440f0b642860da26f/employment-health-questions.pdf",
+        "isbn": "",
+        "title": "Employers: quick start guide to the ban on questions about health and disability during recruitment (PDF file - 333kb)",
+        "filename": "employment-health-questions.pdf",
+        "file_size": 333583,
+        "accessible": false,
+        "content_type": "application/pdf",
+        "attachment_type": "file",
+        "number_of_pages": 8,
+        "unique_reference": "",
+        "command_paper_number": "",
+        "unnumbered_hoc_paper": false,
+        "unnumbered_command_paper": false,
+        "alternative_format_contact_email": "accessible.formats@cabinetoffice.gov.uk"
+      },
+      {
+        "id": "7726824",
+        "url": "https://assets.publishing.service.gov.uk/media/5a78ec44ed915d0422066689/carers.pdf",
+        "isbn": "",
+        "title": "Individuals: what do I need to know as a carer? (PDF file - 237kb)",
+        "filename": "carers.pdf",
+        "file_size": 237264,
+        "accessible": false,
+        "content_type": "application/pdf",
+        "attachment_type": "file",
+        "number_of_pages": 6,
+        "unique_reference": "",
+        "command_paper_number": "",
+        "unnumbered_hoc_paper": false,
+        "unnumbered_command_paper": false,
+        "alternative_format_contact_email": "accessible.formats@cabinetoffice.gov.uk"
+      },
+      {
+        "id": "7726825",
+        "url": "https://assets.publishing.service.gov.uk/media/5a78f58340f0b62b22cbe26d/private-clubs.pdf",
+        "isbn": "",
+        "title": "Private clubs and associations: quick start guide (PDF file - 289kb)",
+        "filename": "private-clubs.pdf",
+        "file_size": 289947,
+        "accessible": false,
+        "content_type": "application/pdf",
+        "attachment_type": "file",
+        "number_of_pages": 12,
+        "unique_reference": "",
+        "command_paper_number": "",
+        "unnumbered_hoc_paper": false,
+        "unnumbered_command_paper": false,
+        "alternative_format_contact_email": "accessible.formats@cabinetoffice.gov.uk"
+      },
+      {
+        "id": "7726828",
+        "url": "https://assets.publishing.service.gov.uk/media/5a78fdcaed915d07d35b4036/public-sector.pdf",
+        "isbn": "",
+        "title": "Public sector: summary guide for public sector organisations (PDF file - 308kb)",
+        "filename": "public-sector.pdf",
+        "file_size": 308562,
+        "accessible": false,
+        "content_type": "application/pdf",
+        "attachment_type": "file",
+        "number_of_pages": 12,
+        "unique_reference": "",
+        "command_paper_number": "",
+        "unnumbered_hoc_paper": false,
+        "unnumbered_command_paper": false,
+        "alternative_format_contact_email": "accessible.formats@cabinetoffice.gov.uk"
+      },
+      {
+        "id": "7726829",
+        "url": "https://assets.publishing.service.gov.uk/media/5a78b9ae40f0b62b22cbc4b4/vcs-association-perception.pdf",
+        "isbn": "",
+        "title": "Voluntary and community sector: quick start guide to discrimination by association and perception for service providers (PDF file - 281kb)",
+        "filename": "vcs-association-perception.pdf",
+        "file_size": 281054,
+        "accessible": false,
+        "content_type": "application/pdf",
+        "attachment_type": "file",
+        "number_of_pages": 6,
+        "unique_reference": "",
+        "command_paper_number": "",
+        "unnumbered_hoc_paper": false,
+        "unnumbered_command_paper": false,
+        "alternative_format_contact_email": "accessible.formats@cabinetoffice.gov.uk"
+      },
+      {
+        "id": "7726830",
+        "url": "https://assets.publishing.service.gov.uk/media/5a74c502ed915d4d83b5ed12/vcs-associations.pdf",
+        "isbn": "",
+        "title": "Voluntary and community sector: quick start guide for associations (PDF file - 301kb)",
+        "filename": "vcs-associations.pdf",
+        "file_size": 301130,
+        "accessible": false,
+        "content_type": "application/pdf",
+        "attachment_type": "file",
+        "number_of_pages": 6,
+        "unique_reference": "",
+        "command_paper_number": "",
+        "unnumbered_hoc_paper": false,
+        "unnumbered_command_paper": false,
+        "alternative_format_contact_email": "accessible.formats@cabinetoffice.gov.uk"
+      },
+      {
+        "id": "7726831",
+        "url": "https://assets.publishing.service.gov.uk/media/5a79007540f0b679c0a07c24/vcs-gender-reassignment.pdf",
+        "isbn": "",
+        "title": "Voluntary and community sector: quick start guide to gender reassignment for service providers (PDF file - 329kb)",
+        "filename": "vcs-gender-reassignment.pdf",
+        "file_size": 329390,
+        "accessible": false,
+        "content_type": "application/pdf",
+        "attachment_type": "file",
+        "number_of_pages": 12,
+        "unique_reference": "",
+        "command_paper_number": "",
+        "unnumbered_hoc_paper": false,
+        "unnumbered_command_paper": false,
+        "alternative_format_contact_email": "accessible.formats@cabinetoffice.gov.uk"
+      },
+      {
+        "id": "7726832",
+        "url": "https://assets.publishing.service.gov.uk/media/5a78fe0a40f0b679c0a07b00/vcs-service-provision-harassment.pdf",
+        "isbn": "",
+        "title": "Voluntary and community sector: quick start guide to harassment for service providers (PDF file - 314kb)",
+        "filename": "vcs-service-provision-harassment.pdf",
+        "file_size": 314264,
+        "accessible": false,
+        "content_type": "application/pdf",
+        "attachment_type": "file",
+        "number_of_pages": 6,
+        "unique_reference": "",
+        "command_paper_number": "",
+        "unnumbered_hoc_paper": false,
+        "unnumbered_command_paper": false,
+        "alternative_format_contact_email": "accessible.formats@cabinetoffice.gov.uk"
+      },
+      {
+        "id": "7726833",
+        "url": "https://assets.publishing.service.gov.uk/media/5a79bdcced915d07d35b7c2a/vcs-positive-action.pdf",
+        "isbn": "",
+        "title": "Voluntary and community sector: quick start guide to positive action for service providers (PDF file - 301kb)",
+        "filename": "vcs-positive-action.pdf",
+        "file_size": 301796,
+        "accessible": false,
+        "content_type": "application/pdf",
+        "attachment_type": "file",
+        "number_of_pages": 6,
+        "unique_reference": "",
+        "command_paper_number": "",
+        "unnumbered_hoc_paper": false,
+        "unnumbered_command_paper": false,
+        "alternative_format_contact_email": "accessible.formats@cabinetoffice.gov.uk"
+      },
+      {
+        "id": "7726834",
+        "url": "https://assets.publishing.service.gov.uk/media/5a78f2f740f0b62b22cbe12b/vcs-religion-belief.pdf",
+        "isbn": "",
+        "title": "Voluntary and community sector: quick start guide to religion or belief discrimination in service provision (PDF file - 426kb)",
+        "filename": "vcs-religion-belief.pdf",
+        "file_size": 426802,
+        "accessible": false,
+        "content_type": "application/pdf",
+        "attachment_type": "file",
+        "number_of_pages": 12,
+        "unique_reference": "",
+        "command_paper_number": "",
+        "unnumbered_hoc_paper": false,
+        "unnumbered_command_paper": false,
+        "alternative_format_contact_email": "accessible.formats@cabinetoffice.gov.uk"
+      },
+      {
+        "id": "7726835",
+        "url": "https://assets.publishing.service.gov.uk/media/5a7963cced915d04220680c7/vcs-service-providers.pdf",
+        "isbn": "",
+        "title": "Voluntary and community sector: summary guide for service providers (PDF file - 643kb)",
+        "filename": "vcs-service-providers.pdf",
+        "file_size": 643028,
+        "accessible": false,
+        "content_type": "application/pdf",
+        "attachment_type": "file",
+        "number_of_pages": 12,
+        "unique_reference": "",
+        "command_paper_number": "",
+        "unnumbered_hoc_paper": false,
+        "unnumbered_command_paper": false,
+        "alternative_format_contact_email": "accessible.formats@cabinetoffice.gov.uk"
+      },
+      {
+        "id": "7726836",
+        "url": "https://assets.publishing.service.gov.uk/media/5a79d58ded915d042206b5fd/welsh-carers.pdf",
+        "isbn": "",
+        "title": "Welsh language guide: Deddf Cydraddoldeb 2010: Beth sydd angen i mi ei wybod fel gofalwr? (PDF file - 266kb)",
+        "filename": "welsh-carers.pdf",
+        "file_size": 266396,
+        "accessible": false,
+        "content_type": "application/pdf",
+        "attachment_type": "file",
+        "number_of_pages": 2,
+        "unique_reference": "",
+        "command_paper_number": "",
+        "unnumbered_hoc_paper": false,
+        "unnumbered_command_paper": false,
+        "alternative_format_contact_email": "accessible.formats@cabinetoffice.gov.uk"
+      },
+      {
+        "id": "7726837",
+        "url": "https://assets.publishing.service.gov.uk/media/5a75767940f0b6397f35e9e1/welsh-your-rights.pdf",
+        "isbn": "",
+        "title": "Welsh language guide: Deddf Cydraddoldeb 2010: Beth sydd angen i mi ei wybod? Canllaw cryno i'ch hawliau (PDF file - 310kb)",
+        "filename": "welsh-your-rights.pdf",
+        "file_size": 310514,
+        "accessible": false,
+        "content_type": "application/pdf",
+        "attachment_type": "file",
+        "number_of_pages": 8,
+        "unique_reference": "",
+        "command_paper_number": "",
+        "unnumbered_hoc_paper": false,
+        "unnumbered_command_paper": false,
+        "alternative_format_contact_email": "accessible.formats@cabinetoffice.gov.uk"
+      },
+      {
+        "id": "7726838",
+        "url": "https://assets.publishing.service.gov.uk/media/5a7ab206e5274a34770e67a3/small-business-guidance.pdf",
+        "isbn": "",
+        "title": "Equality Act 2010 Recruitment – asking questions about disability and health",
+        "filename": "small-business-guidance.pdf",
+        "file_size": 131830,
+        "accessible": false,
+        "content_type": "application/pdf",
+        "attachment_type": "file",
+        "number_of_pages": 4,
+        "unique_reference": "",
+        "command_paper_number": "",
+        "unnumbered_hoc_paper": false,
+        "unnumbered_command_paper": false,
+        "alternative_format_contact_email": "accessible.formats@cabinetoffice.gov.uk"
+      },
+      {
+        "id": "7726839",
+        "url": "https://assets.publishing.service.gov.uk/media/5a7b346d40f0b66a2fc05dc5/Equality_Act_2010_-_Duty_on_employers_to_make_reasonable_adjustments_for....pdf",
+        "isbn": "",
+        "title": "Equality Act 2010 Duty on employers to make reasonable adjustments for their staff",
+        "filename": "Equality_Act_2010_-_Duty_on_employers_to_make_reasonable_adjustments_for....pdf",
+        "file_size": 150860,
+        "accessible": false,
+        "content_type": "application/pdf",
+        "attachment_type": "file",
+        "number_of_pages": 6,
+        "unique_reference": "",
+        "command_paper_number": "",
+        "unnumbered_hoc_paper": false,
+        "unnumbered_command_paper": false,
+        "alternative_format_contact_email": "accessible.formats@cabinetoffice.gov.uk"
+      }
+    ],
+    "change_history": [
+      {
+        "note": "Added 2 recent leaflets: one on pre-employment questions in recruitment and one on reasonable adjustments.",
+        "public_timestamp": "2013-03-08T11:45:45.000+00:00"
+      },
+      {
+        "note": "First published.",
+        "public_timestamp": "2011-06-22T00:00:00.000+01:00"
+      }
+    ],
+    "first_public_at": "2011-06-22T00:00:00.000+01:00",
+    "featured_attachments": [
+      "7726810",
+      "7726811",
+      "7726812",
+      "7726813",
+      "7726814",
+      "7726815",
+      "7726816",
+      "7726817",
+      "7726818",
+      "7726819",
+      "7726820",
+      "7726821",
+      "7726822",
+      "7726823",
+      "7726824",
+      "7726825",
+      "7726828",
+      "7726829",
+      "7726830",
+      "7726831",
+      "7726832",
+      "7726833",
+      "7726834",
+      "7726835",
+      "7726836",
+      "7726837",
+      "7726838",
+      "7726839"
+    ],
+    "emphasised_organisations": [
+      "3df55660-43a9-4494-8146-a0a492a975b6"
+    ]
+  },
+  "routes": [
+    {
+      "path": "/government/publications/equality-act-guidance",
+      "type": "exact"
+    }
+  ],
+  "redirects": [],
+  "content_id": "5d60fe55-7631-11e4-a3cb-005056011aef",
+  "locale": "en",
+  "expanded_links": {
+    "children": [
+      {
+        "content_id": "4ed99d56-7e8a-4a72-9885-243c6788b3e0",
+        "title": "Disability: Equality Act 2010 - Guidance on matters to be taken into account in determining questions relating to the definition of disability (HTML)",
+        "locale": "en",
+        "analytics_identifier": null,
+        "api_path": "/api/content/government/publications/equality-act-guidance/disability-equality-act-2010-guidance-on-matters-to-be-taken-into-account-in-determining-questions-relating-to-the-definition-of-disability-html",
+        "base_path": "/government/publications/equality-act-guidance/disability-equality-act-2010-guidance-on-matters-to-be-taken-into-account-in-determining-questions-relating-to-the-definition-of-disability-html",
+        "document_type": "html_publication",
+        "public_updated_at": "2023-12-19T15:36:25Z",
+        "schema_name": "html_publication",
+        "withdrawn": false,
+        "links": {
+          "parent": [
+            {
+              "content_id": "5d60fe55-7631-11e4-a3cb-005056011aef",
+              "title": "Equality Act 2010: how it might affect you",
+              "locale": "en",
+              "analytics_identifier": null,
+              "api_path": "/api/content/government/publications/equality-act-guidance",
+              "base_path": "/government/publications/equality-act-guidance",
+              "document_type": "guidance",
+              "public_updated_at": "2013-03-08T11:45:45Z",
+              "schema_name": "publication",
+              "withdrawn": false,
+              "links": {}
+            }
+          ]
+        }
+      },
+      {
+        "content_id": "14399b3c-9881-44c2-9e48-fe4fd8b7e1d1",
+        "title": "Individuals: a summary guide to your rights (HTML)",
+        "locale": "en",
+        "analytics_identifier": null,
+        "api_path": "/api/content/government/publications/equality-act-guidance/individuals-a-summary-guide-to-your-rights-html",
+        "base_path": "/government/publications/equality-act-guidance/individuals-a-summary-guide-to-your-rights-html",
+        "document_type": "html_publication",
+        "public_updated_at": "2023-12-19T15:36:25Z",
+        "schema_name": "html_publication",
+        "withdrawn": false,
+        "links": {
+          "parent": [
+            {
+              "content_id": "5d60fe55-7631-11e4-a3cb-005056011aef",
+              "title": "Equality Act 2010: how it might affect you",
+              "locale": "en",
+              "analytics_identifier": null,
+              "api_path": "/api/content/government/publications/equality-act-guidance",
+              "base_path": "/government/publications/equality-act-guidance",
+              "document_type": "guidance",
+              "public_updated_at": "2013-03-08T11:45:45Z",
+              "schema_name": "publication",
+              "withdrawn": false,
+              "links": {}
+            }
+          ]
+        }
+      },
+      {
+        "content_id": "fdd3da65-2155-477a-aa7c-39adb2e025b7",
+        "title": "Disability: quick start guide for service providers (HTML)",
+        "locale": "en",
+        "analytics_identifier": null,
+        "api_path": "/api/content/government/publications/equality-act-guidance/disability-quick-start-guide-for-service-providers-html",
+        "base_path": "/government/publications/equality-act-guidance/disability-quick-start-guide-for-service-providers-html",
+        "document_type": "html_publication",
+        "public_updated_at": "2023-12-19T15:36:25Z",
+        "schema_name": "html_publication",
+        "withdrawn": false,
+        "links": {
+          "parent": [
+            {
+              "content_id": "5d60fe55-7631-11e4-a3cb-005056011aef",
+              "title": "Equality Act 2010: how it might affect you",
+              "locale": "en",
+              "analytics_identifier": null,
+              "api_path": "/api/content/government/publications/equality-act-guidance",
+              "base_path": "/government/publications/equality-act-guidance",
+              "document_type": "guidance",
+              "public_updated_at": "2013-03-08T11:45:45Z",
+              "schema_name": "publication",
+              "withdrawn": false,
+              "links": {}
+            }
+          ]
+        }
+      }
+    ],
+    "government": [
+      {
+        "content_id": "591c83aa-3b74-437d-a342-612bddd97572",
+        "title": "2010 to 2015 Conservative and Liberal Democrat coalition government",
+        "locale": "en",
+        "api_path": "/api/content/government/2010-to-2015-conservative-and-liberal-democrat-coalition-government",
+        "base_path": "/government/2010-to-2015-conservative-and-liberal-democrat-coalition-government",
+        "document_type": "government",
+        "details": {
+          "started_on": "2010-05-12T00:00:00+00:00",
+          "ended_on": "2015-05-08T00:00:00+00:00",
+          "current": false
+        },
+        "links": {}
+      }
+    ],
+    "organisations": [
+      {
+        "content_id": "3df55660-43a9-4494-8146-a0a492a975b6",
+        "title": "Government Equalities Office",
+        "locale": "en",
+        "analytics_identifier": "OT506",
+        "api_path": "/api/content/government/organisations/government-equalities-office",
+        "base_path": "/government/organisations/government-equalities-office",
+        "document_type": "organisation",
+        "schema_name": "organisation",
+        "withdrawn": false,
+        "details": {
+          "acronym": "GEO",
+          "logo": {
+            "crest": "single-identity",
+            "formatted_title": "Government\u003cbr/\u003eEqualities Office"
+          },
+          "brand": "cabinet-office",
+          "default_news_image": null,
+          "organisation_govuk_status": {
+            "url": null,
+            "status": "live",
+            "updated_at": null
+          }
+        },
+        "links": {}
+      }
+    ],
+    "original_primary_publishing_organisation": [
+      {
+        "content_id": "3df55660-43a9-4494-8146-a0a492a975b6",
+        "title": "Government Equalities Office",
+        "locale": "en",
+        "analytics_identifier": "OT506",
+        "api_path": "/api/content/government/organisations/government-equalities-office",
+        "base_path": "/government/organisations/government-equalities-office",
+        "document_type": "organisation",
+        "schema_name": "organisation",
+        "withdrawn": false,
+        "details": {
+          "acronym": "GEO",
+          "logo": {
+            "crest": "single-identity",
+            "formatted_title": "Government\u003cbr/\u003eEqualities Office"
+          },
+          "brand": "cabinet-office",
+          "default_news_image": null,
+          "organisation_govuk_status": {
+            "url": null,
+            "status": "live",
+            "updated_at": null
+          }
+        },
+        "links": {}
+      }
+    ],
+    "primary_publishing_organisation": [
+      {
+        "content_id": "3df55660-43a9-4494-8146-a0a492a975b6",
+        "title": "Government Equalities Office",
+        "locale": "en",
+        "analytics_identifier": "OT506",
+        "api_path": "/api/content/government/organisations/government-equalities-office",
+        "base_path": "/government/organisations/government-equalities-office",
+        "document_type": "organisation",
+        "schema_name": "organisation",
+        "withdrawn": false,
+        "details": {
+          "acronym": "GEO",
+          "logo": {
+            "crest": "single-identity",
+            "formatted_title": "Government\u003cbr/\u003eEqualities Office"
+          },
+          "brand": "cabinet-office",
+          "default_news_image": null,
+          "organisation_govuk_status": {
+            "url": null,
+            "status": "live",
+            "updated_at": null
+          }
+        },
+        "links": {}
+      }
+    ],
+    "suggested_ordered_related_items": [
+      {
+        "content_id": "5d610121-7631-11e4-a3cb-005056011aef",
+        "title": "Easy Read: The Equality Act - making equality real",
+        "locale": "en",
+        "analytics_identifier": null,
+        "api_path": "/api/content/government/publications/easy-read-the-equality-act-making-equality-real",
+        "base_path": "/government/publications/easy-read-the-equality-act-making-equality-real",
+        "document_type": "guidance",
+        "public_updated_at": "2011-06-22T00:00:00Z",
+        "schema_name": "publication",
+        "withdrawn": false,
+        "links": {}
+      },
+      {
+        "content_id": "5d60f638-7631-11e4-a3cb-005056011aef",
+        "title": "Equality Act 2010: Schedule 19 (consolidated) - April 2011",
+        "locale": "en",
+        "analytics_identifier": null,
+        "api_path": "/api/content/government/publications/equality-act-2010-schedule-19-consolidated-april-2011",
+        "base_path": "/government/publications/equality-act-2010-schedule-19-consolidated-april-2011",
+        "document_type": "policy_paper",
+        "public_updated_at": "2011-06-24T00:00:00Z",
+        "schema_name": "publication",
+        "withdrawn": false,
+        "links": {}
+      },
+      {
+        "content_id": "5d63623a-7631-11e4-a3cb-005056011aef",
+        "title": "Equality Act 2010: guidance",
+        "locale": "en",
+        "analytics_identifier": null,
+        "api_path": "/api/content/guidance/equality-act-2010-guidance",
+        "base_path": "/guidance/equality-act-2010-guidance",
+        "document_type": "detailed_guide",
+        "public_updated_at": "2015-06-16T13:56:57Z",
+        "schema_name": "detailed_guide",
+        "withdrawn": false,
+        "links": {}
+      },
+      {
+        "content_id": "29dbb58f-e0dd-49ed-9bfd-7d9ce231b913",
+        "title": "Equality and diversity policy",
+        "locale": "en",
+        "analytics_identifier": null,
+        "api_path": "/api/content/government/publications/equality-and-diversity-policy",
+        "base_path": "/government/publications/equality-and-diversity-policy",
+        "document_type": "guidance",
+        "public_updated_at": "2015-02-18T14:01:53Z",
+        "schema_name": "publication",
+        "withdrawn": false,
+        "links": {}
+      },
+      {
+        "content_id": "18c49235-0527-4eb1-aa4f-7baaf5866a12",
+        "title": "Reporting an accessibility problem on a public sector website",
+        "locale": "en",
+        "analytics_identifier": null,
+        "api_path": "/api/content/reporting-accessibility-problem-public-sector-website",
+        "base_path": "/reporting-accessibility-problem-public-sector-website",
+        "document_type": "answer",
+        "public_updated_at": "2019-11-11T16:15:19Z",
+        "schema_name": "answer",
+        "withdrawn": false,
+        "links": {}
+      }
+    ],
+    "taxons": [
+      {
+        "content_id": "75efcbd0-4f01-4ce2-b151-01a58f8fb7a9",
+        "title": "Equality",
+        "locale": "en",
+        "analytics_identifier": null,
+        "api_path": "/api/content/society-and-culture/equality",
+        "base_path": "/society-and-culture/equality",
+        "document_type": "taxon",
+        "public_updated_at": "2018-09-06T15:56:53Z",
+        "schema_name": "taxon",
+        "withdrawn": false,
+        "description": "",
+        "details": {
+          "internal_name": "Equality [P]",
+          "notes_for_editors": "",
+          "visible_to_departmental_editors": false
+        },
+        "phase": "live",
+        "links": {
+          "parent_taxons": [
+            {
+              "content_id": "b297e49c-7da4-4bc1-8714-da80fa0758d3",
+              "title": "Equality, rights and citizenship",
+              "locale": "en",
+              "analytics_identifier": null,
+              "api_path": "/api/content/society-and-culture/equality-rights-and-citizenship",
+              "base_path": "/society-and-culture/equality-rights-and-citizenship",
+              "document_type": "taxon",
+              "public_updated_at": "2018-08-22T13:12:17Z",
+              "schema_name": "taxon",
+              "withdrawn": false,
+              "description": null,
+              "details": {
+                "internal_name": "Equality, rights and citizenship (society and culture, level 2)",
+                "notes_for_editors": "",
+                "visible_to_departmental_editors": false
+              },
+              "phase": "live",
+              "links": {
+                "parent_taxons": [
+                  {
+                    "content_id": "e2ca2f1a-0ff3-43ce-b813-16645ff27904",
+                    "title": "Society and culture",
+                    "locale": "en",
+                    "analytics_identifier": null,
+                    "api_path": "/api/content/society-and-culture",
+                    "base_path": "/society-and-culture",
+                    "document_type": "taxon",
+                    "public_updated_at": "2018-09-16T20:31:27Z",
+                    "schema_name": "taxon",
+                    "withdrawn": false,
+                    "description": "",
+                    "details": {
+                      "internal_name": "Society and culture",
+                      "notes_for_editors": "",
+                      "visible_to_departmental_editors": true
+                    },
+                    "phase": "live",
+                    "links": {
+                      "root_taxon": [
+                        {
+                          "content_id": "f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a",
+                          "title": "GOV.UK homepage",
+                          "locale": "en",
+                          "analytics_identifier": null,
+                          "api_path": "/api/content/",
+                          "base_path": "/",
+                          "document_type": "homepage",
+                          "public_updated_at": "2023-06-28T09:32:34Z",
+                          "schema_name": "homepage",
+                          "withdrawn": false,
+                          "links": {}
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "available_translations": [
+      {
+        "title": "Equality Act 2010: how it might affect you",
+        "public_updated_at": "2013-03-08T11:45:45Z",
+        "analytics_identifier": null,
+        "document_type": "guidance",
+        "schema_name": "publication",
+        "base_path": "/government/publications/equality-act-guidance",
+        "api_path": "/api/content/government/publications/equality-act-guidance",
+        "withdrawn": false,
+        "content_id": "5d60fe55-7631-11e4-a3cb-005056011aef",
+        "locale": "en"
+      }
+    ]
+  },
+  "user_journey_document_supertype": "thing",
+  "email_document_supertype": "publications",
+  "government_document_supertype": "guidance",
+  "content_purpose_subgroup": "guidance",
+  "content_purpose_supergroup": "guidance_and_regulation",
+  "publishing_request_id": "21-1703000279.831-10.13.20.46-2757",
+  "govuk_request_id": null,
+  "links": {
+    "government": [
+      "591c83aa-3b74-437d-a342-612bddd97572"
+    ],
+    "organisations": [
+      "3df55660-43a9-4494-8146-a0a492a975b6"
+    ],
+    "original_primary_publishing_organisation": [
+      "3df55660-43a9-4494-8146-a0a492a975b6"
+    ],
+    "primary_publishing_organisation": [
+      "3df55660-43a9-4494-8146-a0a492a975b6"
+    ],
+    "related_policies": [
+      "5d37adc5-7631-11e4-a3cb-005056011aef"
+    ],
+    "suggested_ordered_related_items": [
+      "5d610121-7631-11e4-a3cb-005056011aef",
+      "5d60f638-7631-11e4-a3cb-005056011aef",
+      "5d63623a-7631-11e4-a3cb-005056011aef",
+      "29dbb58f-e0dd-49ed-9bfd-7d9ce231b913",
+      "18c49235-0527-4eb1-aa4f-7baaf5866a12"
+    ],
+    "taxons": [
+      "7acd1cbd-2f79-44f9-9ca5-2d12637a77ad",
+      "75efcbd0-4f01-4ce2-b151-01a58f8fb7a9"
+    ]
+  },
+  "payload_version": "12345"
+}

--- a/spec/integration/document_synchronization_spec.rb
+++ b/spec/integration/document_synchronization_spec.rb
@@ -267,6 +267,53 @@ RSpec.describe "Document synchronization" do
     end
   end
 
+  describe "for a 'guidance' message with attachments" do
+    let(:payload) { json_fixture_as_hash("message_queue/guidance_message.json") }
+
+    it "is added to Discovery Engine through the Put service" do
+      expect(put_service).to have_received(:call).with(
+        "5d60fe55-7631-11e4-a3cb-005056011aef",
+        {
+          content_id: "5d60fe55-7631-11e4-a3cb-005056011aef",
+          content_purpose_supergroup: "guidance_and_regulation",
+          description: "How the Equality Act 2010 defines disability, and what law changes mean for the public, businesses, and the public and voluntary sectors.",
+          document_type: "guidance",
+          government_name: "2010 to 2015 Conservative and Liberal Democrat coalition government",
+          is_historic: 0,
+          link: "/government/publications/equality-act-guidance",
+          locale: "en",
+          organisations: %w[government-equalities-office],
+          part_of_taxonomy_tree: %w[
+            7acd1cbd-2f79-44f9-9ca5-2d12637a77ad
+            75efcbd0-4f01-4ce2-b151-01a58f8fb7a9
+          ],
+          public_timestamp: 1_362_743_145,
+          title: "Equality Act 2010: how it might affect you",
+          url: "https://www.gov.uk/government/publications/equality-act-guidance",
+          parts: [
+            {
+              title: "Disability: Equality Act 2010 - Guidance on matters to be taken into account in determining questions relating to the definition of disability (HTML)",
+              body: "",
+              slug: "disability-equality-act-2010-guidance-on-matters-to-be-taken-into-account-in-determining-questions-relating-to-the-definition-of-disability-html",
+            },
+            {
+              title: "Individuals: a summary guide to your rights (HTML)",
+              body: "",
+              slug: "individuals-a-summary-guide-to-your-rights-html",
+            },
+            {
+              title: "Disability: quick start guide for service providers (HTML)",
+              body: "",
+              slug: "disability-quick-start-guide-for-service-providers-html",
+            },
+          ],
+        },
+        content: a_string_starting_with("Equality Act 2010: how it might affect you"),
+        payload_version: 12_345,
+      )
+    end
+  end
+
   describe "for a 'taxon' message that isn't ignorelisted" do
     let(:payload) { json_fixture_as_hash("message_queue/world_taxon_message.json") }
 

--- a/spec/models/concerns/publishing_api/metadata_spec.rb
+++ b/spec/models/concerns/publishing_api/metadata_spec.rb
@@ -319,10 +319,11 @@ RSpec.describe PublishingApi::Metadata do
     describe "parts" do
       subject(:extracted_parts) { extracted_metadata[:parts] }
 
-      let(:document_hash) { { details: { parts: } } }
+      let(:document_hash) { { base_path: "/parent", details: { parts:, attachments: } } }
 
-      context "when the document has no parts" do
+      context "when the document has no parts or attachments" do
         let(:parts) { nil }
+        let(:attachments) { nil }
 
         it { is_expected.to be_nil }
       end
@@ -356,6 +357,7 @@ RSpec.describe PublishingApi::Metadata do
             },
           ]
         end
+        let(:attachments) { nil }
 
         it "contains the expected titles" do
           expect(extracted_parts.map { _1[:title] }).to eq(["Part 1", "Part 2"])
@@ -370,6 +372,42 @@ RSpec.describe PublishingApi::Metadata do
             "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur…",
             nil,
           ])
+        end
+      end
+
+      context "when the document has attachments" do
+        let(:parts) { nil }
+        let(:attachments) do
+          [
+            {
+              url: "http://example.org/external-url",
+              title: "External URL that shouldn't be indexed",
+            },
+            {
+              url: "/different-parent/attachment",
+              title: "Attachment with different parent that shouldn't be indexed",
+            },
+            {
+              url: "/parent/attachment-1",
+              title: "Attachment 1",
+            },
+            {
+              url: "/parent/attachment-2",
+              title: "Attachment 2",
+            },
+          ]
+        end
+
+        it "contains the expected titles" do
+          expect(extracted_parts.map { _1[:title] }).to eq(["Attachment 1", "Attachment 2"])
+        end
+
+        it "contains the expected slugs" do
+          expect(extracted_parts.map { _1[:slug] }).to eq(%w[attachment-1 attachment-2])
+        end
+
+        it "contains blank bodies for all parts" do
+          expect(extracted_parts.map { _1[:body] }).to eq(["", ""])
         end
       end
     end


### PR DESCRIPTION
When a document has "attachments" in Publishing API, these should come through in search as if they were parts (even though they're technically not). This is a bit of a fudge from v1, but we have no choice but to replicate it to keep compatibility and desired functionality.

Unfortunately the message from Publishing API doesn't include the content of the attachment, so depending on whether we consider that necessary, we may have to go out to Publishing API and fetch content to populate the `body` field of generated attachment parts.