### PR TITLE
Expand description truncation to 40 words

### DIFF
--- a/app/models/result.rb
+++ b/app/models/result.rb
@@ -1,6 +1,6 @@
 # Represents an individual result as expected by Finder Frontend
 class Result
-  MAX_DESCRIPTION_WORDS = 30
+  MAX_DESCRIPTION_WORDS = 40
 
   include ActiveModel::Model
 

--- a/spec/models/result_spec.rb
+++ b/spec/models/result_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe Result, type: :model do
       let(:stored_document) { { description: } }
 
       it "truncates the description" do
-        buffalos = ("buffalo " * 30).strip
+        buffalos = ("buffalo " * 40).strip
         expect(result.description_with_highlighting).to eq("#{buffalos}...")
       end
     end


### PR DESCRIPTION
The existing search uses characters which isn't ideal, so its behaviour isn't 100% replicable. 30 words turns out to be a bit too short for some high-profile page descriptions, so bump the limit slighty.