### PR TITLE
Label search requests with consumer details

### DIFF
--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -1,6 +1,6 @@
 class SearchesController < ApplicationController
   def show
-    render json: DiscoveryEngine::Query::Search.new(query_params).result_set
+    render json: DiscoveryEngine::Query::Search.new(query_params, user_agent: request.user_agent).result_set
   end
 
 private

--- a/app/services/discovery_engine/query/search.rb
+++ b/app/services/discovery_engine/query/search.rb
@@ -6,9 +6,11 @@ module DiscoveryEngine::Query
 
     def initialize(
       query_params,
+      user_agent: nil,
       client: ::Google::Cloud::DiscoveryEngine.search_service(version: :v1)
     )
       @query_params = query_params
+      @user_agent = user_agent
       @client = client
 
       Rails.logger.debug { "Instantiated #{self.class.name}: Query: #{discovery_engine_params}" }
@@ -26,7 +28,7 @@ module DiscoveryEngine::Query
 
   private
 
-    attr_reader :query_params, :client
+    attr_reader :query_params, :client, :user_agent
 
     def response
       @response ||= client.search(discovery_engine_params).response
@@ -45,6 +47,7 @@ module DiscoveryEngine::Query
         order_by:,
         filter:,
         boost_spec:,
+        user_labels:,
       }.compact
     end
 
@@ -128,6 +131,10 @@ module DiscoveryEngine::Query
         text: response.corrected_query,
         highlighted: "<mark>#{response.corrected_query}</mark>",
       }]
+    end
+
+    def user_labels
+      UserLabels.from_user_agent(user_agent).to_h
     end
   end
 end

--- a/app/services/discovery_engine/query/user_labels.rb
+++ b/app/services/discovery_engine/query/user_labels.rb
@@ -1,0 +1,19 @@
+module DiscoveryEngine::Query
+  UserLabels = Data.define(:consumer, :consumer_group) do
+    def self.from_user_agent(user_agent)
+      case user_agent.to_s
+      when /gds-api-adapters\/.+ \(([^)]+)\)\z/
+        # e.g., "gds-api-adapters/99.2.0 (finder-frontend)" -> "finder-frontend"
+        new(consumer: Regexp.last_match(1), consumer_group: "web")
+      when /\Agovuk_ios\//
+        new(consumer: "app-ios", consumer_group: "app")
+      when /\Aokhttp\//
+        # NOTE: Android app currently uses the stock `okhttp/` user agent from its HTTP library, but
+        # should hopefully change in the future
+        new(consumer: "app-android", consumer_group: "app")
+      else
+        new(consumer: "other", consumer_group: "other")
+      end
+    end
+  end
+end

--- a/spec/requests/search_request_spec.rb
+++ b/spec/requests/search_request_spec.rb
@@ -23,8 +23,9 @@ RSpec.describe "Making a search request" do
       })
     end
 
-    it "passes any query parameters to the search service in the expected format" do
-      get "/search.json?q=garden+centres&start=11&count=22&filter_public_timestamp=from:2019-01-01"
+    it "passes any query parameters and user agent to the search service in the expected format" do
+      get "/search.json?q=garden+centres&start=11&count=22&filter_public_timestamp=from:2019-01-01",
+          headers: { "User-Agent" => "gds-api-adapters/99.2.0 (finder-frontend)" }
 
       expect(DiscoveryEngine::Query::Search).to have_received(:new).with(
         hash_including(
@@ -33,6 +34,7 @@ RSpec.describe "Making a search request" do
           count: "22",
           filter_public_timestamp: "from:2019-01-01",
         ),
+        user_agent: "gds-api-adapters/99.2.0 (finder-frontend)",
       )
     end
 

--- a/spec/services/discovery_engine/query/search_spec.rb
+++ b/spec/services/discovery_engine/query/search_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe DiscoveryEngine::Query::Search do
-  subject(:search) { described_class.new(query_params, client:) }
+  subject(:search) { described_class.new(query_params, user_agent: "test-user-agent", client:) }
 
   let(:client) { double("SearchService::Client", search: search_return_value) }
   let(:filters) { double(filter_expression: "filter-expression") }
@@ -19,6 +19,13 @@ RSpec.describe DiscoveryEngine::Query::Search do
 
   before do
     allow(DiscoveryEngine::Query::Filters).to receive(:new).and_return(filters)
