### PR TITLE
Best bet for ETA

### DIFF
--- a/config/best_bets.yml
+++ b/config/best_bets.yml
@@ -34,6 +34,7 @@ shared:
   "mediation": /find-legal-advice
   "ombudsman": /find-legal-advice
   "plan for change": /missions
+  "eta": /eta
 
 test:
   "i want to test a single best bet": /here/you/go


### PR DESCRIPTION
New guide 'Get an electronic travel authorisation (ETA) to visit the UK' not yet ranking well.