### PR TITLE
Fix incorrectly desynced documents

### DIFF
--- a/app/models/concerns/publishing_api/action.rb
+++ b/app/models/concerns/publishing_api/action.rb
@@ -10,10 +10,14 @@ module PublishingApi
     PERMITTED_LOCALES = %w[en].freeze
 
     def sync?
-      !desync? && !skip?
+      return false if skip?
+
+      !desync?
     end
 
     def desync?
+      return false if skip?
+
       unpublish_type? || on_ignorelist? || unaddressable? || withdrawn?
     end
 
@@ -24,12 +28,12 @@ module PublishingApi
     end
 
     def action_reason
-      if unpublish_type?
+      if ignored_locale?
+        "locale not permitted (#{locale})"
+      elsif unpublish_type?
         "unpublish type (#{document_type})"
       elsif on_ignorelist?
         "document_type on ignorelist (#{document_type})"
-      elsif ignored_locale?
-        "locale not permitted (#{locale})"
       elsif unaddressable?
         "unaddressable"
       elsif withdrawn?

--- a/app/models/publishing_api_document.rb
+++ b/app/models/publishing_api_document.rb
@@ -19,7 +19,10 @@ class PublishingApiDocument
   end
 
   def synchronize
-    if sync?
+    if skip?
+      Metrics.increment_counter(:documents_skipped)
+      log("skip (#{action_reason})")
+    elsif sync?
       log("sync")
       Metrics.increment_counter(:documents_synced)
       put_service.call(content_id, metadata, content:, payload_version:)
@@ -28,8 +31,7 @@ class PublishingApiDocument
       Metrics.increment_counter(:documents_desynced)
       delete_service.call(content_id, payload_version:)
     else
-      Metrics.increment_counter(:documents_skipped)
-      log("skip (#{action_reason})")
+      raise "Cannot determine action for document: #{content_id}"
     end
   end
 

