### PR TITLE
Implement retrying for transient DE errors

### DIFF
--- a/app/services/discovery_engine/sync/operation.rb
+++ b/app/services/discovery_engine/sync/operation.rb
@@ -1,15 +1,19 @@
 module DiscoveryEngine::Sync
   class Operation
+    MAX_RETRIES_ON_ERROR = 3
+    WAIT_ON_ERROR = 3.seconds
+
     def initialize(type, content_id, payload_version: nil, client: nil)
       @type = type
       @content_id = content_id
       @payload_version = payload_version
       @client = client || ::Google::Cloud::DiscoveryEngine.document_service(version: :v1)
+      @attempt = 1
     end
 
   private
 
-    attr_reader :type, :content_id, :payload_version, :client
+    attr_reader :type, :content_id, :payload_version, :client, :attempt
 
     def sync
       lock.acquire
@@ -26,8 +30,22 @@ module DiscoveryEngine::Sync
         log(Logger::Severity::INFO, "Ignored as newer version already synced")
       end
     rescue Google::Cloud::Error => e
+      if attempt < MAX_RETRIES_ON_ERROR
+        increment_counter("retry")
+        log(
+          Logger::Severity::WARN,
+          "Failed attempt #{attempt} to #{type} document (#{e.message}), retrying",
+        )
+        @attempt += 1
+        Kernel.sleep(WAIT_ON_ERROR)
+        retry
+      end
+
       increment_counter("error")
-      log(Logger::Severity::ERROR, "Failed to #{type} document due to an error (#{e.message})")
+      log(
+        Logger::Severity::ERROR,
+        "Failed on attempt #{attempt} to #{type} document (#{e.message}), giving up",
+      )
       GovukError.notify(e)
     ensure
       lock.release

--- a/spec/services/discovery_engine/sync/delete_spec.rb
+++ b/spec/services/discovery_engine/sync/delete_spec.rb
@@ -1,26 +1,15 @@
+require_relative "shared_examples"
+
 RSpec.describe DiscoveryEngine::Sync::Delete do
-  let(:client) { double("DocumentService::Client", delete_document: nil) }
-  let(:logger) { double("Logger", add: nil) }
+  subject(:sync) { described_class.new("some_content_id", payload_version: "1", client:) }
 
-  let(:lock) { instance_double(Coordination::DocumentLock, acquire: true, release: true) }
+  include_context "with sync context"
 
-  let(:version_cache) { instance_double(Coordination::DocumentVersionCache, sync_required?: sync_required, set_as_latest_synced_version: nil) }
   let(:sync_required) { true }
-
-  before do
-    allow(Kernel).to receive(:sleep).and_return(nil)
-    allow(Rails).to receive(:logger).and_return(logger)
-    allow(Rails.configuration).to receive(:discovery_engine_datastore_branch).and_return("branch")
-    allow(GovukError).to receive(:notify)
-
-    allow(Coordination::DocumentLock).to receive(:new).with("some_content_id").and_return(lock)
-    allow(Coordination::DocumentVersionCache).to receive(:new)
-      .with("some_content_id", payload_version: "1").and_return(version_cache)
-  end
 
   context "when the delete succeeds" do
     before do
-      described_class.new("some_content_id", payload_version: "1", client:).call
+      sync.call
     end
 
     it "deletes the document" do
@@ -28,51 +17,28 @@ RSpec.describe DiscoveryEngine::Sync::Delete do
         .with(name: "branch/documents/some_content_id")
     end
 
-    it "sets the new latest remote version" do
-      expect(version_cache).to have_received(:set_as_latest_synced_version)
-    end
-
-    it "logs the delete operation" do
-      expect(logger).to have_received(:add).with(
-        Logger::Severity::INFO,
-        "[DiscoveryEngine::Sync::Delete] Successful delete content_id:some_content_id payload_version:1",
-      )
-    end
-
-    it "acquires and releases the lock" do
-      expect(lock).to have_received(:acquire)
-      expect(lock).to have_received(:release)
-    end
+    it_behaves_like "a successful sync operation", "delete"
   end
 
   context "when the incoming document doesn't require syncing" do
     let(:sync_required) { false }
 
     before do
-      described_class.new("some_content_id", payload_version: "1", client:).call
+      sync.call
     end
 
     it "does not delete the document" do
       expect(client).not_to have_received(:delete_document)
     end
 
