### PR TITLE
Allow branches to be deployed to integration

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,6 +31,7 @@ jobs:
       gitRef: ${{ inputs.gitRef || github.ref_name }}
     permissions:
       id-token: write
+      contents: read
   trigger-deploy:
     name: Trigger deploy to ${{ inputs.environment || 'integration' }}
     needs: build-and-publish-image


### PR DESCRIPTION
We need to be able to test branches in integration to be able to test Ruby upgrades like https://github.com/alphagov/search-api-v2/pull/217