--- a/spec/fixtures/files/message_queue/gone_message.json
+++ b/spec/fixtures/files/message_queue/gone_message.json
@@ -1,21 +1,118 @@
 {
+  "title": null,
+  "public_updated_at": "2024-01-17T14:43:22Z",
+  "publishing_app": "hmrc-manuals-api",
+  "rendering_app": null,
+  "update_type": "major",
+  "phase": "live",
+  "analytics_identifier": null,
   "document_type": "gone",
   "schema_name": "gone",
-  "base_path": "/government/publications/guidance-for-parents-and-carers-on-safeguarding-children-in-out-of-school-settings.lt",
-  "locale": "lt",
-  "publishing_app": "whitehall",
-  "public_updated_at": "2023-09-15T10:25:05Z",
-  "details": {
-    "explanation": "<div class=\"govspeak\"><p>This translation is no longer available. You can find the original version of this content at <a href=\"https://www.gov.uk/government/publications/guidance-for-parents-and-carers-on-safeguarding-children-in-out-of-school-settings\" class=\"govuk-link\">https://www.gov.uk/government/publications/guidance-for-parents-and-carers-on-safeguarding-children-in-out-of-school-settings</a></p>\n</div>",
-    "alternative_path": ""
-  },
+  "first_published_at": "2019-04-11T10:12:08Z",
+  "base_path": "/hmrc-internal-manuals/vat-input-tax/vit31100",
+  "description": null,
+  "details": {},
   "routes": [
     {
-      "path": "/government/publications/guidance-for-parents-and-carers-on-safeguarding-children-in-out-of-school-settings.lt",
+      "path": "/hmrc-internal-manuals/vat-input-tax/vit31100",
       "type": "exact"
     }
   ],
-  "content_id": "966bae6d-223e-4102-a6e5-e874012390e5",
-  "govuk_request_id": "21-1695137029.556-10.13.22.59-107886",
-  "payload_version": 65893230
+  "redirects": [],
+  "content_id": "0dd44b7a-3c10-5a3b-8bda-6ccb736102e0",
+  "locale": "en",
+  "expanded_links": {
+    "organisations": [
+      {
+        "content_id": "6667cce2-e809-4e21-ae09-cb0bdc1ddda3",
+        "title": "HM Revenue \u0026 Customs",
+        "locale": "en",
+        "analytics_identifier": "D25",
+        "api_path": "/api/content/government/organisations/hm-revenue-customs",
+        "base_path": "/government/organisations/hm-revenue-customs",
+        "document_type": "organisation",
+        "schema_name": "organisation",
+        "withdrawn": false,
+        "details": {
+          "acronym": "HMRC",
+          "logo": {
+            "crest": "hmrc",
+            "formatted_title": "HM Revenue\u003cbr/\u003e\u0026amp; Customs"
+          },
+          "brand": "hm-revenue-customs",
+          "default_news_image": {
+            "url": "https://assets.publishing.service.gov.uk/media/5efdb7ac3a6f4023cb365a65/s300_HMRC_sign__media_library_-_alternative__GOVUK_960.jpg",
+            "high_resolution_url": "https://assets.publishing.service.gov.uk/media/5efdb7ace90e075c58556288/s960_HMRC_sign__media_library_-_alternative__GOVUK_960.jpg"
+          },
+          "organisation_govuk_status": {
+            "url": null,
+            "status": "live",
+            "updated_at": null
+          }
+        },
+        "links": {}
+      }
+    ],
+    "primary_publishing_organisation": [
+      {
+        "content_id": "6667cce2-e809-4e21-ae09-cb0bdc1ddda3",
+        "title": "HM Revenue \u0026 Customs",
+        "locale": "en",
+        "analytics_identifier": "D25",
+        "api_path": "/api/content/government/organisations/hm-revenue-customs",
+        "base_path": "/government/organisations/hm-revenue-customs",
+        "document_type": "organisation",
+        "schema_name": "organisation",
+        "withdrawn": false,
+        "details": {
+          "acronym": "HMRC",
+          "logo": {
+            "crest": "hmrc",
+            "formatted_title": "HM Revenue\u003cbr/\u003e\u0026amp; Customs"
+          },
+          "brand": "hm-revenue-customs",
+          "default_news_image": {
+            "url": "https://assets.publishing.service.gov.uk/media/5efdb7ac3a6f4023cb365a65/s300_HMRC_sign__media_library_-_alternative__GOVUK_960.jpg",
+            "high_resolution_url": "https://assets.publishing.service.gov.uk/media/5efdb7ace90e075c58556288/s960_HMRC_sign__media_library_-_alternative__GOVUK_960.jpg"
+          },
+          "organisation_govuk_status": {
+            "url": null,
+            "status": "live",
+            "updated_at": null
+          }
+        },
+        "links": {}
+      }
+    ],
+    "available_translations": [
+      {
+        "title": null,
+        "public_updated_at": "2024-01-17T14:43:22Z",
+        "analytics_identifier": null,
+        "document_type": "gone",
+        "schema_name": "gone",
+        "base_path": "/hmrc-internal-manuals/vat-input-tax/vit31100",
+        "api_path": "/api/content/hmrc-internal-manuals/vat-input-tax/vit31100",
+        "withdrawn": false,
+        "content_id": "0dd44b7a-3c10-5a3b-8bda-6ccb736102e0",
+        "locale": "en"
+      }
+    ]
+  },
+  "user_journey_document_supertype": "thing",
+  "email_document_supertype": "other",
+  "government_document_supertype": "other",
+  "content_purpose_subgroup": "other",
+  "content_purpose_supergroup": "other",
+  "publishing_request_id": "21-1705502602.937-10.13.34.26-690",
+  "govuk_request_id": null,
+  "links": {
+    "organisations": [
+      "6667cce2-e809-4e21-ae09-cb0bdc1ddda3"
+    ],
+    "primary_publishing_organisation": [
+      "6667cce2-e809-4e21-ae09-cb0bdc1ddda3"
+    ]
+  },
+  "payload_version": "12345"
 }

--- a/spec/integration/document_synchronization_spec.rb
+++ b/spec/integration/document_synchronization_spec.rb
@@ -443,8 +443,8 @@ RSpec.describe "Document synchronization" do
 
     it "is deleted from Discovery Engine through the Delete service" do
       expect(delete_service).to have_received(:call).with(
-        "966bae6d-223e-4102-a6e5-e874012390e5",
-        payload_version: 65_893_230,
+        "0dd44b7a-3c10-5a3b-8bda-6ccb736102e0",
+        payload_version: 12_345,
       )
     end
   end

--- a/spec/models/concerns/publishing_api/action_spec.rb
+++ b/spec/models/concerns/publishing_api/action_spec.rb
@@ -12,13 +12,25 @@ RSpec.describe PublishingApi::Action do
     context "when the document type is #{document_type}" do
       let(:document_type) { document_type }
 
+      it { is_expected.not_to be_skip }
+      it { is_expected.not_to be_sync }
       it { is_expected.to be_desync }