-    it "does not set the remote version" do
-      expect(version_cache).not_to have_received(:set_as_latest_synced_version)
-    end
-
-    it "logs that the document hasn't been deleted" do
-      expect(logger).to have_received(:add).with(
-        Logger::Severity::INFO,
-        "[DiscoveryEngine::Sync::Delete] Ignored as newer version already synced content_id:some_content_id payload_version:1",
-      )
-    end
+    it_behaves_like "a noop sync operation"
   end
 
   context "when locking the document fails" do
     before do
       allow(lock).to receive(:acquire).and_return(false)
 
-      described_class.new("some_content_id", payload_version: "1", client:).call
+      sync.call
     end
 
     it "deletes the document regardless" do
@@ -86,7 +52,7 @@ RSpec.describe DiscoveryEngine::Sync::Delete do
     before do
       allow(client).to receive(:delete_document).and_raise(err)
 
-      described_class.new("some_content_id", payload_version: "1", client:).call
+      sync.call
     end
 
     it "logs the failure" do
@@ -107,27 +73,10 @@ RSpec.describe DiscoveryEngine::Sync::Delete do
     before do
       allow(client).to receive(:delete_document).and_raise(err)
 
-      described_class.new("some_content_id", payload_version: "1", client:).call
+      sync.call
     end
 
-    it "logs the failed attempts" do
-      expect(logger).to have_received(:add).with(
-        Logger::Severity::WARN,
-        "[DiscoveryEngine::Sync::Delete] Failed attempt 1 to delete document (Something went wrong), retrying content_id:some_content_id payload_version:1",
-      )
-      expect(logger).to have_received(:add).with(
-        Logger::Severity::WARN,
-        "[DiscoveryEngine::Sync::Delete] Failed attempt 2 to delete document (Something went wrong), retrying content_id:some_content_id payload_version:1",
-      )
-      expect(logger).to have_received(:add).with(
-        Logger::Severity::ERROR,
-        "[DiscoveryEngine::Sync::Delete] Failed on attempt 3 to delete document (Something went wrong), giving up content_id:some_content_id payload_version:1",
-      )
-    end
-
-    it "send the error to Sentry" do
-      expect(GovukError).to have_received(:notify).with(err)
-    end
+    it_behaves_like "a failed sync operation after the maximum attempts", "delete"
   end
 
   context "when failing transiently but succeeding within the maximum attempts" do
@@ -140,30 +89,13 @@ RSpec.describe DiscoveryEngine::Sync::Delete do
         ->(_) { double(name: "document-name") },
       )
 
-      described_class.new("some_content_id", payload_version: "1", client:).call
+      sync.call
     end
 
     it "tries three times" do
       expect(client).to have_received(:delete_document).exactly(3).times
     end
 
-    it "logs the failed and successful attempts" do
-      expect(logger).to have_received(:add).with(
-        Logger::Severity::WARN,
-        "[DiscoveryEngine::Sync::Delete] Failed attempt 1 to delete document (Something went wrong), retrying content_id:some_content_id payload_version:1",
-      ).ordered
-      expect(logger).to have_received(:add).with(
-        Logger::Severity::WARN,
-        "[DiscoveryEngine::Sync::Delete] Failed attempt 2 to delete document (Something went wrong), retrying content_id:some_content_id payload_version:1",
-      ).ordered
-      expect(logger).to have_received(:add).with(
-        Logger::Severity::INFO,
-        "[DiscoveryEngine::Sync::Delete] Successful delete content_id:some_content_id payload_version:1",
-      ).ordered
-    end
-
-    it "does not send an error to Sentry" do
-      expect(GovukError).not_to have_received(:notify)
-    end
+    it_behaves_like "a sync operation that eventually succeeds", "delete"
   end
 end

--- a/spec/services/discovery_engine/sync/delete_spec.rb
+++ b/spec/services/discovery_engine/sync/delete_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe DiscoveryEngine::Sync::Delete do
   let(:sync_required) { true }
 
   before do
+    allow(Kernel).to receive(:sleep).and_return(nil)
     allow(Rails).to receive(:logger).and_return(logger)
     allow(Rails.configuration).to receive(:discovery_engine_datastore_branch).and_return("branch")
     allow(GovukError).to receive(:notify)
@@ -100,7 +101,7 @@ RSpec.describe DiscoveryEngine::Sync::Delete do
     end
   end
 
-  context "when the delete fails for another reason" do
+  context "when failing consistently for the maximum number of attempts" do
     let(:err) { Google::Cloud::Error.new("Something went wrong") }
 
     before do
@@ -109,15 +110,60 @@ RSpec.describe DiscoveryEngine::Sync::Delete do
       described_class.new("some_content_id", payload_version: "1", client:).call
     end
 
