### PR TITLE
Catch and stop reporting VAIS autocomplete errors that cannot be actioned

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,7 @@
 class ApplicationController < ActionController::API
+private
+
+  def render_internal_error
+    render json: { "error": "Internal server error" }, status: :internal_server_error
+  end
 end

--- a/app/controllers/autocompletes_controller.rb
+++ b/app/controllers/autocompletes_controller.rb
@@ -1,4 +1,6 @@
 class AutocompletesController < ApplicationController
+  rescue_from DiscoveryEngine::InternalError, with: :render_internal_error
+
   def show
     render json: completion_result
   end

--- a/app/services/discovery_engine/autocomplete/complete.rb
+++ b/app/services/discovery_engine/autocomplete/complete.rb
@@ -26,6 +26,8 @@ module DiscoveryEngine::Autocomplete
         .complete_query(complete_query_request)
         .query_suggestions
         .map(&:suggestion)
+    rescue Google::Cloud::DeadlineExceededError => e
+      Rails.logger.warn("#{self.class.name}: Did not get autocomplete suggestion: '#{e.message}'")
     end
 
     def complete_query_request

--- a/app/services/discovery_engine/autocomplete/complete.rb
+++ b/app/services/discovery_engine/autocomplete/complete.rb
@@ -26,7 +26,7 @@ module DiscoveryEngine::Autocomplete
         .complete_query(complete_query_request)
         .query_suggestions
         .map(&:suggestion)
-    rescue Google::Cloud::DeadlineExceededError => e
+    rescue Google::Cloud::DeadlineExceededError, Google::Cloud::InternalError => e
       Rails.logger.warn("#{self.class.name}: Did not get autocomplete suggestion: '#{e.message}'")
     end
 

--- a/app/services/discovery_engine/autocomplete/complete.rb
+++ b/app/services/discovery_engine/autocomplete/complete.rb
@@ -28,6 +28,8 @@ module DiscoveryEngine::Autocomplete
         .map(&:suggestion)
     rescue Google::Cloud::DeadlineExceededError, Google::Cloud::InternalError => e
       Rails.logger.warn("#{self.class.name}: Did not get autocomplete suggestion: '#{e.message}'")
+
+      raise DiscoveryEngine::InternalError
     end
 
     def complete_query_request

--- a/app/services/discovery_engine/internal_error.rb
+++ b/app/services/discovery_engine/internal_error.rb
@@ -1,0 +1,3 @@
+module DiscoveryEngine
+  class InternalError < StandardError; end
+end

--- a/app/services/quality_monitoring/runner.rb
+++ b/app/services/quality_monitoring/runner.rb
@@ -1,7 +1,5 @@
 module QualityMonitoring
   class Runner
-    class FailuresEncountered < StandardError; end
-
     attr_reader :file, :type, :cutoff, :report_query_below_score, :judge_by, :metric_collector
 
     def initialize(

--- a/spec/requests/autocomplete_request_spec.rb
+++ b/spec/requests/autocomplete_request_spec.rb
@@ -32,4 +32,17 @@ RSpec.describe "Making an autocomplete request" do
       })
     end
   end
+
+  context "when autocomplete returns a DiscoveryEngine::InternalError" do
+    before do
+      allow(DiscoveryEngine::Autocomplete::Complete).to receive(:new)
+        .and_raise(DiscoveryEngine::InternalError)
+    end
+
+    it "returns a 500 response" do
+      get "/autocomplete.json?q=foo"
+
+      expect(response).to have_http_status(:internal_server_error)
+    end
+  end
 end

--- a/spec/services/discovery_engine/autocomplete/complete_spec.rb
+++ b/spec/services/discovery_engine/autocomplete/complete_spec.rb
@@ -50,8 +50,8 @@ RSpec.describe DiscoveryEngine::Autocomplete::Complete do
       context "and the error is a Google::Cloud::DeadlineExceededError" do
         let(:error) { Google::Cloud::DeadlineExceededError.new("Deadline error") }
 
