### PR TITLE
Force start Prometheus Exporter

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -48,3 +48,6 @@ Rails.application.configure do
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
 end
+
+# TODO: remove this workaround once GovukPrometheusExporter initialisation is fixed in govuk_app_config.
+ENV["GOVUK_PROMETHEUS_EXPORTER"] = "force"

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -48,3 +48,6 @@ Rails.application.configure do
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true
 end
+
+# TODO: remove this workaround once GovukPrometheusExporter initialisation is fixed in govuk_app_config.
+ENV["GOVUK_PROMETHEUS_EXPORTER"] = "force"


### PR DESCRIPTION
# What?

Suppresses Prometheus Exporter errors in development and test environments.

## Before
<img width="1527" alt="Screenshot 2024-03-26 at 13 30 32" src="https://github.com/alphagov/search-api-v2/assets/5793815/386c8773-aa69-48a6-b227-d8df927dc1ee">