-    it "logs the failure" do
+    it "logs the failed attempts" do
+      expect(logger).to have_received(:add).with(
+        Logger::Severity::WARN,
+        "[DiscoveryEngine::Sync::Delete] Failed attempt 1 to delete document (Something went wrong), retrying content_id:some_content_id payload_version:1",
+      )
+      expect(logger).to have_received(:add).with(
+        Logger::Severity::WARN,
+        "[DiscoveryEngine::Sync::Delete] Failed attempt 2 to delete document (Something went wrong), retrying content_id:some_content_id payload_version:1",
+      )
       expect(logger).to have_received(:add).with(
         Logger::Severity::ERROR,
-        "[DiscoveryEngine::Sync::Delete] Failed to delete document due to an error (Something went wrong) content_id:some_content_id payload_version:1",
+        "[DiscoveryEngine::Sync::Delete] Failed on attempt 3 to delete document (Something went wrong), giving up content_id:some_content_id payload_version:1",
       )
     end
 
     it "send the error to Sentry" do
       expect(GovukError).to have_received(:notify).with(err)
+    end
+  end
+
+  context "when failing transiently but succeeding within the maximum attempts" do
+    let(:err) { Google::Cloud::Error.new("Something went wrong") }
+
+    before do
+      allow(client).to receive(:delete_document).and_invoke(
+        ->(_) { raise err },
+        ->(_) { raise err },
+        ->(_) { double(name: "document-name") },
+      )
+
+      described_class.new("some_content_id", payload_version: "1", client:).call
+    end
+
+    it "tries three times" do
+      expect(client).to have_received(:delete_document).exactly(3).times
+    end
+
+    it "logs the failed and successful attempts" do
+      expect(logger).to have_received(:add).with(
+        Logger::Severity::WARN,
+        "[DiscoveryEngine::Sync::Delete] Failed attempt 1 to delete document (Something went wrong), retrying content_id:some_content_id payload_version:1",
+      ).ordered
+      expect(logger).to have_received(:add).with(
+        Logger::Severity::WARN,
+        "[DiscoveryEngine::Sync::Delete] Failed attempt 2 to delete document (Something went wrong), retrying content_id:some_content_id payload_version:1",
+      ).ordered
+      expect(logger).to have_received(:add).with(
+        Logger::Severity::INFO,
+        "[DiscoveryEngine::Sync::Delete] Successful delete content_id:some_content_id payload_version:1",
+      ).ordered
+    end
+
+    it "does not send an error to Sentry" do
+      expect(GovukError).not_to have_received(:notify)
     end
   end
 end

--- a/spec/services/discovery_engine/sync/put_spec.rb
+++ b/spec/services/discovery_engine/sync/put_spec.rb
@@ -1,36 +1,25 @@
+require_relative "shared_examples"
+
 RSpec.describe DiscoveryEngine::Sync::Put do
-  let(:client) { double("DocumentService::Client", update_document: nil) }
-  let(:logger) { double("Logger", add: nil) }
-
-  let(:lock) { instance_double(Coordination::DocumentLock, acquire: true, release: true) }
-  let(:version_cache) { instance_double(Coordination::DocumentVersionCache, sync_required?: sync_required, set_as_latest_synced_version: nil) }
-  let(:sync_required) { true }
-
-  before do
-    allow(Kernel).to receive(:sleep).and_return(nil)
-    allow(Rails).to receive(:logger).and_return(logger)
-    allow(Rails.configuration).to receive(:discovery_engine_datastore_branch).and_return("branch")
-    allow(GovukError).to receive(:notify)
-
-    allow(Coordination::DocumentLock).to receive(:new).with("some_content_id").and_return(lock)
-
-    allow(Coordination::DocumentVersionCache).to receive(:new)
-      .with("some_content_id", payload_version: "1").and_return(version_cache)
+  subject(:sync) do
+    described_class.new(
+      "some_content_id",
+      { foo: "bar" },
+      content: "some content",
+      payload_version: "1",
+      client:,
+    )
   end
+
+  include_context "with sync context"
+
+  let(:sync_required) { true }
 
   context "when updating the document succeeds" do
     before do
-      allow(client).to receive(:update_document).and_return(
-        double(name: "document-name"),
-      )
+      allow(client).to receive(:update_document).and_return(double(name: "document-name"))
 
-      described_class.new(
-        "some_content_id",
-        { foo: "bar" },
-        content: "some content",
-        payload_version: "1",
-        client:,
-      ).call
+      sync.call
     end
 
     it "updates the document" do
