### PR TITLE
Rename rake task

### DIFF
--- a/lib/tasks/evaluation.rake
+++ b/lib/tasks/evaluation.rake
@@ -2,30 +2,28 @@ require "prometheus/client"
 require "prometheus/client/push"
 
 namespace :evaluation do
-  namespace :clickstream do
-    desc "Create a sample query set for last month's clickstream data and import from BigQuery"
-    task setup_sample_set: :environment do
-      DiscoveryEngine::Evaluation::SampleQuerySet.new.create_and_import
-    end
+  desc "Create a sample query set for last month's clickstream data and import from BigQuery"
+  task setup_sample_query_sets: :environment do
+    DiscoveryEngine::Evaluation::SampleQuerySet.new.create_and_import
+  end
 
-    desc "Create evaluation and fetch results"
-    task :fetch_evaluations, [:sample_set_id] => [:environment] do |_, args|
-      sample_set_id = args[:sample_set_id]
+  desc "Create evaluation and fetch results"
+  task :fetch_evaluations, [:sample_set_id] => [:environment] do |_, args|
+    sample_set_id = args[:sample_set_id]
 
-      raise "sample_set_id is required" unless sample_set_id
+    raise "sample_set_id is required" unless sample_set_id
 
-      evaluations = DiscoveryEngine::Evaluation::EvaluationRunner.new(sample_set_id).fetch_quality_metrics
+    evaluations = DiscoveryEngine::Evaluation::EvaluationRunner.new(sample_set_id).fetch_quality_metrics
 
-      Rails.logger.info(evaluations)
+    Rails.logger.info(evaluations)
 
-      registry = Prometheus::Client.registry
+    registry = Prometheus::Client.registry
 
-      Metrics::Evaluation.new(registry).record_evaluations(evaluations)
+    Metrics::Evaluation.new(registry).record_evaluations(evaluations)
 
-      Prometheus::Client::Push.new(
-        job: "evaluation_clickstream_fetch_evaluations",
-        gateway: ENV.fetch("PROMETHEUS_PUSHGATEWAY_URL"),
-      ).add(registry)
-    end
+    Prometheus::Client::Push.new(
+      job: "evaluation_clickstream_fetch_evaluations",
+      gateway: ENV.fetch("PROMETHEUS_PUSHGATEWAY_URL"),
+    ).add(registry)
   end
 end

--- a/spec/lib/tasks/evaluation_spec.rb
+++ b/spec/lib/tasks/evaluation_spec.rb
@@ -1,9 +1,9 @@
 RSpec.describe "Evaluation tasks" do
-  describe "setup_sample_set" do
+  describe "setup_sample_query_sets" do
     let(:sample_query_set) { instance_double(DiscoveryEngine::Evaluation::SampleQuerySet) }
 
     before do
-      Rake::Task["evaluation:clickstream:setup_sample_set"].reenable
+      Rake::Task["evaluation:setup_sample_query_sets"].reenable
 
       allow(DiscoveryEngine::Evaluation::SampleQuerySet)
       .to receive(:new)
@@ -14,7 +14,7 @@ RSpec.describe "Evaluation tasks" do
       expect(sample_query_set)
         .to receive(:create_and_import)
         .once
-      Rake::Task["evaluation:clickstream:setup_sample_set"].invoke
+      Rake::Task["evaluation:setup_sample_query_sets"].invoke
     end
   end
 
@@ -25,7 +25,7 @@ RSpec.describe "Evaluation tasks" do
     let(:metric_evaluation) { instance_double(Metrics::Evaluation) }
 
     before do
-      Rake::Task["evaluation:clickstream:fetch_evaluations"].reenable
+      Rake::Task["evaluation:fetch_evaluations"].reenable
 
       allow(DiscoveryEngine::Evaluation::EvaluationRunner)
         .to receive(:new)
@@ -55,13 +55,13 @@ RSpec.describe "Evaluation tasks" do
         expect(metric_evaluation)
           .to receive(:record_evaluations)
           .once
-        Rake::Task["evaluation:clickstream:fetch_evaluations"].invoke("clickstream_01_07")
+        Rake::Task["evaluation:fetch_evaluations"].invoke("clickstream_01_07")
       end
     end
 
     context "when sample_id is not passed in" do
       it "raises and error" do
-        expect { Rake::Task["evaluation:clickstream:fetch_evaluations"].invoke }
+        expect { Rake::Task["evaluation:fetch_evaluations"].invoke }
           .to raise_error("sample_set_id is required")
       end
     end


### PR DESCRIPTION
In the future, we will be creating sample query sets from three big query tables. So pluralising the task name now to future proof.