### PR TITLE
Add ability to run result invariant check

### DIFF
--- a/app/services/quality_monitoring/check_result_invariants.rb
+++ b/app/services/quality_monitoring/check_result_invariants.rb
@@ -1,0 +1,33 @@
+module QualityMonitoring
+  class InvariantViolatedError < StandardError; end
+
+  # Ensures that Discovery Engine returns expected results for a set of invariants
+  class CheckResultInvariants
+    def initialize(search_service_klass: DiscoveryEngine::Query::Search)
+      @search_service_klass = search_service_klass
+    end
+
+    def violations
+      invariants = QualityMonitoring::ResultInvariant.all
+
+      invariants.filter_map { |invariant|
+        query_params = { q: invariant.query }
+        result_links = search_service_klass.new(query_params).result_set.results.map(&:link)
+
+        missing_links = invariant.expected_links - result_links
+        next if missing_links.empty?
+
+        missing_links.map do |missing_link|
+          ResultInvariantViolation.new(
+            query: invariant.query,
+            expected_link: missing_link,
+          )
+        end
+      }.flatten
+    end
+
+  private
+
+    attr_reader :search_service_klass
+  end
+end

--- a/app/services/quality_monitoring/result_invariant.rb
+++ b/app/services/quality_monitoring/result_invariant.rb
@@ -1,0 +1,12 @@
+module QualityMonitoring
+  # Represents a query and the links that should always be returned on the first page of results
+  ResultInvariant = Data.define(:query, :expected_links) do
+    def self.all
+      config_values = Rails.application.config.result_invariants || {}
+
+      config_values.map do |query, expected_link_or_links|
+        new(query: query.to_s, expected_links: Array(expected_link_or_links))
+      end
+    end
+  end
+end

--- a/app/services/quality_monitoring/result_invariant_violation.rb
+++ b/app/services/quality_monitoring/result_invariant_violation.rb
@@ -1,0 +1,4 @@
+module QualityMonitoring
+  # Represents a missing result link for a query
+  ResultInvariantViolation = Data.define(:query, :expected_link)
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -28,5 +28,8 @@ module SearchApiV2
 
     # Query configuration
     config.best_bets = config_for(:best_bets)
+
+    # Quality monitoring configuration
+    config.result_invariants = config_for(:result_invariants)
   end
 end

