### PR TITLE
Reject timestamp filters that are the wrong way around

### DIFF
--- a/app/services/discovery_engine/query/filter_expression_helpers.rb
+++ b/app/services/discovery_engine/query/filter_expression_helpers.rb
@@ -37,6 +37,14 @@ module DiscoveryEngine::Query
       from = match[:from] ? Date.parse(match[:from]).beginning_of_day.to_i : "*"
       to = match[:to] ? Date.parse(match[:to]).end_of_day.to_i : "*"
 
+      # Finder Frontend does not validate that the from date is before the to date, so we need to
+      # handle this case gracefully because Discovery Engine will return an error. The easiest way
+      # to do this is to just swap the dates if they are in the wrong order.
+      if match[:from] && match[:to] && from > to
+        from = Date.parse(match[:to]).beginning_of_day.to_i
+        to = Date.parse(match[:from]).end_of_day.to_i
+      end
+
       "#{timestamp_field}: IN(#{from},#{to})"
     end
 

--- a/spec/services/discovery_engine/query/filters_spec.rb
+++ b/spec/services/discovery_engine/query/filters_spec.rb
@@ -117,6 +117,12 @@ RSpec.describe DiscoveryEngine::Query::Filters do
         it { is_expected.to eq("public_timestamp: IN(629510400,629596799)") }
       end
 
+      context "with both from and to parameters but the wrong way around" do
+        let(:query_params) { { q: "garden centres", filter_public_timestamp: "from:1989-12-14,to:1989-12-13" } }
+
+        it { is_expected.to eq("public_timestamp: IN(629510400,629683199)") }
+      end
+
       context "with an invalid from parameter" do
         let(:query_params) { { q: "garden centres", filter_public_timestamp: "from:1989" } }
 


### PR DESCRIPTION
Finder Frontend will happily let users enter a "from" timestamp filter that is after the "to" value. This doesn't make sense, and Discovery Engine rightly complains and refuses to service the request.

Until this gets fixed upstream (if ever), flip from and to dates so we at least return some sort of meaningful results.