### PR TITLE
Fix sync failures due to excessive taxons

### DIFF
--- a/spec/models/concerns/publishing_api/metadata_spec.rb
+++ b/spec/models/concerns/publishing_api/metadata_spec.rb
@@ -173,7 +173,21 @@ RSpec.describe PublishingApi::Metadata do
           }
         end
 
-        it { is_expected.to match_array(%w[0000 1111 2222 3333 4444 5555]) }
+        it { is_expected.to eq(%w[0000 4444 5555 1111 2222 3333]) }
+      end
+
+      context "with an excessive number of taxon links" do
+        let(:document_hash) do
+          {
+            expanded_links: {
+              taxons: Array.new(260) { { content_id: sprintf("%04d", _1) } },
+            },
+          }
+        end
+
+        it "is truncated to 250 taxons" do
+          expect(extracted_part_of_taxonomy_tree.count).to eq(250)
+        end
       end
 
       context "without taxon links" do


### PR DESCRIPTION
There are a few documents that are tagged to several hundred taxons in the GOV.UK topic taxonomy, for example broad travel advice that is considered applicable to all countries. This causes issues with an undocumented (other than in Cloud Retail Search documentation on tags) limit of 250 elements in an array field in Vertex, leading any document tagged to more than 250 taxons to fail to sync.

- Truncate `part_of_taxonomy_tree` field to a maximum of 250 array items
- Reorder how we parse the taxonomy tree so that parent taxons come first (before direct taxons), as these are needed for faceting so we want them to have a better chance of being in the first 250