### PR TITLE
Configure default location name from environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ jobs:
       # All Google client library calls are mocked, but the application needs this set to boot
       GOOGLE_CLOUD_PROJECT_ID: not-used
       DISCOVERY_ENGINE_DEFAULT_COLLECTION_NAME: not-used
+      DISCOVERY_ENGINE_DEFAULT_LOCATION_NAME: not-used
       # Redis running through govuk-infrastructure action
       REDIS_URL: redis://localhost:6379
     steps:

--- a/config/application.rb
+++ b/config/application.rb
@@ -18,9 +18,8 @@ module SearchApiV2
 
     # Google Discovery Engine configuration
     config.discovery_engine_default_collection_name = ENV.fetch("DISCOVERY_ENGINE_DEFAULT_COLLECTION_NAME")
+    config.discovery_engine_default_location_name = ENV.fetch("DISCOVERY_ENGINE_DEFAULT_LOCATION_NAME")
     config.google_cloud_project_id = ENV.fetch("GOOGLE_CLOUD_PROJECT_ID")
-    # TODO: Move this into an env var later
-    config.discovery_engine_default_location_name = "projects/#{config.google_cloud_project_id}/locations/global"
 
     # Document sync configuration
     config.document_type_ignorelist = config_for(:document_type_ignorelist)

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -42,6 +42,7 @@ Rails.application.configure do
 
   # Google Discovery Engine configuration
   config.discovery_engine_default_collection_name = "[collection]"
+  config.discovery_engine_default_location_name = "[location]"
 end
 
 # TODO: remove this workaround once GovukPrometheusExporter initialisation is fixed in govuk_app_config.


### PR DESCRIPTION
This is now set through the Helm chart[1] and can be used instead of fudging it manually.

[1]: https://github.com/alphagov/govuk-helm-charts/pull/3268