### PR TITLE
Fix incorrect document locking version check

### DIFF
--- a/app/services/discovery_engine/sync/delete.rb
+++ b/app/services/discovery_engine/sync/delete.rb
@@ -10,7 +10,7 @@ module DiscoveryEngine::Sync
 
     def call(content_id, payload_version: nil)
       with_locked_document(content_id, payload_version:) do
-        if payload_newer_than_remote?(content_id, payload_version:)
+        if outdated_payload_version?(content_id, payload_version:)
           log(
             Logger::Severity::INFO,
             "Ignored as newer version (#{latest_synced_version(content_id)}) already synced",

--- a/app/services/discovery_engine/sync/locking.rb
+++ b/app/services/discovery_engine/sync/locking.rb
@@ -49,15 +49,15 @@ module DiscoveryEngine::Sync
       critical_section.call
     end
 
-    def payload_newer_than_remote?(content_id, payload_version:)
+    def outdated_payload_version?(content_id, payload_version:)
       # Sense check: This shouldn't ever come through as nil from Publishing API, but if it does,
       # the only really useful thing we can do is ignore this check entirely because we can't
       # meaningfully make a comparison.
-      return true if payload_version.nil?
+      return false if payload_version.nil?
 
       # If there is no remote version yet, our version is always newer by definition
       remote_version = latest_synced_version(content_id)
-      return true if remote_version.nil?
+      return false if remote_version.nil?
 
       remote_version.to_i >= payload_version.to_i
     end

--- a/app/services/discovery_engine/sync/put.rb
+++ b/app/services/discovery_engine/sync/put.rb
@@ -12,7 +12,7 @@ module DiscoveryEngine::Sync
 
     def call(content_id, metadata, content: "", payload_version: nil)
       with_locked_document(content_id, payload_version:) do
-        if payload_newer_than_remote?(content_id, payload_version:)
+        if outdated_payload_version?(content_id, payload_version:)
           log(
             Logger::Severity::INFO,
             "Ignored as newer version (#{latest_synced_version(content_id)}) already synced",

--- a/spec/services/discovery_engine/sync/locking_spec.rb
+++ b/spec/services/discovery_engine/sync/locking_spec.rb
@@ -1,0 +1,54 @@
+RSpec.describe DiscoveryEngine::Sync::Locking do
+  subject(:lockable) { Class.new.include(described_class).new }
+
+  let(:content_id) { "some-content-id" }
+  let(:payload_version) { 10 }
+
+  let(:redis_client) { double("Redis Client") }
+
+  before do
+    allow(Rails.application.config.redis_pool).to receive(:with).and_yield(redis_client)
+  end
+
+  describe "#outdated_payload_version?" do
+    subject(:outdated_payload_version) { lockable.outdated_payload_version?(content_id, payload_version:) }
+
+    let(:remote_version) { 42 }
+
+    before do
+      allow(redis_client).to receive(:get)
+        .with("search_api_v2:latest_synced_version:some-content-id")
+        .and_return(remote_version.to_s)
+    end
+
+    context "when payload_version is nil" do
+      let(:payload_version) { nil }
+
+      it { is_expected.to be(false) }
+    end
+
+    context "when there is no remote version" do
+      let(:remote_version) { nil }
+
+      it { is_expected.to be(false) }
+    end
+
+    context "when remote version is equal to payload version" do
+      let(:remote_version) { payload_version }
+
+      it { is_expected.to be(true) }
+    end
+
+    context "when remote version is greater than payload version" do
+      let(:remote_version) { payload_version + 1 }
+
+      it { is_expected.to be(true) }
+    end
+
+    context "when remote version is less than payload version" do
+      let(:remote_version) { payload_version - 1 }
+
+      it { is_expected.to be(false) }
+    end
+  end
+end


### PR DESCRIPTION
This actually has parts of the logic "upside down" and accidentally discards incoming changes where no version number is yet stored in Redis.

- Invert name and incorrect parts of version determination logic of `DiscoveryEngine::Sync::Locking#payload_newer_than_remote?` to `#outdated_payload_version?` to more clearly describe what it does and its use as a guard clause
- Add missing tests to cover behaviour when no version is stored in Redis yet