### PR TITLE
Move to new engine and serving config

### DIFF
--- a/app/models/engine.rb
+++ b/app/models/engine.rb
@@ -13,6 +13,6 @@ Engine = Data.define(:remote_resource_id) do
 
   # The default engine created through Terraform in `govuk-infrastructure`
   def self.default
-    new("govuk")
+    new("govuk_global")
   end
 end

--- a/app/models/serving_config.rb
+++ b/app/models/serving_config.rb
@@ -11,7 +11,7 @@ ServingConfig = Data.define(:remote_resource_id) do
 
   # The default serving config automatically available on an engine
   def self.default
-    new("default_search")
+    new("default")
   end
 
   # Used as the variant ("B") when AB testing

--- a/spec/models/engine_spec.rb
+++ b/spec/models/engine_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe Engine do
 
   describe ".default" do
     it "returns the default engine" do
-      expect(described_class.default).to eq(described_class.new("govuk"))
+      expect(described_class.default).to eq(described_class.new("govuk_global"))
     end
   end
 

--- a/spec/models/serving_config_spec.rb
+++ b/spec/models/serving_config_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe ServingConfig do
 
   describe ".default" do
     it "returns the default serving config" do
-      expect(described_class.default).to eq(described_class.new("default_search"))
+      expect(described_class.default).to eq(described_class.new("default"))
     end
   end
 
@@ -15,7 +15,7 @@ RSpec.describe ServingConfig do
 
   describe "#name" do
     it "returns the fully qualified name of the serving config" do
-      expect(serving_config.name).to eq("[collection]/engines/govuk/servingConfigs/my-serving-config")
+      expect(serving_config.name).to eq("[collection]/engines/govuk_global/servingConfigs/my-serving-config")
     end
   end
 end


### PR DESCRIPTION
We have created a new `govuk_global` engine[1] with a `default` serving config[2].

This changes Search API v2 to use these new resources instead of the current ones.

[1]: https://github.com/alphagov/govuk-infrastructure/blob/main/terraform/deployments/search-api-v2/discovery_engine.tf#L50
[2]: https://github.com/alphagov/govuk-infrastructure/blob/main/terraform/deployments/search-api-v2/serving_config_global_default.tf#L4