--- a/config/result_invariants.yml
+++ b/config/result_invariants.yml
@@ -1,0 +1,246 @@
+# Defines expected top results for business-critical queries as a mapping from query keywords to
+# either a single link or an array of links (relative to GOV.UK for internal content, absolute for
+# external content). These are run regularly through `QualityMonitoring::CheckInvariants` to ensure
+# we catch high-impact regressions as early as possible.
+production: &production
+  "apprenticeship": /apply-apprenticeship
+  "apprenticeships": /apply-apprenticeship
+  "attendance allowance": /attendance-allowance
+  "band check": /council-tax-bands
+  "battery": /guidance/mot-inspection-manual-for-private-passenger-and-light-commercial-vehicles/4-lamps-reflectors-and-electrical-equipment
+  "birth certificate": /order-copy-birth-death-marriage-certificate
+  "blue badge": /apply-blue-badge
+  "bno visa": /british-national-overseas-bno-visa
+  "book driving test": /book-driving-test
+  "brp": /biometric-residence-permits
+  "car tax":
+  - /vehicle-tax
+  - /check-vehicle-tax
+  "carers allowance": /carers-allowance
+  "change address": /tell-hmrc-change-of-details
+  "change driving test": /change-driving-test
+  "change of address": /tell-hmrc-change-of-details
+  "check mot": /check-mot-history
+  "check your business rate valuation": /guidance/check-and-challenge-your-business-rates-valuation-step-by-step
+  "child benefit": /child-benefit
+  "child care account": /sign-in-childcare-account
+  "child care": /sign-in-childcare-account
+  "child trust fund": /child-trust-funds
+  "childcare account": /sign-in-childcare-account
+  "childcare": /sign-in-childcare-account
+  "cis": /what-is-the-construction-industry-scheme
+  "cold weather payment": /cold-weather-payment
+  "companies house": /government/organisations/companies-house
+  "company house": /government/organisations/companies-house
+  "company tax returns": /file-your-company-accounts-and-tax-return
+  "contact hmrc": /contact-hmrc
+  "contact": /contact-hmrc
+  "corporation tax":
+  - /pay-corporation-tax
+  - /log-in-register-hmrc-online-services
+  "cost of living payment": /guidance/cost-of-living-payment
+  "cost of living": /guidance/cost-of-living-payment
+  "council tax band": /council-tax-bands
+  "council tax bands": /council-tax-bands
+  "council tax":
+  - /council-tax-bands
+  - /pay-council-tax
+  "covid tests": /order-coronavirus-rapid-lateral-flow-tests
+  "dart charge": /pay-dartford-crossing-charge
+  "dbs":
+  - /government/organisations/disclosure-and-barring-service
+  - /request-copy-criminal-record
+  - /dbs-update-service
+  - /guidance/dbs-online-account-guidance
+  "driving licence":
+  - /view-driving-licence
+  - /renew-driving-licence
+  - /apply-first-provisional-driving-licence
+  "driving license": /apply-first-provisional-driving-licence
+  "driving test":
+  - /book-driving-test
+  - /change-driving-test
+  "ds01": /government/publications/strike-off-a-company-from-the-register-ds01
+  "dvla": /government/organisations/driver-and-vehicle-licensing-agency
+  "epc": /find-energy-certificate
+  "esta": https://esta.cbp.dhs.gov/
+  "eta": /guidance/apply-for-an-electronic-travel-authorisation-eta
+  "eu": /settled-status-eu-citizens-families
+  "euss": /settled-status-eu-citizens-families
+  "family visa": /uk-family-visa
+  "find a job": /find-a-job
+  "gateway": /log-in-register-hmrc-online-services
+  "gmr": /guidance/get-a-goods-movement-reference
+  "government gateway": /log-in-register-hmrc-online-services
+  "graduate visa": /graduate-visa
+  "help to save": /sign-in-help-to-save
+  "hmrc login": /log-in-register-hmrc-online-services
+  "hmrc sign in": /log-in-register-hmrc-online-services
+  "hmrc":
+  - /log-in-register-hmrc-online-services
+  - /contact-hmrc
+  "id check": /guidance/using-the-govuk-id-check-app
+  "immigration status": /view-prove-immigration-status
+  "income tax": /check-income-tax-current-year
+  "job": /find-a-job
+  "jobs": /find-a-job
+  "land registry": /government/organisations/land-registry
+  "log in": /log-in-register-hmrc-online-services
+  "login":
+  - /log-in-register-hmrc-online-services
+  - /sign-in
+  "lpa": /power-of-attorney
+  "minimum wage": /government/publications/minimum-wage-rates-for-2024
+  "mot check": /check-mot-history
+  "mot history": /check-mot-history
+  "mot":
+  - /check-mot-status
+  - /check-mot-history
+  "national insurance number":
+  - /lost-national-insurance-number
+  - /government/publications/national-insurance-get-your-national-insurance-number-in-writing-ca5403
+  "national insurance": /check-national-insurance-record
+  "ni38": /government/publications/social-security-abroad-ni38
+  "p60": /paye-forms-p45-p60-p11d
+  "passport renewal": /renew-adult-passport
+  "passport":
+  - /renew-adult-passport
+  - /apply-renew-passport
+  - /find-regional-passport-office
+  - /get-a-child-passport
+  "pay corporation tax": /pay-corporation-tax
+  "pay self assessment": /pay-self-assessment-tax-bill
+  "pay your corporation tax bill": /pay-corporation-tax
+  "paye": /log-in-register-hmrc-online-services
+  "paying hmrc":
+  - /pay-corporation-tax
+  - /pay-tax-debit-credit-card
+  "pension forecast": /check-state-pension
+  "pension":
+  - /check-state-pension
+  - /check-national-insurance-record
+  "pensions": /check-state-pension
+  "personal tax account":
+  - /personal-tax-account
+  - /log-in-register-hmrc-online-services
+  "personal tax":
+  - /log-in-register-hmrc-online-services
+  - /personal-tax-account
+  "pip": /pip
+  "power of attorney": /power-of-attorney
+  "probate":
+  - /applying-for-probate
+  - /search-will-probate
+  "prove": /prove-right-to-work
+  "provisional licence": /apply-first-provisional-driving-licence
+  "provisional license": /apply-first-provisional-driving-licence
+  "provisional": /apply-first-provisional-driving-licence
+  "psw": /graduate-visa
+  "pta": /personal-tax-account
+  "register for self assessment": /register-for-self-assessment
+  "register to vote": /register-to-vote
+  "renew driving licence": /renew-driving-licence
+  "renew driving license": /renew-driving-licence
+  "renew passport": /renew-adult-passport
+  "right to work":
+  - /prove-right-to-work
+  - /view-right-to-work
+  "road tax":
+  - /vehicle-tax
+  - /check-vehicle-tax
+  "rp02a": /government/publications/apply-for-rectification-by-the-registrar-of-companies-rp02a
+  "rp07": /government/publications/apply-to-change-a-companys-disputed-registered-office-address-rp07
+  "sa1": /guidance/register-for-self-assessment-if-you-are-not-self-employed
+  "sa100": /self-assessment-tax-return-forms
+  "sa302": /sa302-tax-calculation
+  "self assesment":
+  - /log-in-file-self-assessment-tax-return
+  - /self-assessment-tax-returns
+  "self assessment tax return": /log-in-file-self-assessment-tax-return
+  "self assessment tax returns": /self-assessment-tax-returns
+  "self assessment":
+  - /log-in-file-self-assessment-tax-return
+  - /self-assessment-tax-returns
+  - /log-in-register-hmrc-online-services
+  - /pay-self-assessment-tax-bill
+  "self employed": /set-up-self-employed
+  "share code":
+  - /view-prove-immigration-status
+  - /prove-right-to-work
+  - /prove-right-to-work/get-a-share-code-online
+  - /view-right-to-work
+  "sharecode": /view-prove-immigration-status
+  "sign in":
+  - /sign-in
+  - /log-in-register-hmrc-online-services
+  - /sign-in-visa
+  "simple assessment": /simple-assessment
+  "skilled worker visa": /skilled-worker-visa
+  "skilled worker": /skilled-worker-visa
+  "sorn": /make-a-sorn
+  "spouse visa": /uk-family-visa
+  "state pension":
+  - /check-state-pension
+  - /get-state-pension
+  "status": /view-prove-immigration-status
+  "student finance": /student-finance-register-login
+  "student visa": /student-visa
+  "suspension": /guidance/mot-inspection-manual-for-private-passenger-and-light-commercial-vehicles/5-axles-wheels-tyres-and-suspension
+  "tax account": /log-in-register-hmrc-online-services
+  "tax car": /vehicle-tax
+  "tax code": /personal-tax-account
+  "tax free childcare": /sign-in-childcare-account
+  "tax my car": /vehicle-tax
+  "tax rebate": /claim-tax-refund
+  "tax refund": /claim-tax-refund
+  "tax return":
+  - /self-assessment-tax-returns
+  - /log-in-file-self-assessment-tax-return
+  "tax vehicle": /vehicle-tax
+  "tax":
+  - /log-in-register-hmrc-online-services
+  - /vehicle-tax
+  - /guidance/sign-in-to-your-hmrc-business-tax-account
+  - /check-vehicle-tax
+  - /log-in-file-self-assessment-tax-return
+  - /government/organisations/hm-revenue-customs/contact/income-tax-enquiries-for-individuals-pensioners-and-employees
+  - /check-income-tax-current-year
+  "theory test": /book-theory-test
+  "theory": /book-theory-test
+  "travel": /foreign-travel-advice
+  "tyres": /guidance/mot-inspection-manual-for-private-passenger-and-light-commercial-vehicles/5-axles-wheels-tyres-and-suspension
+  "uc": /sign-in-universal-credit
+  "uc50": /government/publications/uc50-form-universal-credit-capability-for-work-questionnaire
+  "universal credit":
+  - /sign-in-universal-credit
+  - /universal-credit
+  - /government/publications/uc50-form-universal-credit-capability-for-work-questionnaire
+  - /government/collections/universal-credit-statistics
+  "update": /update-uk-visas-immigration-account-details
+  "utr number": /find-utr-number
+  "utr": /find-utr-number
+  "v62": /government/publications/application-for-a-vehicle-registration-certificate
+  "vat": /log-in-register-hmrc-online-services
+  "vehicle tax":
+  - /vehicle-tax
+  - /check-vehicle-tax
+  "veterans id card": /government/news/new-veterans-id-cards-rolled-out-to-service-leavers
+  "view and prove": /view-prove-immigration-status
+  "view": /view-prove-immigration-status
+  "visa":
+  - /check-uk-visa
+  - /apply-to-come-to-the-uk
+  - /sign-in-visa
+  # TODO: Remove me soon, just used to validate post-deployment
+  "i am a broken invariant for validation": /i-am-a-path/that-does-not-exist
+development:
+  <<: *production
+test:
+  "query one": /expected/result/1
+  "query two":
+    - /expected/result/2
+    - /expected/result/2.5
+  "query three":
+    - /expected/result/3
+    - /expected/result/3.5
+  "query four": /expected/result/4

