### PR TITLE
Enable concurrency in Bunny worker pool.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,7 +125,7 @@ GEM
       sentry-rails (~> 5.3)
       sentry-ruby (~> 5.3)
       statsd-ruby (~> 1.5)
-    govuk_message_queue_consumer (4.2.0)
+    govuk_message_queue_consumer (5.0.0)
       bunny (~> 2.17)
     govuk_test (4.0.2)
       brakeman (>= 5.0.2)

--- a/lib/tasks/document_sync_worker.rake
+++ b/lib/tasks/document_sync_worker.rake
@@ -19,6 +19,7 @@ namespace :document_sync_worker do
     GovukMessageQueueConsumer::Consumer.new(
       queue_name: ENV.fetch("PUBLISHED_DOCUMENTS_MESSAGE_QUEUE_NAME"),
       processor: PublishingApiMessageProcessor.new,
+      worker_threads: ENV.fetch("PUBLISHED_DOCUMENTS_MESSAGE_QUEUE_THREADS", 1),
     ).run
   rescue Interrupt
     Rails.logger.info("Stopping document sync worker (received interrupt)")


### PR DESCRIPTION
govuk_message_queue_consumer >=5.0.0 [supports](https://github.com/alphagov/govuk_message_queue_consumer/pull/109) passing the `consumer_pool_size` argument to `Bunny::Session::create_channel`.

Make it tunable via an environment variable so it's easier to try it out and revert if it doesn't work well.