### PR TITLE
Flip logic and name of version check method

### DIFF
--- a/app/services/coordination/document_version_cache.rb
+++ b/app/services/coordination/document_version_cache.rb
@@ -10,17 +10,18 @@ module Coordination
       @payload_version = payload_version
     end
 
-    # Checks whether this document version is outdated (because the cache tracks a newer version).
-    def outdated?
+    # Checks whether this document should be synced based on the current payload version and the
+    # latest synced version in the cache (if any).
+    def sync_required?
       # Sense check: This shouldn't ever come through as nil from Publishing API, but if it does,
       # the only really useful thing we can do is ignore this check entirely because we can't
       # meaningfully make a comparison.
-      return false if payload_version.nil?
+      return true if payload_version.nil?
 
-      # If there is no remote version yet, our version is always newer by definition
-      return false if latest_synced_version.nil?
+      # If there is no remote version yet (or the cache has expired), we always want to sync.
+      return true if latest_synced_version.nil?
 
-      latest_synced_version.to_i >= payload_version.to_i
+      payload_version.to_i > latest_synced_version.to_i
     end
 
     # Sets the latest synced version to the current payload version, for example after a successful

--- a/app/services/discovery_engine/sync/delete.rb
+++ b/app/services/discovery_engine/sync/delete.rb
@@ -3,7 +3,7 @@ module DiscoveryEngine::Sync
     def call
       lock.acquire
 
-      if version_cache.outdated?
+      unless version_cache.sync_required?
         log(
           Logger::Severity::INFO,
           "Ignored as newer version already synced",

--- a/app/services/discovery_engine/sync/put.rb
+++ b/app/services/discovery_engine/sync/put.rb
@@ -12,7 +12,7 @@ module DiscoveryEngine::Sync
     def call
       lock.acquire
 
-      if version_cache.outdated?
+      unless version_cache.sync_required?
         log(
           Logger::Severity::INFO,
           "Ignored as newer version already synced",

--- a/spec/services/coordination/document_version_cache_spec.rb
+++ b/spec/services/coordination/document_version_cache_spec.rb
@@ -12,37 +12,37 @@ RSpec.describe Coordination::DocumentVersionCache do
         .with("search_api_v2:latest_synced_version:content-id").and_return(remote_version)
   end
 
-  describe "outdated?" do
-    subject(:outdated) { document_version_cache.outdated? }
+  describe "sync_required?" do
+    subject(:sync_required) { document_version_cache.sync_required? }
 
     context "when the remote version is newer" do
       let(:remote_version) { payload_version + 1 }
 
-      it { is_expected.to be true }
+      it { is_expected.to be false }
     end
 
     context "when the remote version is the same" do
       let(:remote_version) { payload_version }
 
-      it { is_expected.to be true }
+      it { is_expected.to be false }
     end
 
     context "when the remote version is older" do
       let(:remote_version) { payload_version - 1 }
 
-      it { is_expected.to be false }
+      it { is_expected.to be true }
     end
 
     context "when there is no remote version" do
       let(:remote_version) { nil }
 
-      it { is_expected.to be false }
+      it { is_expected.to be true }
     end
 
     context "when there is no payload version" do
       let(:payload_version) { nil }
 
-      it { is_expected.to be false }
+      it { is_expected.to be true }
     end
   end
 

--- a/spec/services/discovery_engine/sync/delete_spec.rb
+++ b/spec/services/discovery_engine/sync/delete_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe DiscoveryEngine::Sync::Delete do
 
   let(:lock) { instance_double(Coordination::DocumentLock, acquire: true, release: true) }
 
-  let(:version_cache) { instance_double(Coordination::DocumentVersionCache, outdated?: outdated, set_as_latest_synced_version: nil) }
-  let(:outdated) { false }
+  let(:version_cache) { instance_double(Coordination::DocumentVersionCache, sync_required?: sync_required, set_as_latest_synced_version: nil) }
+  let(:sync_required) { true }
 
   before do
     allow(Rails).to receive(:logger).and_return(logger)
@@ -44,8 +44,8 @@ RSpec.describe DiscoveryEngine::Sync::Delete do
     end
   end
 
-  context "when the incoming document is outdated" do
-    let(:outdated) { true }
+  context "when the incoming document doesn't require syncing" do
+    let(:sync_required) { false }
 
     before do
       described_class.new("some_content_id", payload_version: "1", client:).call

--- a/spec/services/discovery_engine/sync/put_spec.rb
+++ b/spec/services/discovery_engine/sync/put_spec.rb
@@ -3,8 +3,8 @@ RSpec.describe DiscoveryEngine::Sync::Put do
   let(:logger) { double("Logger", add: nil) }
 
   let(:lock) { instance_double(Coordination::DocumentLock, acquire: true, release: true) }
-  let(:version_cache) { instance_double(Coordination::DocumentVersionCache, outdated?: outdated, set_as_latest_synced_version: nil) }
-  let(:outdated) { false }
+  let(:version_cache) { instance_double(Coordination::DocumentVersionCache, sync_required?: sync_required, set_as_latest_synced_version: nil) }
+  let(:sync_required) { true }
 
   before do
     allow(Rails).to receive(:logger).and_return(logger)
@@ -64,8 +64,8 @@ RSpec.describe DiscoveryEngine::Sync::Put do
     end
   end
 
-  context "when the incoming document is outdated" do
-    let(:outdated) { true }
+  context "when the incoming document doesn't need syncing" do
+    let(:sync_required) { false }
 
     before do
       described_class.new(


### PR DESCRIPTION
The `DocumentVersionCache#outdated?` method was named a bit confusingly as it doesn't just check whether a document is stricly outdated, but also whether its ID exists in the cache to begin with (and whether the incoming document has a payload version).

This renames it to a positive `#sync_required?` which better describes its function, and flips the logic around.