### PR TITLE
Add explicit `csv` gem to dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem "railties", RAILS_GEMS_VERSION
 
 gem "bootsnap", require: false
 gem "connection_pool"
+gem "csv"
 gem "google-cloud-discovery_engine"
 gem "govuk_app_config"
 gem "govuk_message_queue_consumer"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,6 +55,7 @@ GEM
     concurrent-ruby (1.2.3)
     connection_pool (2.4.1)
     crass (1.0.6)
+    csv (3.3.0)
     debug (1.9.2)
       irb (~> 1.10)
       reline (>= 0.3.8)
@@ -556,6 +557,7 @@ DEPENDENCIES
   bootsnap
   brakeman
   connection_pool
+  csv
   debug
   google-cloud-discovery_engine
   govuk_app_config


### PR DESCRIPTION
This is being extracted from the stdlib and won't be part of Ruby 3.4.x anymore.