### PR TITLE
Ensure incoming filter parameters are valid

### DIFF
--- a/spec/services/discovery_engine/query/filters_spec.rb
+++ b/spec/services/discovery_engine/query/filters_spec.rb
@@ -57,6 +57,14 @@ RSpec.describe DiscoveryEngine::Query::Filters do
         it { is_expected.to eq('content_purpose_supergroup: ANY("services","guidance")') }
       end
 
+      context "with common garbled query parameters" do
+        let(:query_params) do
+          { q: "garden centres", filter_content_purpose_supergroup: { "\\\\\\\\" => "oops" } }
+        end
+
+        it { is_expected.to be_nil }
+      end
+
       context "with an unknown field" do
         let(:query_params) { { q: "garden centres", filter_foo: "bar" } }
 
@@ -83,6 +91,14 @@ RSpec.describe DiscoveryEngine::Query::Filters do
         end
 
         it { is_expected.to eq('(part_of_taxonomy_tree: ANY("cafe-1234")) AND (part_of_taxonomy_tree: ANY("face-5678"))') }
+      end
+
+      context "with common nonsencial hash query parameters" do
+        let(:query_params) do
+          { q: "garden centres", filter_all_part_of_taxonomy_tree: { "\\\\\\\\" => "oops" } }
+        end
+
+        it { is_expected.to be_nil }
       end
 
       context "with an unknown field" do


### PR DESCRIPTION
Finder Frontend should be validating these, but isn't, and it's easier to deal with this here. We sometimes get garbled, clearly non-human search requests into Finder Frontend with nonsensical query parameters like the following example:

```
GET /search/all?commit=Refresh+results&page=3&
    topics%5B%5C%5C%5C%5C%5D=all&world_locations%5B%5C%5C%5C%5C%5D=all
```

This then gets passed on to us and we end up with a query parameter that should always be a single value or an array being parsed into a hash, causing errors.

This commit adds some simple validation to ensure we discard such invalid parameters if they make it as far as our app.