### PR TITLE
Add initial metrics support

### DIFF
--- a/app/services/discovery_engine/query/search.rb
+++ b/app/services/discovery_engine/query/search.rb
@@ -29,7 +29,10 @@ module DiscoveryEngine::Query
     attr_reader :query_params, :client
 
     def response
-      @response ||= client.search(discovery_engine_params).response
+      @response ||= begin
+        Metrics.increment_counter(:search_requests)
+        client.search(discovery_engine_params).response
+      end
     end
 
     def discovery_engine_params

--- a/app/services/discovery_engine/sync/delete.rb
+++ b/app/services/discovery_engine/sync/delete.rb
@@ -11,6 +11,7 @@ module DiscoveryEngine::Sync
       client.delete_document(name: document_name(content_id))
 
       log(Logger::Severity::INFO, "Successfully deleted", content_id:, payload_version:)
+      Metrics.increment_counter(:delete_requests)
     rescue Google::Cloud::NotFoundError => e
       log(
         Logger::Severity::INFO,
@@ -24,6 +25,7 @@ module DiscoveryEngine::Sync
         content_id:, payload_version:,
       )
       GovukError.notify(e)
+      Metrics.increment_counter(:failed_delete_requests)
     end
 
   private

--- a/app/services/discovery_engine/sync/put.rb
+++ b/app/services/discovery_engine/sync/put.rb
@@ -25,6 +25,7 @@ module DiscoveryEngine::Sync
       )
 
       log(Logger::Severity::INFO, "Successfully added/updated", content_id:, payload_version:)
+      Metrics.increment_counter(:put_requests)
     rescue Google::Cloud::Error => e
       log(
         Logger::Severity::ERROR,
@@ -32,6 +33,7 @@ module DiscoveryEngine::Sync
         content_id:, payload_version:,
       )
       GovukError.notify(e)
+      Metrics.increment_counter(:failed_put_requests)
     end
 
   private

--- a/app/services/metrics.rb
+++ b/app/services/metrics.rb
@@ -1,0 +1,28 @@
+module Metrics
+  CLIENT = PrometheusExporter::Client.default
+  COUNTERS = {
+    search_requests: CLIENT.register(
+      :counter, "search_api_v2_search_requests", "number of incoming search requests"
+    ),
+    put_requests: CLIENT.register(
+      :counter, "search_api_v2_put_requests", "number of put requests to Discovery Engine"
+    ),
+    delete_requests: CLIENT.register(
+      :counter, "search_api_v2_put_requests", "number of delete requests to Discovery Engine"
+    ),
+    failed_put_requests: CLIENT.register(
+      :counter, "search_api_v2_failed_put_requests", "number of failed put requests to Discovery Engine"
+    ),
+    failed_delete_requests: CLIENT.register(
+      :counter, "search_api_v2_failed_delete_requests", "number of failed delete requests to Discovery Engine"
+    ),
+  }.freeze
+
+  def self.increment_counter(counter)
+    Rails.logger.warn("Unknown counter: #{counter}") and return unless COUNTERS.key?(counter)
+
+    COUNTERS[counter].observe(1)
+  rescue StandardError
+    # Metrics are best effort only, don't raise if they fail
+  end
+end


### PR DESCRIPTION
- Add `Metrics` module to abstract metric updates using default `PrometheusExporter` client
- Add basic initial metrics for number of search/put/delete requests and failures