### PR TITLE
Use location as top-level resource

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
       RAILS_ENV: test
       # All Google client library calls are mocked, but the application needs this set to boot
       GOOGLE_CLOUD_PROJECT_ID: not-used
-      DISCOVERY_ENGINE_DEFAULT_COLLECTION_NAME: not-used
+      DISCOVERY_ENGINE_DEFAULT_LOCATION_NAME: not-used
       # Redis running through govuk-infrastructure action
       REDIS_URL: redis://localhost:6379
     steps:

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -1,0 +1,13 @@
+# Represents a collection on Discovery Engine.
+#
+# A collection is a logical grouping that contains other resources like engines and data stores.
+# Currently, Discovery Engine uses a single default collection with no ability to create further
+# ones.
+Collection = Data.define(:remote_resource_id) do
+  include DiscoveryEngineNameable
+
+  # The default collection
+  def self.default
+    new("default_collection")
+  end
+end

--- a/app/models/concerns/discovery_engine_nameable.rb
+++ b/app/models/concerns/discovery_engine_nameable.rb
@@ -24,8 +24,8 @@ private
     if respond_to?(:parent)
       parent.name
     else
-      # The default collection is the parent of all root-level resources
-      Rails.configuration.discovery_engine_default_collection_name
+      # The default location is the parent of all root-level resources
+      Rails.configuration.discovery_engine_default_location_name
     end
   end
 end

--- a/app/models/data_store.rb
+++ b/app/models/data_store.rb
@@ -12,4 +12,8 @@ DataStore = Data.define(:remote_resource_id) do
   def self.default
     new("govuk_content")
   end
+
+  def parent
+    Collection.default
+  end
 end

--- a/app/models/engine.rb
+++ b/app/models/engine.rb
@@ -15,4 +15,8 @@ Engine = Data.define(:remote_resource_id) do
   def self.default
     new("govuk_global")
   end
+
+  def parent
+    Collection.default
+  end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -17,10 +17,8 @@ module SearchApiV2
     config.api_only = true
 
     # Google Discovery Engine configuration
-    config.discovery_engine_default_collection_name = ENV.fetch("DISCOVERY_ENGINE_DEFAULT_COLLECTION_NAME")
+    config.discovery_engine_default_location_name = ENV.fetch("DISCOVERY_ENGINE_DEFAULT_LOCATION_NAME")
     config.google_cloud_project_id = ENV.fetch("GOOGLE_CLOUD_PROJECT_ID")
-    # TODO: Move this into an env var later
-    config.discovery_engine_default_location_name = "projects/#{config.google_cloud_project_id}/locations/global"
 
     # Document sync configuration
     config.document_type_ignorelist = config_for(:document_type_ignorelist)

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -41,7 +41,7 @@ Rails.application.configure do
   config.action_controller.raise_on_missing_callback_actions = true
 
   # Google Discovery Engine configuration
-  config.discovery_engine_default_collection_name = "[collection]"
+  config.discovery_engine_default_location_name = "[location]"
 end
 
 # TODO: remove this workaround once GovukPrometheusExporter initialisation is fixed in govuk_app_config.

--- a/spec/models/branch_spec.rb
+++ b/spec/models/branch_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Branch do
 
   describe "#name" do
     it "returns the fully qualified name of the branch" do
-      expect(branch.name).to eq("[collection]/dataStores/govuk_content/branches/my-branch")
+      expect(branch.name).to eq("[location]/collections/default_collection/dataStores/govuk_content/branches/my-branch")
     end
   end
 end

--- a/spec/models/data_store_spec.rb
+++ b/spec/models/data_store_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe DataStore do
 
   describe "#name" do
     it "returns the fully qualified name of the data store" do
-      expect(data_store.name).to eq("[collection]/dataStores/my-data-store")
+      expect(data_store.name).to eq("[location]/collections/default_collection/dataStores/my-data-store")
     end
   end
 end

--- a/spec/models/engine_spec.rb
+++ b/spec/models/engine_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Engine do
 
   describe "#name" do
     it "returns the fully qualified name of the engine" do
-      expect(engine.name).to eq("[collection]/engines/my-engine")
+      expect(engine.name).to eq("[location]/collections/default_collection/engines/my-engine")
     end
   end
 end

--- a/spec/models/serving_config_spec.rb
+++ b/spec/models/serving_config_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe ServingConfig do
 
   describe "#name" do
     it "returns the fully qualified name of the serving config" do
-      expect(serving_config.name).to eq("[collection]/engines/govuk_global/servingConfigs/my-serving-config")
+      expect(serving_config.name).to eq("[location]/collections/default_collection/engines/govuk_global/servingConfigs/my-serving-config")
     end
   end
 end


### PR DESCRIPTION
Up until now, we've had the default collection passed in through the app's environment as the top-level resource that other things are nested underneath. Since we will now have to start dealing with resources that are on a sibling level to collections (sample query sets), this changes the app to use the location as the top level resource.

- Introduce `Collection` model to represent collections, and set it as the parent for engines and datastores
- Remove configuration of default collection in favour of default location