### PR TITLE
Improve search quality monitoring

### DIFF
--- a/app/services/metrics/quality_monitoring.rb
+++ b/app/services/metrics/quality_monitoring.rb
@@ -11,6 +11,11 @@ module Metrics
         docstring: "Quality monitoring failure count for Search API v2",
         labels: %i[dataset_type dataset_name],
       )
+      @quality_monitoring_total = registry.gauge(
+        :search_api_v2_quality_monitoring_total,
+        docstring: "Quality monitoring total count for Search API v2",
+        labels: %i[dataset_type dataset_name],
+      )
     end
 
     def record_score(dataset_type, dataset_name, score)
@@ -27,8 +32,15 @@ module Metrics
       })
     end
 
+    def record_total_count(dataset_type, dataset_name, count)
+      quality_monitoring_total.set(count, labels: {
+        dataset_type: dataset_type.to_s,
+        dataset_name: dataset_name.to_s,
+      })
+    end
+
   private
 
-    attr_reader :quality_monitoring_score, :quality_monitoring_failures
+    attr_reader :quality_monitoring_score, :quality_monitoring_failures, :quality_monitoring_total
   end
 end

--- a/app/services/quality_monitoring/runner.rb
+++ b/app/services/quality_monitoring/runner.rb
@@ -70,15 +70,6 @@ module QualityMonitoring
             failure_details.join("\n"),
           ),
         )
-
-        err = FailuresEncountered.new(
-          "Quality monitoring: #{failure_details.size} failures encountered " \
-          "for #{type} dataset #{dataset_name}",
-        )
-        GovukError.notify(
-          err,
-          extra: { dataset_name:, type:, failure_details: failure_details.join("\n") },
-        )
       end
 
       if metric_collector

--- a/app/services/quality_monitoring/runner.rb
+++ b/app/services/quality_monitoring/runner.rb
@@ -57,7 +57,6 @@ module QualityMonitoring
           mean_score,
         ),
       )
-      metric_collector.record_score(type, dataset_name, mean_score) if metric_collector
 
       if failure_details.any?
         Rails.logger.warn(
@@ -73,7 +72,9 @@ module QualityMonitoring
       end
 
       if metric_collector
+        metric_collector.record_score(type, dataset_name, mean_score)
         metric_collector.record_failure_count(type, dataset_name, failure_details.size)
+        metric_collector.record_total_count(type, dataset_name, scores.size)
       end
     end
 

--- a/spec/services/metrics/quality_monitoring_spec.rb
+++ b/spec/services/metrics/quality_monitoring_spec.rb
@@ -4,12 +4,15 @@ RSpec.describe Metrics::QualityMonitoring do
   let(:registry) { double("registry") }
   let(:score_gauge) { double("score gauge") }
   let(:failure_gauge) { double("failure gauge") }
+  let(:total_gauge) { double("total gauge") }
 
   before do
     allow(registry).to receive(:gauge)
       .with(:search_api_v2_quality_monitoring_score, anything).and_return(score_gauge)
     allow(registry).to receive(:gauge)
       .with(:search_api_v2_quality_monitoring_failures, anything).and_return(failure_gauge)
+    allow(registry).to receive(:gauge)
+      .with(:search_api_v2_quality_monitoring_total, anything).and_return(total_gauge)
 
     allow(score_gauge).to receive(:set)
   end
@@ -29,6 +32,15 @@ RSpec.describe Metrics::QualityMonitoring do
         .with(50, labels: { dataset_type: "foo", dataset_name: "bar" })
 
       quality_monitoring.record_failure_count(:foo, "bar", 50)
+    end
+  end
+
+  describe "#record_total_count" do
+    it "records the total count" do
+      expect(total_gauge).to receive(:set)
+        .with(100, labels: { dataset_type: "foo", dataset_name: "bar" })
+
+      quality_monitoring.record_total_count(:foo, "bar", 100)
     end
   end
 end


### PR DESCRIPTION
Two small changes to improve our quality monitoring ("judgement lists"):
* [Remove Sentry reporting of quality monitoring failures](https://github.com/alphagov/search-api-v2/commit/0cbde9014d81d6ce775460bf5bf6adb537a92df6)
* [Track total checks per file in quality monitoring](https://github.com/alphagov/search-api-v2/commit/a706fe1cebf0f4509ec4be18b6a4a3ce3299cacc)