@@ -48,63 +37,28 @@ RSpec.describe DiscoveryEngine::Sync::Put do
       )
     end
 
-    it "acquires and releases the lock" do
-      expect(lock).to have_received(:acquire)
-      expect(lock).to have_received(:release)
-    end
-
-    it "sets the new latest remote version" do
-      expect(version_cache).to have_received(:set_as_latest_synced_version)
-    end
-
-    it "logs the put operation" do
-      expect(logger).to have_received(:add).with(
-        Logger::Severity::INFO,
-        "[DiscoveryEngine::Sync::Put] Successful put content_id:some_content_id payload_version:1",
-      )
-    end
+    it_behaves_like "a successful sync operation", "put"
   end
 
   context "when the incoming document doesn't need syncing" do
     let(:sync_required) { false }
 
     before do
-      described_class.new(
-        "some_content_id",
-        { foo: "bar" },
-        content: "some content",
-        payload_version: "1",
-        client:,
-      ).call
+      sync.call
     end
 
     it "does not update the document" do
       expect(client).not_to have_received(:update_document)
     end
 
-    it "does not set the remote version" do
-      expect(version_cache).not_to have_received(:set_as_latest_synced_version)
-    end
-
-    it "logs that the document hasn't been updated" do
-      expect(logger).to have_received(:add).with(
-        Logger::Severity::INFO,
-        "[DiscoveryEngine::Sync::Put] Ignored as newer version already synced content_id:some_content_id payload_version:1",
-      )
-    end
+    it_behaves_like "a noop sync operation"
   end
 
   context "when locking the document fails" do
     before do
       allow(lock).to receive(:acquire).and_return(false)
 
-      described_class.new(
-        "some_content_id",
-        { foo: "bar" },
-        content: "some content",
-        payload_version: "1",
-        client:,
-      ).call
+      sync.call
     end
 
     it "updates the document regardless" do
@@ -118,27 +72,10 @@ RSpec.describe DiscoveryEngine::Sync::Put do
     before do
       allow(client).to receive(:update_document).and_raise(err)
 
-      described_class.new("some_content_id", {}, payload_version: "1", client:).call
+      sync.call
     end
 
-    it "logs the failed attempts" do
-      expect(logger).to have_received(:add).with(
-        Logger::Severity::WARN,
-        "[DiscoveryEngine::Sync::Put] Failed attempt 1 to put document (Something went wrong), retrying content_id:some_content_id payload_version:1",
-      )
-      expect(logger).to have_received(:add).with(
-        Logger::Severity::WARN,
-        "[DiscoveryEngine::Sync::Put] Failed attempt 2 to put document (Something went wrong), retrying content_id:some_content_id payload_version:1",
-      )
-      expect(logger).to have_received(:add).with(
-        Logger::Severity::ERROR,
-        "[DiscoveryEngine::Sync::Put] Failed on attempt 3 to put document (Something went wrong), giving up content_id:some_content_id payload_version:1",
-      )
-    end
-
-    it "sends the error to Sentry" do
-      expect(GovukError).to have_received(:notify).with(err)
-    end
+    it_behaves_like "a failed sync operation after the maximum attempts", "put"
   end
 
   context "when failing transiently but succeeding within the maximum attempts" do
@@ -151,30 +88,13 @@ RSpec.describe DiscoveryEngine::Sync::Put do
         ->(_) { double(name: "document-name") },
       )
 
-      described_class.new("some_content_id", {}, payload_version: "1", client:).call
+      sync.call
     end
 
     it "tries three times" do
       expect(client).to have_received(:update_document).exactly(3).times
     end
 
-    it "logs the failed and successful attempts" do
-      expect(logger).to have_received(:add).with(
-        Logger::Severity::WARN,
-        "[DiscoveryEngine::Sync::Put] Failed attempt 1 to put document (Something went wrong), retrying content_id:some_content_id payload_version:1",
-      ).ordered
-      expect(logger).to have_received(:add).with(
-        Logger::Severity::WARN,
-        "[DiscoveryEngine::Sync::Put] Failed attempt 2 to put document (Something went wrong), retrying content_id:some_content_id payload_version:1",
-      ).ordered
-      expect(logger).to have_received(:add).with(
-        Logger::Severity::INFO,
-        "[DiscoveryEngine::Sync::Put] Successful put content_id:some_content_id payload_version:1",
-      ).ordered
-    end
-
-    it "does not send an error to Sentry" do
-      expect(GovukError).not_to have_received(:notify)
-    end
+    it_behaves_like "a sync operation that eventually succeeds", "put"
   end
 end

