### PR TITLE
Improve metrics

### DIFF
--- a/app/message_processors/publishing_api_message_processor.rb
+++ b/app/message_processors/publishing_api_message_processor.rb
@@ -9,8 +9,6 @@ class PublishingApiMessageProcessor
 
     message.ack
   rescue StandardError => e
-    Metrics::Exported.increment_counter(:message_processing_errors)
-
     # TODO: Consider options for handling errors more granularly, and for differentiating between
     # retriable (e.g. transient connection issue) and fatal (e.g. malformed document on queue)
     # errors. For now while we aren't live, log an error, send the error to Sentry, and reject the

--- a/app/message_processors/publishing_api_message_processor.rb
+++ b/app/message_processors/publishing_api_message_processor.rb
@@ -1,8 +1,6 @@
 class PublishingApiMessageProcessor
   # Implements the callback interface required by `govuk_message_queue_consumer`
   def process(message)
-    Metrics::Exported.increment_counter(:incoming_messages)
-
     Metrics::Exported.observe_duration(:total_processing_duration) do
       document_hash = message.payload.deep_symbolize_keys
       document = PublishingApiDocument.new(document_hash)

--- a/app/models/publishing_api_document.rb
+++ b/app/models/publishing_api_document.rb
@@ -20,15 +20,15 @@ class PublishingApiDocument
 
   def synchronize
     if skip?
-      Metrics::Exported.increment_counter(:documents_skipped)
+      Metrics::Exported.increment_counter(:documents_processed_total, labels: { action: "skip" })
       log("skip (#{action_reason})")
     elsif sync?
       log("sync")
-      Metrics::Exported.increment_counter(:documents_synced)
+      Metrics::Exported.increment_counter(:documents_processed_total, labels: { action: "sync" })
       put_service.new(content_id, metadata, content:, payload_version:).call
     elsif desync?
       log("desync (#{action_reason}))")
-      Metrics::Exported.increment_counter(:documents_desynced)
+      Metrics::Exported.increment_counter(:documents_processed_total, labels: { action: "desync" })
       delete_service.new(content_id, payload_version:).call
     else
       raise "Cannot determine action for document: #{content_id}"

--- a/app/services/discovery_engine/autocomplete/complete.rb
+++ b/app/services/discovery_engine/autocomplete/complete.rb
@@ -22,8 +22,6 @@ module DiscoveryEngine::Autocomplete
       # Discovery Engine returns an error on an empty query, so we need to handle it ourselves
       return [] if query.blank?
 
-      Metrics::Exported.increment_counter(:autocomplete_requests)
-
       client
         .complete_query(complete_query_request)
         .query_suggestions

--- a/app/services/discovery_engine/query/search.rb
+++ b/app/services/discovery_engine/query/search.rb
@@ -29,14 +29,7 @@ module DiscoveryEngine::Query
     attr_reader :query_params, :client
 
     def response
-      @response ||= client.search(discovery_engine_params).response.tap do
-        Metrics::Exported.increment_counter(
-          :search_requests,
-          query_present: query.present?,
-          filter_present: filter.present?,
-          best_bets_applied: best_bets_boost_specs.present?,
-        )
-      end
+      @response ||= client.search(discovery_engine_params).response
     end
 
     def discovery_engine_params

--- a/app/services/discovery_engine/sync/delete.rb
+++ b/app/services/discovery_engine/sync/delete.rb
@@ -8,7 +8,6 @@ module DiscoveryEngine::Sync
       sync do
         client.delete_document(name: document_name)
       rescue Google::Cloud::NotFoundError => e
