### PR TITLE
Gracefully recover from RabbitMQ failures

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ gem "redis"
 gem "redlock"
 
 group :test do
+  gem "climate_control"
   gem "grpc_mock"
   gem "json_schemer"
   gem "simplecov", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,6 +56,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    climate_control (1.2.0)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.3)
     crass (1.0.6)
@@ -600,6 +601,7 @@ DEPENDENCIES
   activesupport (= 8.0.1)
   bootsnap
   brakeman
+  climate_control
   connection_pool
   csv
   debug

--- a/lib/tasks/document_sync_worker.rake
+++ b/lib/tasks/document_sync_worker.rake
@@ -24,5 +24,8 @@ namespace :document_sync_worker do
     ).run
   rescue Interrupt
     Rails.logger.info("Stopping document sync worker (received interrupt)")
+  rescue AMQ::Protocol::EmptyResponseError => e
+    Rails.logger.warn("Stopping document sync worker: '#{e.message}'")
+    exit(1)
   end
 end

--- a/spec/lib/tasks/document_sync_worker_spec.rb
+++ b/spec/lib/tasks/document_sync_worker_spec.rb
@@ -1,0 +1,44 @@
+RSpec.describe "Document synchronisation tasks" do
+  describe "document_sync_worker:run" do
+    let(:consumer) { instance_double(GovukMessageQueueConsumer::Consumer) }
+
+    before do
+      allow(GovukMessageQueueConsumer::Consumer)
+        .to receive(:new)
+        .and_return(consumer)
+
+      allow(Rails.logger).to receive(:info)
+      Rake::Task["document_sync_worker:run"].reenable
+    end
+
+    it "processes a document" do
+      ClimateControl.modify PUBLISHED_DOCUMENTS_MESSAGE_QUEUE_NAME: "my queue" do
+        expect(consumer)
+          .to receive(:run)
+          .once
+
+        expect(Rails.logger).to receive(:info).with(
+          "Starting document sync worker",
+        )
+
+        Rake::Task["document_sync_worker:run"].invoke
+      end
+    end
+
+    context "when the task is interrupted" do
+      it "catches the interrupt and logs it to the Rails logger" do
+        ClimateControl.modify PUBLISHED_DOCUMENTS_MESSAGE_QUEUE_NAME: "my queue" do
+          allow(consumer)
+            .to receive(:run)
+            .and_raise(Interrupt)
+
+          expect(Rails.logger).to receive(:info).with(
+            "Stopping document sync worker (received interrupt)",
+          )
+
+          Rake::Task["document_sync_worker:run"].invoke
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,6 +20,8 @@ Timecop.safe_mode = true
 require "redlock/testing"
 Redlock::Client.testing_mode = :bypass
 
+Rails.application.load_tasks
+
 # See https://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
   config.default_formatter = "doc" if config.files_to_run.one?


### PR DESCRIPTION
[Trello card](https://trello.com/c/5zTXuAJG/823-gracefully-recover-from-rabbitmq-failures)

# What's changed?

Rescue `AMQ::Protocol::EmptyResponseError` from RabbitMQ and exit the `document_sync_worker:run` rake task, rather than leaving them uncaught and filling up Sentry. Kubernetes will continue to take care of restarting the worker once it has exited

#Why?

These errors cannot be actioned and just clog up Sentry, leading us to possibly miss more critical issues. 