### PR TITLE
Ignore empty filter params from Finder Frontend

### DIFF
--- a/app/services/discovery_engine/query/filters.rb
+++ b/app/services/discovery_engine/query/filters.rb
@@ -66,13 +66,17 @@ module DiscoveryEngine::Query
     end
 
     def valid_filter_value?(value)
-      # Finder Frontend should be more resilient to invalid filter values, but we can't rely on that
-      # for the time being. This ensures that occasionally observed garbage parameters such as:
+      # Finder Frontend should be more resilient to invalid filter values and send through perfectly
+      # formatted requests, but we can't rely on that for the time being. This ensures that
+      # occasionally observed garbage parameters such as:
       #
       #   filter_world_locations[\\\\]=all
       #
-      # are ignored by checking that the value is either a string or an array of strings.
-      Array(value).all? { _1.is_a?(String) }
+      # as well as empty params that Finder Frontend will send through (particularly for
+      # `part_of_taxonomy_tree`) are ignored by checking that the value is either a string or an
+      # array of strings, and each individual value is present.
+      values = Array(value)
+      values.all? { _1.is_a?(String) && _1.present? }
     end
   end
 end

--- a/spec/services/discovery_engine/query/filters_spec.rb
+++ b/spec/services/discovery_engine/query/filters_spec.rb
@@ -65,6 +65,14 @@ RSpec.describe DiscoveryEngine::Query::Filters do
         it { is_expected.to be_nil }
       end
 
+      context "with empty string filters" do
+        let(:query_params) do
+          { q: "garden centres", filter_content_purpose_supergroup: ["", ""] }
+        end
+
+        it { is_expected.to be_nil }
+      end
+
       context "with an unknown field" do
         let(:query_params) { { q: "garden centres", filter_foo: "bar" } }
 


### PR DESCRIPTION
Finder Frontend's buggy filter query construction logic will send through empty query params for `part_of_taxonomy_tree` whenever a finder has a taxon facet and none have been selected by the user. This is difficult to fix upstream, and other clients may misbehave similarly in the future.

This would otherwise be "fine", but when running behind an AWS API Gateway, these empty params are transformed from
`part_of_taxonomy_tree[]` to `part_of_taxonomy_tree[]=`, causing Search API v2's Rails app to parse them as an empty string rather than nil, and we end up filtering for empty strings as taxon IDs (which matches no documents).

- Remove blank filter params using a `present?` check as part of filter parsing