### PR TITLE
Don't perform custom news recency boost on variant serving config

### DIFF
--- a/app/models/serving_config.rb
+++ b/app/models/serving_config.rb
@@ -14,6 +14,11 @@ ServingConfig = Data.define(:remote_resource_id) do
     new("default_search")
   end
 
+  # Used as the variant ("B") when AB testing
+  def self.variant
+    new("variant_search")
+  end
+
   def parent
     # We only use a single engine in our architecture, so we can hardcode it here.
     Engine.default

--- a/app/services/discovery_engine/query/search.rb
+++ b/app/services/discovery_engine/query/search.rb
@@ -95,10 +95,23 @@ module DiscoveryEngine::Query
     def boost_spec
       {
         condition_boost_specs: [
-          *NewsRecencyBoost.new.boost_specs,
+          *news_recency_boost_specs,
           *best_bets_boost_specs,
         ],
       }
+    end
+
+    def news_recency_boost_specs
+      # Since we first created `NewsRecencyBoost`, Vertex AI Search has gained the equivalent
+      # functionality natively. As of Mar 2025, we are AB testing this new feature on the `variant`
+      # serving configuration, so we do not want to apply our custom boost if that is the serving
+      # config used for the current search, as it would cause content to be boosted twice.
+      #
+      # TODO: Remove this method (and `NewsRecencyBoost` class) when we have successfully concluded
+      # the AB test.
+      return [] if serving_config == ServingConfig.variant
+
+      NewsRecencyBoost.new.boost_specs
     end
 
     def best_bets_boost_specs

--- a/app/services/discovery_engine/query/search.rb
+++ b/app/services/discovery_engine/query/search.rb
@@ -42,7 +42,7 @@ module DiscoveryEngine::Query
     def discovery_engine_params
       {
         query:,
-        serving_config:,
+        serving_config: serving_config.name,
         page_size:,
         offset:,
         order_by:,
@@ -56,9 +56,9 @@ module DiscoveryEngine::Query
     end
 
     def serving_config
-      return ServingConfig.default.name if query_params[:serving_config].blank?
+      return ServingConfig.default if query_params[:serving_config].blank?
 
-      ServingConfig.new(query_params[:serving_config]).name
+      ServingConfig.new(query_params[:serving_config])
     end
 
     def page_size

--- a/spec/models/serving_config_spec.rb
+++ b/spec/models/serving_config_spec.rb
@@ -7,6 +7,12 @@ RSpec.describe ServingConfig do
     end
   end
 
+  describe ".variant" do
+    it "returns the variant serving config" do
+      expect(described_class.variant).to eq(described_class.new("variant_search"))
+    end
+  end
+
   describe "#name" do
     it "returns the fully qualified name of the serving config" do
       expect(serving_config.name).to eq("[collection]/engines/govuk/servingConfigs/my-serving-config")

--- a/spec/services/discovery_engine/query/search_spec.rb
+++ b/spec/services/discovery_engine/query/search_spec.rb
@@ -214,6 +214,19 @@ RSpec.describe DiscoveryEngine::Query::Search do
           )
         end
       end
+
+      context "when using the variant serving config" do
+        let(:query_params) { { q: "garden centres", serving_config: "variant_search" } }
+
+        it "does not include our manual news recency boosts" do
+          expect(client).to have_received(:search).with(
+            hash_including(
+              serving_config: ServingConfig.variant.name,
+              boost_spec: { condition_boost_specs: [] },
+            ),
+          )
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
We apply a set of basic manual boosts (through `NewsRecencyBoost`) to all search queries to try and increase the ranking of new content, and decrease that of old content (under the assumption that newer content is more relevant to users).

Vertex AI Search now provides a more powerful feature natively, so we are considering switching to that. This works by applying a boost control using a `FRESHNESS` attribute, which we have [created and applied to the variant serving config in `govuk-infrastructure`][infra] ahead of an upcoming AB test.

This PR changes the search logic so that it doesn't apply our own news recency boosts if that serving config is in use, as that would cause recent content to be double boosted.

see https://trello.com/c/EjqLzGdu

[infra]: https://github.com/alphagov/govuk-infrastructure/blob/main/terraform/deployments/search-api-v2/serving_config_variant.tf