### PR TITLE
Improve result invariant check reporting

### DIFF
--- a/lib/tasks/quality_monitoring.rake
+++ b/lib/tasks/quality_monitoring.rake
@@ -2,18 +2,23 @@ namespace :quality_monitoring do
   desc "Check result invariants and log and report violations to Sentry"
   task check_result_invariants: :environment do
     violations = QualityMonitoring::CheckResultInvariants.new.violations
+    violation_count_text = "#{violations.count} #{'violation'.pluralize(violations.count)}"
 
-    violations.each do |violation|
-      Rails.logger.error(<<~MSG)
-        Result invariant violated for '#{violation.query}'
-        Expected to find link link: #{violation.expected_link}
-      MSG
+    if violations.any?
+      violations.each do |violation|
+        Rails.logger.error(<<~MSG)
+          Result invariant violated for '#{violation.query}'
+          Expected to find link: #{violation.expected_link}
+        MSG
+      end
+
       GovukError.notify(
-        "Result invariant violated for '#{violation.query}'",
-        extra: violation.to_h,
+        "⚠️ Result invariants check: #{violation_count_text}",
+        extra: {
+          violations: violations.map { "'#{_1.query}': missing #{_1.expected_link}" }.join("\n"),
+        },
       )
     end
-
-    Rails.logger.info("Result invariant check complete, #{violations.count} violation(s) found")
+    Rails.logger.info("Result invariant check complete, #{violation_count_text} found")
   end
 end


### PR DESCRIPTION
This tidies up the result invariant check into reporting a single Sentry error per run instead of one per violation for a better overview.