### PR TITLE
Add ignorelist override for `/contact`

### DIFF
--- a/config/document_type_ignorelist_path_overrides.yml
+++ b/config/document_type_ignorelist_path_overrides.yml
@@ -10,6 +10,7 @@ shared:
 - /help # special_route
 - /help/cookies # special_route
 - /find-local-council # special_route
+- /contact # special_route
 
 test:
 - /test_ignored_path_override


### PR DESCRIPTION
This is a special route that is normally ignored, but we _do_ want it to show up in results.