### PR TITLE
Make serving config optionally dynamic

### DIFF
--- a/app/services/discovery_engine/query/search.rb
+++ b/app/services/discovery_engine/query/search.rb
@@ -56,7 +56,9 @@ module DiscoveryEngine::Query
     end
 
     def serving_config
-      ServingConfig.default.name
+      return ServingConfig.default.name if query_params[:serving_config].blank?
+
+      ServingConfig.new(query_params[:serving_config]).name
     end
 
     def page_size

--- a/spec/services/discovery_engine/query/search_spec.rb
+++ b/spec/services/discovery_engine/query/search_spec.rb
@@ -204,6 +204,16 @@ RSpec.describe DiscoveryEngine::Query::Search do
           )
         end
       end
+
+      context "when a serving config is manually specified" do
+        let(:query_params) { { q: "garden centres", serving_config: "preview" } }
+
+        it "calls the client with the expected parameters" do
+          expect(client).to have_received(:search).with(
+            hash_including(serving_config: ServingConfig.new("preview").name),
+          )
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This adds the ability to switch to a different serving config from the default one using a `serving_config` query parameter.

This will allow us to build a feature in Finder Frontend for internal users to preview changes to serving configs.