--- a/lib/tasks/quality_monitoring.rake
+++ b/lib/tasks/quality_monitoring.rake
@@ -1,0 +1,19 @@
+namespace :quality_monitoring do
+  desc "Check result invariants and log and report violations to Sentry"
+  task check_result_invariants: :environment do
+    violations = QualityMonitoring::CheckResultInvariants.new.violations
+
+    violations.each do |violation|
+      Rails.logger.error(<<~MSG)
+        Result invariant violated for '#{violation.query}'
+        Expected to find link link: #{violation.expected_link}
+      MSG
+      GovukError.notify(
+        "Result invariant violated for '#{violation.query}'",
+        extra: violation.to_h,
+      )
+    end
+
+    Rails.logger.info("Result invariant check complete, #{violations.count} violation(s) found")
+  end
+end

--- a/spec/services/quality_monitoring/check_result_invariants_spec.rb
+++ b/spec/services/quality_monitoring/check_result_invariants_spec.rb
@@ -1,0 +1,71 @@
+RSpec.describe QualityMonitoring::CheckResultInvariants do
+  subject(:check_result_invariants) { described_class.new(search_service_klass:) }
+
+  let(:search_service_klass) { double("DiscoveryEngine::Query::Search", new: client) }
+  let(:client) { double("SearchService::Client") }
+
+  describe "#violations" do
+    subject(:violations) { check_result_invariants.violations }
+
+    context "when all invariants are satisfied" do
+      before do
+        allow(client).to receive(:result_set).and_return(
+          ResultSet.new(results: [
+            Result.new(link: "/expected/result/1"),
+          ]),
+          ResultSet.new(results: [
+            Result.new(link: "/expected/result/2"),
+            Result.new(link: "/expected/result/2.5"),
+          ]),
+          ResultSet.new(results: [
+            Result.new(link: "/expected/result/3.5"),
+            Result.new(link: "/expected/result/3"),
+          ]),
+          ResultSet.new(results: [
+            Result.new(link: "/expected/result/4"),
+            Result.new(link: "/expected/result/abcde"),
+          ]),
+        )
+      end
+
+      it { is_expected.to be_empty }
+    end
+
+    context "when invariants are violated" do
+      let(:expected_violations) do
+        [
+          QualityMonitoring::ResultInvariantViolation.new(
+            query: "query two",
+            expected_link: "/expected/result/2.5",
+          ),
+          QualityMonitoring::ResultInvariantViolation.new(
+            query: "query four",
+            expected_link: "/expected/result/4",
+          ),
+        ]
+      end
+
+      before do
+        allow(client).to receive(:result_set).and_return(
+          ResultSet.new(results: [
+            Result.new(link: "/expected/result/1"),
+          ]),
+          ResultSet.new(results: [
+            Result.new(link: "/expected/result/2"),
+            Result.new(link: "/expected/result/42"),
+          ]),
+          ResultSet.new(results: [
+            Result.new(link: "/expected/result/3.5"),
+            Result.new(link: "/expected/result/3"),
+          ]),
+          ResultSet.new(results: [
+            Result.new(link: "/expected/result/123"),
+            Result.new(link: "/expected/result/321"),
+          ]),
+        )
+      end
+
+      it { is_expected.to eq(expected_violations) }
+    end
+  end
+end


### PR DESCRIPTION
This will allow us to spot unexpected changes in search behaviour for business-critical results.

- Add `QualityMonitoring` module to encapsulate monitoring functionality
- Add `QualityMonitoring::CheckResultInvariants` and a Rake task to invoke it
- Add configuration file with initial set of invariants