### PR TITLE
Add histogram metric for processing duration

### DIFF
--- a/app/message_processors/publishing_api_message_processor.rb
+++ b/app/message_processors/publishing_api_message_processor.rb
@@ -3,9 +3,11 @@ class PublishingApiMessageProcessor
   def process(message)
     Metrics.increment_counter(:incoming_messages)
 
-    document_hash = message.payload.deep_symbolize_keys
-    document = PublishingApiDocument.new(document_hash)
-    document.synchronize
+    Metrics.observe_duration(:total_processing_duration) do
+      document_hash = message.payload.deep_symbolize_keys
+      document = PublishingApiDocument.new(document_hash)
+      document.synchronize
+    end
 
     message.ack
   rescue StandardError => e

--- a/app/services/metrics.rb
+++ b/app/services/metrics.rb
@@ -33,6 +33,15 @@ module Metrics
       "number of documents skipped from syncing to Discovery Engine",
     ),
   }.freeze
+  HISTOGRAMS = {
+    ### Syncing histograms
+    total_processing_duration: CLIENT.register(
+      :histogram,
+      "search_api_v2_total_processing_duration",
+      "total time taken to process an incoming message from Publishing API (seconds)",
+      buckets: [0.1, 0.5, 1, 2, 5],
+    ),
+  }.freeze
 
   def self.increment_counter(counter, labels = {})
     Rails.logger.warn("Unknown counter: #{counter}") and return unless COUNTERS.key?(counter)
@@ -40,5 +49,25 @@ module Metrics
     COUNTERS[counter].observe(1, labels)
   rescue StandardError
     # Metrics are best effort only, don't raise if they fail
+  end
+
+  def self.observe_duration(histogram, labels = {}, &block)
+    unless HISTOGRAMS.key?(histogram)
+      Rails.logger.warn("Unknown histogram: #{histogram}")
+      return block.call
+    end
+
+    result = nil
+    duration = Benchmark.realtime do
+      result = block.call
+    end
+
+    begin
+      HISTOGRAMS[histogram].observe(duration, labels)
+    rescue StandardError
+      # Metrics are best effort only, don't raise if they fail
+    end
+
+    result
   end
 end


### PR DESCRIPTION
- Add `total_processing_duration` histogram to track how long it takes to process a metric
- Add `Metrics.observe_duration` as a convenience method to track execution time of a block