### PR TITLE
Refactor document syncing

### DIFF
--- a/app/services/discovery_engine/sync/delete.rb
+++ b/app/services/discovery_engine/sync/delete.rb
@@ -1,46 +1,19 @@
 module DiscoveryEngine::Sync
   class Delete < Operation
-    def call
-      lock.acquire
+    def initialize(content_id, payload_version: nil, client: nil)
+      super(:delete, content_id, payload_version:, client:)
+    end
 
-      unless version_cache.sync_required?
+    def call
+      sync do
+        client.delete_document(name: document_name)
+      rescue Google::Cloud::NotFoundError => e
+        increment_counter("already_not_present")
         log(
           Logger::Severity::INFO,
-          "Ignored as newer version already synced",
+          "Did not delete document as it doesn't exist remotely (#{e.message}).",
         )
-        Metrics::Exported.increment_counter(
-          :discovery_engine_requests, type: "delete", status: "ignored_outdated"
-        )
-        return
       end
-
-      client.delete_document(name: document_name)
-
-      version_cache.set_as_latest_synced_version
-
-      log(Logger::Severity::INFO, "Successfully deleted")
-      Metrics::Exported.increment_counter(
-        :discovery_engine_requests, type: "delete", status: "success"
-      )
-    rescue Google::Cloud::NotFoundError => e
-      log(
-        Logger::Severity::INFO,
-        "Did not delete document as it doesn't exist remotely (#{e.message}).",
-      )
-      Metrics::Exported.increment_counter(
-        :discovery_engine_requests, type: "delete", status: "already_not_present"
-      )
-    rescue Google::Cloud::Error => e
-      log(
-        Logger::Severity::ERROR,
-        "Failed to delete document due to an error (#{e.message})",
-      )
-      GovukError.notify(e)
-      Metrics::Exported.increment_counter(
-        :discovery_engine_requests, type: "delete", status: "error"
-      )
-    ensure
-      lock.release
     end
   end
 end

--- a/app/services/discovery_engine/sync/put.rb
+++ b/app/services/discovery_engine/sync/put.rb
@@ -3,55 +3,28 @@ module DiscoveryEngine::Sync
     MIME_TYPE = "text/html".freeze
 
     def initialize(content_id, metadata = nil, content: "", payload_version: nil, client: nil)
-      super(content_id, payload_version:, client:)
+      super(:put, content_id, payload_version:, client:)
 
       @metadata = metadata
       @content = content
     end
 
     def call
-      lock.acquire
-
-      unless version_cache.sync_required?
-        log(
-          Logger::Severity::INFO,
-          "Ignored as newer version already synced",
-        )
-        Metrics::Exported.increment_counter(
-          :discovery_engine_requests, type: "put", status: "ignored_outdated"
-        )
-        return
-      end
-
-      client.update_document(
-        document: {
-          id: content_id,
-          name: document_name,
-          json_data: metadata.merge(payload_version:).to_json,
-          content: {
-            mime_type: MIME_TYPE,
-            # The Google client expects an IO object to extract raw byte content from
-            raw_bytes: StringIO.new(content),
+      sync do
+        client.update_document(
+          document: {
+            id: content_id,
+            name: document_name,
+            json_data: metadata.merge(payload_version:).to_json,
+            content: {
+              mime_type: MIME_TYPE,
+              # The Google client expects an IO object to extract raw byte content from
+              raw_bytes: StringIO.new(content),
+            },
           },
-        },
-        allow_missing: true,
-      )
-
-      version_cache.set_as_latest_synced_version
-
-      log(Logger::Severity::INFO, "Successfully added/updated")
-      Metrics::Exported.increment_counter(
-        :discovery_engine_requests, type: "put", status: "success"
-      )
-    rescue Google::Cloud::Error => e
-      log(
-        Logger::Severity::ERROR,
-        "Failed to add/update document due to an error (#{e.message})",
-      )
-      GovukError.notify(e)
-      Metrics::Exported.increment_counter(:discovery_engine_requests, type: "put", status: "error")
-    ensure
-      lock.release
+          allow_missing: true,
+        )
+      end
     end
 
   private

--- a/spec/services/discovery_engine/sync/delete_spec.rb
+++ b/spec/services/discovery_engine/sync/delete_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe DiscoveryEngine::Sync::Delete do
     it "logs the delete operation" do
       expect(logger).to have_received(:add).with(
         Logger::Severity::INFO,
-        "[DiscoveryEngine::Sync::Delete] Successfully deleted content_id:some_content_id payload_version:1",
+        "[DiscoveryEngine::Sync::Delete] Successful delete content_id:some_content_id payload_version:1",
       )
     end
 

--- a/spec/services/discovery_engine/sync/put_spec.rb
+++ b/spec/services/discovery_engine/sync/put_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe DiscoveryEngine::Sync::Put do
     it "logs the put operation" do
       expect(logger).to have_received(:add).with(
         Logger::Severity::INFO,
-        "[DiscoveryEngine::Sync::Put] Successfully added/updated content_id:some_content_id payload_version:1",
+        "[DiscoveryEngine::Sync::Put] Successful put content_id:some_content_id payload_version:1",
       )
     end
   end
@@ -123,7 +123,7 @@ RSpec.describe DiscoveryEngine::Sync::Put do
     it "logs the failure" do
       expect(logger).to have_received(:add).with(
         Logger::Severity::ERROR,
-        "[DiscoveryEngine::Sync::Put] Failed to add/update document due to an error (Something went wrong) content_id:some_content_id payload_version:1",
+        "[DiscoveryEngine::Sync::Put] Failed to put document due to an error (Something went wrong) content_id:some_content_id payload_version:1",
       )
     end
 


### PR DESCRIPTION
Extract common logic into `Operation` from subclasses, so they can focus on the unique behaviour for each respective operation.