### PR TITLE
Capture attribution token for quality monitoring fails

### DIFF
--- a/app/services/quality_monitoring/judge.rb
+++ b/app/services/quality_monitoring/judge.rb
@@ -2,18 +2,6 @@ module QualityMonitoring
   class Judge
     attr_reader :result_links, :expected_links
 
-    # Returns a new instance of Judge for a given query and expected links and a cutoff
-    def self.for_query(query, expected_links, cutoff: 10)
-      if expected_links.count > cutoff
-        raise ArgumentError,  "cannot have more than cutoff (#{cutoff}) expected links"
-      end
-
-      query_params = { q: query }
-      result_links = DiscoveryEngine::Query::Search.new(query_params).result_set.results.map(&:link)
-
-      new(result_links, expected_links)
-    end
-
     # Initializes a new instance of Judge for a given set of result links and expected links
     def initialize(result_links, expected_links)
       @result_links = Array(result_links)

--- a/spec/services/quality_monitoring/judge_spec.rb
+++ b/spec/services/quality_monitoring/judge_spec.rb
@@ -3,33 +3,6 @@ RSpec.describe QualityMonitoring::Judge do
 
   let(:expected_links) { %w[A B C D E F G H I J] }
 
-  describe ".for_query" do
-    subject(:judge) { described_class.for_query(query, expected_links, cutoff:) }
-
-    let(:query) { "query" }
-    let(:cutoff) { 10 }
-
-    let(:search) { instance_double(DiscoveryEngine::Query::Search, result_set:) }
-    let(:result_set) { ResultSet.new(results:) }
-    let(:results) do
-      [
-        Result.new(link: "X"),
-        Result.new(link: "Y"),
-        Result.new(link: "Z"),
-      ]
-    end
-
-    before do
-      allow(DiscoveryEngine::Query::Search).to receive(:new)
-        .with({ q: query }).and_return(search)
-    end
-
-    it "returns a correctly set up instance of Judge" do
-      expect(judge.result_links).to eq(%w[X Y Z])
-      expect(judge.expected_links).to eq(expected_links)
-    end
-  end
-
   describe "#initialize" do
     context "when expected links is empty" do
       let(:result_links) { [] }


### PR DESCRIPTION
- Inline judge instantiation into `Runner`
- Add attribution token to failure logs