### PR TITLE
Switch to the multi-arch workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,7 @@ jobs:
   build-and-publish-image:
     if: github.event_name == 'workflow_dispatch' || startsWith(github.ref_name, 'v')
     name: Build and publish image
-    uses: alphagov/govuk-infrastructure/.github/workflows/build-and-push-image.yml@main
+    uses: alphagov/govuk-infrastructure/.github/workflows/build-and-push-multiarch-image.yml@main
     with:
       gitRef: ${{ inputs.gitRef || github.ref_name }}
     permissions:


### PR DESCRIPTION
## What?
This PR switches the used Workflow to use the multi-arch one. K8s is trying to pull an image on Integration and is backing-off because we don't yet have an ARM-compatible one. This should fix it.