### PR TITLE
Remove VS Code configuration

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,8 +1,0 @@
-{
-  "recommendations": [
-    "connorshea.vscode-ruby-test-adapter",
-    "hbenl.vscode-test-explorer", // Remove when `vscode-ruby-test-adapter` supports native UI
-    "KoichiSasada.vscode-rdbg",
-    "Shopify.ruby-lsp",
-  ]
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,0 @@
-{
-  // GOV.UK Docker uses `rbenv` to manage Ruby versions
-  "rubyLsp.rubyVersionManager": {
-    "identifier": "rbenv"
-  },
-  "rubyLsp.formatter": "rubocop",
-  "testExplorer.useNativeTesting": true
-}


### PR DESCRIPTION
Having this in the repository isn't canonical across GOV.UK, and it's slightly outdated with how the app actually runs.