+    allow(DiscoveryEngine::Query::UserLabels).to receive(:from_user_agent)
+      .with("test-user-agent")
+      .and_return(
+        DiscoveryEngine::Query::UserLabels.new(
+          consumer: "test-consumer", consumer_group: "test-group",
+        ),
+      )
   end
 
   around do |example|
@@ -56,6 +63,7 @@ RSpec.describe DiscoveryEngine::Query::Search do
           page_size: 10,
           filter: "filter-expression",
           boost_spec: { condition_boost_specs: expected_boost_specs },
+          user_labels: { consumer: "test-consumer", consumer_group: "test-group" },
         )
       end
 
@@ -80,6 +88,7 @@ RSpec.describe DiscoveryEngine::Query::Search do
             page_size: 22,
             filter: "filter-expression",
             boost_spec: { condition_boost_specs: expected_boost_specs },
+            user_labels: { consumer: "test-consumer", consumer_group: "test-group" },
           )
         end
 

--- a/spec/services/discovery_engine/query/user_labels_spec.rb
+++ b/spec/services/discovery_engine/query/user_labels_spec.rb
@@ -1,0 +1,77 @@
+RSpec.describe DiscoveryEngine::Query::UserLabels do
+  subject { described_class.from_user_agent(user_agent) }
+
+  context "when user agent is from a GOV.UK web app" do
+    context "with gds-api-adapters finder-frontend user agent" do
+      let(:user_agent) { "gds-api-adapters/99.2.0 (finder-frontend)" }
+
+      it { is_expected.to have_attributes(consumer: "finder-frontend", consumer_group: "web") }
+    end
+
+    context "with different app names" do
+      let(:user_agent) { "gds-api-adapters/1.0.0 (government-frontend)" }
+
+      it { is_expected.to have_attributes(consumer: "government-frontend", consumer_group: "web") }
+    end
+
+    context "with different version numbers" do
+      let(:user_agent) { "gds-api-adapters/123.45.67 (collections)" }
+
+      it { is_expected.to have_attributes(consumer: "collections", consumer_group: "web") }
+    end
+  end
+
+  context "when user agent is from iOS app" do
+    context "with basic govuk_ios user agent" do
+      let(:user_agent) { "govuk_ios/1.0.0" }
+
+      it { is_expected.to have_attributes(consumer: "app-ios", consumer_group: "app") }
+    end
+
+    context "with govuk_ios user agent with additional info" do
+      let(:user_agent) { "govuk_ios/2.5.1 (iPhone; iOS 15.0)" }
+
+      it { is_expected.to have_attributes(consumer: "app-ios", consumer_group: "app") }
+    end
+  end
+
+  context "when user agent is from Android app" do
+    context "with basic okhttp user agent" do
+      let(:user_agent) { "okhttp/4.9.0" }
+
+      it { is_expected.to have_attributes(consumer: "app-android", consumer_group: "app") }
+    end
+
+    context "with okhttp user agent with additional info" do
+      let(:user_agent) { "okhttp/4.9.0 (Android 11)" }
+
+      it { is_expected.to have_attributes(consumer: "app-android", consumer_group: "app") }
+    end
+  end
+
+  context "when user agent is from other sources" do
+    context "with browser user agent" do
+      let(:user_agent) { "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36" }
+
+      it { is_expected.to have_attributes(consumer: "other", consumer_group: "other") }
+    end
+
+    context "with curl user agent" do
+      let(:user_agent) { "curl/7.68.0" }
+
+      it { is_expected.to have_attributes(consumer: "other", consumer_group: "other") }
+    end
+
+    context "with empty user agent" do
+      let(:user_agent) { "" }
+
+      it { is_expected.to have_attributes(consumer: "other", consumer_group: "other") }
+    end
+
+    context "with nil user agent" do
+      let(:user_agent) { nil }
+
+      it { is_expected.to have_attributes(consumer: "other", consumer_group: "other") }
+    end
+  end
+end


### PR DESCRIPTION
This adds user labels to search requests based on the user agent string, allowing us to differentiate between consumers for analytics and billing purposes.

A `consumer_group` label is set based on the kind of consumer (`web`/`app`/`other`), and a more specific `consumer` label is set to the consuming app itself (e.g. `finder-frontend` or `app-ios`).

These labels don't affect results, but can be used in the Google Cloud billing console to differentiate between different consumers, so costs of search use can be tracked and associated with specific teams.