--- a/spec/services/discovery_engine/sync/shared_examples.rb
+++ b/spec/services/discovery_engine/sync/shared_examples.rb
@@ -1,0 +1,91 @@
+RSpec.shared_context "with sync context" do
+  let(:client) { double("DocumentService::Client", update_document: nil, delete_document: nil) }
+  let(:logger) { double("Logger", add: nil) }
+
+  let(:lock) { instance_double(Coordination::DocumentLock, acquire: true, release: true) }
+  let(:version_cache) { instance_double(Coordination::DocumentVersionCache, sync_required?: sync_required, set_as_latest_synced_version: nil) }
+
+  before do
+    allow(Kernel).to receive(:sleep).and_return(nil)
+    allow(Rails).to receive(:logger).and_return(logger)
+    allow(Rails.configuration).to receive(:discovery_engine_datastore_branch).and_return("branch")
+    allow(GovukError).to receive(:notify)
+
+    allow(Coordination::DocumentLock).to receive(:new).with("some_content_id").and_return(lock)
+    allow(Coordination::DocumentVersionCache).to receive(:new)
+      .with("some_content_id", payload_version: "1").and_return(version_cache)
+  end
+end
+
+RSpec.shared_examples "a successful sync operation" do |type|
+  it "sets the new latest remote version" do
+    expect(version_cache).to have_received(:set_as_latest_synced_version)
+  end
+
+  it "logs the delete operation" do
+    expect(logger).to have_received(:add).with(
+      Logger::Severity::INFO,
+      "[#{described_class}] Successful #{type} content_id:some_content_id payload_version:1",
+    )
+  end
+
+  it "acquires and releases the lock" do
+    expect(lock).to have_received(:acquire)
+    expect(lock).to have_received(:release)
+  end
+end
+
+RSpec.shared_examples "a noop sync operation" do
+  it "does not set the remote version" do
+    expect(version_cache).not_to have_received(:set_as_latest_synced_version)
+  end
+
+  it "logs that the document hasn't been deleted" do
+    expect(logger).to have_received(:add).with(
+      Logger::Severity::INFO,
+      "[#{described_class}] Ignored as newer version already synced content_id:some_content_id payload_version:1",
+    )
+  end
+end
+
+RSpec.shared_examples "a failed sync operation after the maximum attempts" do |type|
+  it "logs the failed attempts" do
+    expect(logger).to have_received(:add).with(
+      Logger::Severity::WARN,
+      "[#{described_class}] Failed attempt 1 to #{type} document (Something went wrong), retrying content_id:some_content_id payload_version:1",
+    )
+    expect(logger).to have_received(:add).with(
+      Logger::Severity::WARN,
+      "[#{described_class}] Failed attempt 2 to #{type} document (Something went wrong), retrying content_id:some_content_id payload_version:1",
+    )
+    expect(logger).to have_received(:add).with(
+      Logger::Severity::ERROR,
+      "[#{described_class}] Failed on attempt 3 to #{type} document (Something went wrong), giving up content_id:some_content_id payload_version:1",
+    )
+  end
+
+  it "sends the error to Sentry" do
+    expect(GovukError).to have_received(:notify)
+  end
+end
+
+RSpec.shared_examples "a sync operation that eventually succeeds" do |type|
+  it "logs the failed and successful attempts" do
+    expect(logger).to have_received(:add).with(
+      Logger::Severity::WARN,
+      "[#{described_class}] Failed attempt 1 to #{type} document (Something went wrong), retrying content_id:some_content_id payload_version:1",
+    ).ordered
+    expect(logger).to have_received(:add).with(
+      Logger::Severity::WARN,
+      "[#{described_class}] Failed attempt 2 to #{type} document (Something went wrong), retrying content_id:some_content_id payload_version:1",
+    ).ordered
+    expect(logger).to have_received(:add).with(
+      Logger::Severity::INFO,
+      "[#{described_class}] Successful #{type} content_id:some_content_id payload_version:1",
+    ).ordered
+  end
+
+  it "does not send an error to Sentry" do
+    expect(GovukError).not_to have_received(:notify)
+  end
+end


### PR DESCRIPTION
On occasion, we will experience transient errors from Discovery Engine that will resolve themselves if we wait briefly and try again. In particular, this can happen when a number of updates come through in quick succession for the same document that are handled by different workers.

- Add ability for put/delete operations to try for up to three attempts when an error occurs before giving up