### PR TITLE
Push quality monitoring metrics to Prometheus

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem "govuk_app_config"
 gem "govuk_message_queue_consumer"
 gem "jsonpath"
 gem "loofah"
+gem "prometheus-client"
 
 group :test do
   gem "grpc_mock"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -381,6 +381,7 @@ GEM
       ast (~> 2.4.1)
       racc
     plek (5.0.0)
+    prometheus-client (4.2.2)
     prometheus_exporter (2.1.0)
       webrick
     psych (5.1.2)
@@ -543,6 +544,7 @@ DEPENDENCIES
   json_schemer
   jsonpath
   loofah
+  prometheus-client
   railties (= 7.1.3)
   rspec-rails
   rubocop-govuk

--- a/app/services/metrics/quality_monitoring.rb
+++ b/app/services/metrics/quality_monitoring.rb
@@ -1,0 +1,34 @@
+module Metrics
+  class QualityMonitoring
+    def initialize(registry)
+      @quality_monitoring_score = registry.gauge(
+        :search_api_v2_quality_monitoring_score,
+        docstring: "Quality monitoring scores for Search API v2 (between 0 and 1)",
+        labels: %i[dataset_type dataset_name],
+      )
+      @quality_monitoring_failures = registry.gauge(
+        :search_api_v2_quality_monitoring_failures,
+        docstring: "Quality monitoring failure count for Search API v2",
+        labels: %i[dataset_type dataset_name],
+      )
+    end
+
+    def record_score(dataset_type, dataset_name, score)
+      quality_monitoring_score.set(score, labels: {
+        dataset_type: dataset_type.to_s,
+        dataset_name: dataset_name.to_s,
+      })
+    end
+
+    def record_failure_count(dataset_type, dataset_name, count)
+      quality_monitoring_failures.set(count, labels: {
+        dataset_type: dataset_type.to_s,
+        dataset_name: dataset_name.to_s,
+      })
+    end
+
+  private
+
+    attr_reader :quality_monitoring_score, :quality_monitoring_failures
+  end
+end

--- a/lib/tasks/quality_monitoring.rake
+++ b/lib/tasks/quality_monitoring.rake
@@ -1,6 +1,12 @@
+require "prometheus/client"
+require "prometheus/client/push"
+
 namespace :quality_monitoring do
   desc "Runs the invariant dataset and validates 100% recall"
   task assert_invariants: :environment do
+    registry = Prometheus::Client.registry
+    metric_collector = Metrics::QualityMonitoring.new(registry)
+
     dir = Rails.root.join("config/quality_monitoring_datasets/invariants")
     invariant_dataset_files = Dir.glob("#{dir}/*.csv")
 
@@ -11,7 +17,13 @@ namespace :quality_monitoring do
         cutoff: 10,
         report_query_below_score: 1.0,
         judge_by: :recall,
+        metric_collector:,
       ).run
     end
+
+    Prometheus::Client::Push.new(
+      job: "quality_monitoring_assert_invariants",
+      gateway: ENV.fetch("PROMETHEUS_PUSHGATEWAY_URL"),
+    ).add(registry)
   end
 end

--- a/spec/services/metrics/quality_monitoring_spec.rb
+++ b/spec/services/metrics/quality_monitoring_spec.rb
@@ -1,0 +1,34 @@
+RSpec.describe Metrics::QualityMonitoring do
+  subject(:quality_monitoring) { described_class.new(registry) }
+
+  let(:registry) { double("registry") }
+  let(:score_gauge) { double("score gauge") }
+  let(:failure_gauge) { double("failure gauge") }
+
+  before do
+    allow(registry).to receive(:gauge)
+      .with(:search_api_v2_quality_monitoring_score, anything).and_return(score_gauge)
+    allow(registry).to receive(:gauge)
+      .with(:search_api_v2_quality_monitoring_failures, anything).and_return(failure_gauge)
+
+    allow(score_gauge).to receive(:set)
+  end
+
+  describe "#record_score" do
+    it "records the score" do
+      expect(score_gauge).to receive(:set)
+        .with(0.5, labels: { dataset_type: "foo", dataset_name: "bar" })
+
+      quality_monitoring.record_score(:foo, "bar", 0.5)
+    end
+  end
+
+  describe "#record_failure_count" do
+    it "records the failure count" do
+      expect(failure_gauge).to receive(:set)
+        .with(50, labels: { dataset_type: "foo", dataset_name: "bar" })
+
+      quality_monitoring.record_failure_count(:foo, "bar", 50)
+    end
+  end
+end


### PR DESCRIPTION
The quality monitoring jobs are one-off Rake tasks and thus cannot use the Prometheus exporter. We need to add the regular Prometheus client and use that.

- Add `prometheus-client` gem
- Add `Metrics::QualityMonitoring` to manage capturing metrics for the quality monitoring runner using `prometheus-client`
- Modify `QualityMonitoring::Runner` to accept the metrics collector
- Modify the Rake task to pass the metrics collector in to the runner and push the metrics at the end