### PR TITLE
Fix logging for `UserEvents::Import`

### DIFF
--- a/app/services/discovery_engine/user_events/import.rb
+++ b/app/services/discovery_engine/user_events/import.rb
@@ -84,7 +84,9 @@ module DiscoveryEngine::UserEvents
     end
 
     def logger
-      @logger ||= Rails.logger.tagged(self.class.name, event_type, date)
+      @logger ||= ActiveSupport::TaggedLogging
+        .new(Rails.logger)
+        .tagged(self.class.name, "event_type=#{event_type}", "date=#{date}")
     end
   end
 end


### PR DESCRIPTION
Turns out `govuk_app_config` overrides the nicely configured default Rails logger that supports tagging with its own basic logger.

This wraps the Rails logger with `ActiveSupport::TaggedLogging` to ensure we can emit tags for the event type and date.