### PR TITLE
Log `update_type` with incoming documents

### DIFF
--- a/app/models/concerns/publishing_api/action.rb
+++ b/app/models/concerns/publishing_api/action.rb
@@ -69,6 +69,10 @@ module PublishingApi
       document_hash[:withdrawn_notice].present?
     end
 
+    def update_type
+      document_hash[:update_type]
+    end
+
     def document_type
       document_hash.fetch(:document_type)
     end

--- a/app/models/publishing_api_document.rb
+++ b/app/models/publishing_api_document.rb
@@ -39,10 +39,11 @@ private
 
   def log(message)
     combined_message = sprintf(
-      "[%s] Processing document to %s with content_id:%s link:%s payload_version:%d",
+      "[%s] Processing document to %s with content_id:%s update_type:%s link:%s payload_version:%d",
       self.class.name,
       message,
       content_id,
+      update_type,
       link,
       payload_version,
     )


### PR DESCRIPTION
This is to help us debug the flood of incoming messages.