-        increment_counter("already_not_present")
         log(
           Logger::Severity::INFO,
           "Did not delete document as it doesn't exist remotely (#{e.message}).",

--- a/app/services/discovery_engine/sync/operation.rb
+++ b/app/services/discovery_engine/sync/operation.rb
@@ -23,15 +23,12 @@ module DiscoveryEngine::Sync
 
         version_cache.set_as_latest_synced_version
 
-        increment_counter("success")
         log(Logger::Severity::INFO, "Successful #{type}")
       else
-        increment_counter("ignored_outdated")
         log(Logger::Severity::INFO, "Ignored as newer version already synced")
       end
     rescue Google::Cloud::Error => e
       if attempt < MAX_RETRIES_ON_ERROR
-        increment_counter("retry")
         log(
           Logger::Severity::WARN,
           "Failed attempt #{attempt} to #{type} document (#{e.message}), retrying",
@@ -41,7 +38,6 @@ module DiscoveryEngine::Sync
         retry
       end
 
-      increment_counter("error")
       log(
         Logger::Severity::ERROR,
         "Failed on attempt #{attempt} to #{type} document (#{e.message}), giving up",
@@ -72,10 +68,6 @@ module DiscoveryEngine::Sync
         payload_version,
       )
       Rails.logger.add(level, combined_message)
-    end
-
-    def increment_counter(status)
-      Metrics::Exported.increment_counter(:discovery_engine_requests, type:, status:)
     end
   end
 end

--- a/app/services/metrics/exported.rb
+++ b/app/services/metrics/exported.rb
@@ -3,18 +3,11 @@ module Metrics
     CLIENT = PrometheusExporter::Client.default
     COUNTERS = {
       ### Synchronisation counters
-      documents_synced: CLIENT.register(
-        :counter, "search_api_v2_documents_synced", "number of documents synced to Discovery Engine"
-      ),
-      documents_desynced: CLIENT.register(
+      documents_processed_total: CLIENT.register(
         :counter,
-        "search_api_v2_documents_desynced",
-        "number of documents desynced from Discovery Engine",
-      ),
-      documents_skipped: CLIENT.register(
-        :counter,
-        "search_api_v2_documents_skipped",
-        "number of documents skipped from syncing to Discovery Engine",
+        "search_api_v2_documents_processed_total",
+        "documents synchronised to Discovery Engine",
+        labels: %i[action],
       ),
     }.freeze
     HISTOGRAMS = {

--- a/app/services/metrics/exported.rb
+++ b/app/services/metrics/exported.rb
@@ -2,13 +2,6 @@ module Metrics
   module Exported
     CLIENT = PrometheusExporter::Client.default
     COUNTERS = {
-      ### User facing counters
-      search_requests: CLIENT.register(
-        :counter, "search_api_v2_search_requests", "number of incoming search requests"
-      ),
-      autocomplete_requests: CLIENT.register(
-        :counter, "search_api_v2_autocomplete_requests", "number of incoming autocomplete requests"
-      ),
       ### Synchronisation counters
       incoming_messages: CLIENT.register(
         :counter, "search_api_v2_incoming_messages", "number of incoming messages from Publishing API"

--- a/app/services/metrics/exported.rb
+++ b/app/services/metrics/exported.rb
@@ -3,16 +3,6 @@ module Metrics
     CLIENT = PrometheusExporter::Client.default
     COUNTERS = {
       ### Synchronisation counters
-      message_processing_errors: CLIENT.register(
-        :counter,
-        "search_api_v2_message_processing_errors",
-        "number of messages from Publishing API that failed to process",
-      ),
-      discovery_engine_requests: CLIENT.register(
-        :counter,
-        "search_api_v2_discovery_engine_requests",
-        "number of requests to Discovery Engine",
-      ),
       documents_synced: CLIENT.register(
         :counter, "search_api_v2_documents_synced", "number of documents synced to Discovery Engine"
       ),

--- a/app/services/metrics/exported.rb
+++ b/app/services/metrics/exported.rb
@@ -3,9 +3,6 @@ module Metrics
     CLIENT = PrometheusExporter::Client.default
     COUNTERS = {
       ### Synchronisation counters
-      incoming_messages: CLIENT.register(
-        :counter, "search_api_v2_incoming_messages", "number of incoming messages from Publishing API"
-      ),
       message_processing_errors: CLIENT.register(
         :counter,
         "search_api_v2_message_processing_errors",


### PR DESCRIPTION
We've added a whole bunch of metrics originally that turned out to be unnecessary, or in some cases useful but not in line with Prometheus best practices (missing `_total` suffix for counter metrics that Grafana is now raising as an issue, using separate metrics for things that should be labels on a single metric).

This removes a whole bunch of those superfluous metrics where we can:
* infer the metric through other means (such as existing HTTP request metrics for a specific controller), or
* can establish the happy path from other metrics and don't need to track the unhappy path as every exception should be handled individually (and we have Sentry for that)