-        it "catches the error and logs it to the Rails logger" do
-          completion_result
+        it "raises an error and logs it to the Rails logger" do
+          expect { completion_result }.to raise_error(DiscoveryEngine::InternalError)
 
           expect(Rails.logger).to have_received(:warn).with(
             "DiscoveryEngine::Autocomplete::Complete: Did not get autocomplete suggestion: 'Deadline error'",
@@ -62,8 +62,8 @@ RSpec.describe DiscoveryEngine::Autocomplete::Complete do
       context "and the error is a Google::Cloud::InternalError" do
         let(:error) { Google::Cloud::InternalError.new("Internal error") }
 
-        it "catches the error and logs it to the Rails logger" do
-          completion_result
+        it "raises an error and logs it only to the Rails logger" do
+          expect { completion_result }.to raise_error(DiscoveryEngine::InternalError)
 
           expect(Rails.logger).to have_received(:warn).with(
             "DiscoveryEngine::Autocomplete::Complete: Did not get autocomplete suggestion: 'Internal error'",

--- a/spec/services/discovery_engine/autocomplete/complete_spec.rb
+++ b/spec/services/discovery_engine/autocomplete/complete_spec.rb
@@ -46,6 +46,18 @@ RSpec.describe DiscoveryEngine::Autocomplete::Complete do
           expect { completion_result }.to raise_error(error)
         end
       end
+
+      context "and the error is a Google::Cloud::DeadlineExceededError" do
+        let(:error) { Google::Cloud::DeadlineExceededError.new("Deadline error") }
+
+        it "catches the error and logs it to the Rails logger" do
+          completion_result
+
+          expect(Rails.logger).to have_received(:warn).with(
+            "DiscoveryEngine::Autocomplete::Complete: Did not get autocomplete suggestion: 'Deadline error'",
+          )
+        end
+      end
     end
   end
 end

--- a/spec/services/discovery_engine/autocomplete/complete_spec.rb
+++ b/spec/services/discovery_engine/autocomplete/complete_spec.rb
@@ -32,5 +32,20 @@ RSpec.describe DiscoveryEngine::Autocomplete::Complete do
         expect(client).not_to have_received(:complete_query)
       end
     end
+
+    context "when the completion service fails" do
+      before do
+        allow(client).to receive(:complete_query).and_raise(error)
+        allow(Rails.logger).to receive(:warn)
+      end
+
+      context "and the error is actionable" do
+        let(:error) { Google::Cloud::PermissionDeniedError.new("Permission denied") }
+
+        it "returns the error from Google Cloud" do
+          expect { completion_result }.to raise_error(error)
+        end
+      end
+    end
   end
 end

--- a/spec/services/discovery_engine/autocomplete/complete_spec.rb
+++ b/spec/services/discovery_engine/autocomplete/complete_spec.rb
@@ -58,6 +58,18 @@ RSpec.describe DiscoveryEngine::Autocomplete::Complete do
           )
         end
       end
+
+      context "and the error is a Google::Cloud::InternalError" do
+        let(:error) { Google::Cloud::InternalError.new("Internal error") }
+
+        it "catches the error and logs it to the Rails logger" do
+          completion_result
+
+          expect(Rails.logger).to have_received(:warn).with(
+            "DiscoveryEngine::Autocomplete::Complete: Did not get autocomplete suggestion: 'Internal error'",
+          )
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
[Trello card](https://trello.com/c/jsRK85PW/822-catch-and-stop-reporting-transient-vais-errors)

# What's changed?

Rescue `Google::Cloud::InternalError`[1] and `Google::Cloud::DeadlineExceededError`[2] errors from VAIS completion service and return a 500 status to the user rather than leaving them uncaught and filling up Sentry.

# Why?

VAIS occasionally experiences short term hiccups on search and autocomplete that are low in volume. These errors have zero actionable information in them and just clog up Sentry, leading us to possibly miss more critical issues. 

The [dashboard](https://grafana.eks.production.govuk.digital/d/govuk-search/gov-uk-search?orgId=1&from=now-24h&to=now&timezone=browser) tracks overall search success rates, and we have alerts set up for when things get too bad, so we don’t really need to know about individual instances of transient errors.

[1]: https://govuk.sentry.io/issues/6193888700/?environment=production&project=4505862568935424&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&stream_index=3
[2]: https://govuk.sentry.io/issues/6096544951/?environment=production&project=4505862568935424&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&stream_index=0