+
+      context "and it is in a non-English locale" do
+        let(:locale) { "de" }
+
+        it { is_expected.to be_skip }
+        it { is_expected.not_to be_sync }
+        it { is_expected.not_to be_desync }
+      end
     end
   end
 
   context "when the document type is on the ignore list as a string" do
     let(:document_type) { "test_ignored_type" } # see test section in YAML config
 
+    it { is_expected.not_to be_skip }
+    it { is_expected.not_to be_sync }
     it { is_expected.to be_desync }
 
     it "has the expected action_reason" do
@@ -29,18 +41,24 @@ RSpec.describe PublishingApi::Action do
   context "when part of (but not the whole) document type is on the ignore list as a string" do
     let(:document_type) { "test_ignored_type_foo" } # see test section in YAML config
 
+    it { is_expected.not_to be_skip }
     it { is_expected.to be_sync }
+    it { is_expected.not_to be_desync }
   end
 
   context "when a type is on the ignore list as a string that contains the document_type" do
     let(:document_type) { "test_ignored" } # see test section in YAML config
 
+    it { is_expected.not_to be_skip }
     it { is_expected.to be_sync }
+    it { is_expected.not_to be_desync }
   end
 
   context "when the document type is on the ignore list as a pattern" do
     let(:document_type) { "another_test_ignored_type_foo" } # see test section in YAML config
 
+    it { is_expected.not_to be_skip }
+    it { is_expected.not_to be_sync }
     it { is_expected.to be_desync }
 
     it "has the expected action_reason" do
@@ -55,6 +73,8 @@ RSpec.describe PublishingApi::Action do
     let(:base_path) { nil }
     let(:url) { nil }
 
+    it { is_expected.not_to be_skip }
+    it { is_expected.not_to be_sync }
     it { is_expected.to be_desync }
 
     it "has the expected action_reason" do
@@ -67,6 +87,8 @@ RSpec.describe PublishingApi::Action do
     let(:locale) { "de" }
 
     it { is_expected.to be_skip }
+    it { is_expected.not_to be_sync }
+    it { is_expected.not_to be_desync }
 
     it "has the expected action_reason" do
       expect(action.action_reason).to eq("locale not permitted (de)")
@@ -77,13 +99,17 @@ RSpec.describe PublishingApi::Action do
     let(:document_type) { "test_ignored_type" } # see test section in YAML config
     let(:base_path) { "/test_ignored_path_override" } # see test section in YAML config
 
+    it { is_expected.not_to be_skip }
     it { is_expected.to be_sync }
+    it { is_expected.not_to be_desync }
   end
 
   context "when the document type is on the ignore list and a non-exact subset of the path is excluded" do
     let(:document_type) { "test_ignored_type" } # see test section in YAML config
     let(:base_path) { "/test_ignored_path" } # see test section in YAML config
 
+    it { is_expected.not_to be_skip }
+    it { is_expected.not_to be_sync }
     it { is_expected.to be_desync }
   end
 
@@ -91,6 +117,8 @@ RSpec.describe PublishingApi::Action do
     let(:document_type) { "notice" }
     let(:withdrawn_notice) { { explanation: "test" } }
 
+    it { is_expected.not_to be_skip }
+    it { is_expected.not_to be_sync }
     it { is_expected.to be_desync }
 
     it "has the expected action_reason" do
@@ -103,19 +131,25 @@ RSpec.describe PublishingApi::Action do
     let(:base_path) { nil }
     let(:url) { "https://www.example.com" }
 
+    it { is_expected.not_to be_skip }
     it { is_expected.to be_sync }
+    it { is_expected.not_to be_desync }
   end
 
   context "when the document has a blank locale but otherwise should be added" do
     let(:document_type) { "stuff" }
     let(:locale) { nil }
 
+    it { is_expected.not_to be_skip }
     it { is_expected.to be_sync }
+    it { is_expected.not_to be_desync }
   end
 
   context "when the document type is anything else" do
     let(:document_type) { "anything-else" }
 
+    it { is_expected.not_to be_skip }
     it { is_expected.to be_sync }
+    it { is_expected.not_to be_desync }
   end
 end


### PR DESCRIPTION
We've encountered an issue where unpublishing of a non-English version of a document could lead to its English counterpart being desynced from Discovery Engine. This was due to the test for whether a document should be desynced not checking if it should be skippd.

- Ensure both `Action#sync?` and `Action#desync?` consistently check for `Action#skip?` and return a negative result if so
- Add exhaustive negative tests for the actions that _shouldn't_ be taken for a given message, not just the ones that should
- Update fixture for `gone` message to be an English edition rather than a different locale