### PR TITLE
Daily task to report quality metrics for the previous two months

### DIFF
--- a/app/services/discovery_engine/quality/sample_query_set_fields.rb
+++ b/app/services/discovery_engine/quality/sample_query_set_fields.rb
@@ -1,0 +1,22 @@
+module DiscoveryEngine
+  module Quality::SampleQuerySetFields
+    BIGQUERY_DATASET_ID = "automated_evaluation_input".freeze
+    BIGQUERY_TABLE_ID = "clickstream".freeze
+
+    def display_name(date)
+      "#{BIGQUERY_TABLE_ID} #{formatted_date(date)}"
+    end
+
+    def description(date)
+      "Generated from #{formatted_date(date)} BigQuery #{BIGQUERY_TABLE_ID} data"
+    end
+
+    def sample_query_set_id(date)
+      "#{BIGQUERY_TABLE_ID}_#{formatted_date(date)}"
+    end
+
+    def formatted_date(date)
+      date.strftime("%Y-%m")
+    end
+  end
+end

--- a/app/services/discovery_engine/quality/sample_query_set_fields.rb
+++ b/app/services/discovery_engine/quality/sample_query_set_fields.rb
@@ -3,6 +3,8 @@ module DiscoveryEngine
     BIGQUERY_DATASET_ID = "automated_evaluation_input".freeze
     BIGQUERY_TABLE_ID = "clickstream".freeze
 
+  module_function
+
     def display_name(date)
       "#{BIGQUERY_TABLE_ID} #{formatted_date(date)}"
     end

--- a/app/services/metrics/evaluation.rb
+++ b/app/services/metrics/evaluation.rb
@@ -2,40 +2,41 @@ module Metrics
   class Evaluation
     TOP_K_LEVELS = %w[1 3 5 10].freeze
 
-    def initialize(registry)
+    def initialize(registry, month)
       @doc_recall = registry.gauge(
         :search_api_v2_evaluation_monitoring_recall,
         docstring: "Vertex AI search evaluation recall",
-        labels: %i[top],
+        labels: %i[top month],
       )
       @doc_precision = registry.gauge(
         :search_api_v2_evaluation_monitoring_precision,
         docstring: "Vertex AI search evaluation precision",
-        labels: %i[top],
+        labels: %i[top month],
       )
       @doc_ndcg = registry.gauge(
         :search_api_v2_evaluation_monitoring_ndcg,
         docstring: "Vertex AI search evaluation ndcg",
-        labels: %i[top],
+        labels: %i[top month],
       )
+      @month = month
     end
 
     def record_evaluations(evaluation_result)
-      metrics.each { |key, registry| record_evaluation(key, registry, evaluation_result) }
+      metrics.each { |key, registry| record_evaluation(key, registry, month, evaluation_result) }
     end
 
   private
 
-    attr_reader :doc_recall, :doc_precision, :doc_ndcg
+    attr_reader :doc_recall, :doc_precision, :doc_ndcg, :month
 
     def metrics
       { doc_recall:, doc_precision:, doc_ndcg: }
     end
 
-    def record_evaluation(key, registry, evaluation_result)
+    def record_evaluation(key, registry, month, evaluation_result)
       TOP_K_LEVELS.each do |k|
         value = evaluation_result[key][:"top_#{k}"]
-        registry.set(value, labels: { top: k })
+        registry.set(value, labels: { top: k, month: })
       end
     end
   end

--- a/lib/tasks/evaluation.rake
+++ b/lib/tasks/evaluation.rake
@@ -19,7 +19,7 @@ namespace :evaluation do
 
     registry = Prometheus::Client.registry
 
-    Metrics::Evaluation.new(registry).record_evaluations(evaluations)
+    Metrics::Evaluation.new(registry, :last_month).record_evaluations(evaluations)
 
     Prometheus::Client::Push.new(
       job: "evaluation_push_quality_metrics",

--- a/lib/tasks/evaluation.rake
+++ b/lib/tasks/evaluation.rake
@@ -8,22 +8,27 @@ namespace :evaluation do
   end
 
   desc "Create evaluation and push results to Prometheus"
-  task :report_quality_metrics, [:sample_set_id] => [:environment] do |_, args|
-    sample_set_id = args[:sample_set_id]
+  task report_quality_metrics: :environment do
+    fields = DiscoveryEngine::Quality::SampleQuerySetFields
 
-    raise "sample_set_id is required" unless sample_set_id
-
-    evaluations = DiscoveryEngine::Quality::Evaluation.new(sample_set_id).fetch_quality_metrics
-
-    Rails.logger.info(evaluations)
+    sample_query_sets = {
+      last_month: fields.sample_query_set_id(Time.zone.now.prev_month),
+      month_before_last: fields.sample_query_set_id(Time.zone.now.prev_month(2)),
+    }
 
     registry = Prometheus::Client.registry
 
-    Metrics::Evaluation.new(registry, :last_month).record_evaluations(evaluations)
+    sample_query_sets.each do |month_label, id|
+      e = DiscoveryEngine::Quality::Evaluation.new(id).fetch_quality_metrics
 
-    Prometheus::Client::Push.new(
-      job: "evaluation_push_quality_metrics",
-      gateway: ENV.fetch("PROMETHEUS_PUSHGATEWAY_URL"),
-    ).add(registry)
+      Rails.logger.info(e)
+
+      Metrics::Evaluation.new(registry, month_label).record_evaluations(e)
+
+      Prometheus::Client::Push.new(
+        job: "evaluation_report_quality_metrics",
+        gateway: ENV.fetch("PROMETHEUS_PUSHGATEWAY_URL"),
+      ).add(registry)
+    end
   end
 end

--- a/spec/lib/tasks/evaluation_spec.rb
+++ b/spec/lib/tasks/evaluation_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "Evaluation tasks" do
 
       allow(DiscoveryEngine::Quality::Evaluation)
         .to receive(:new)
-        .with("clickstream_01_07")
+        .with("clickstream_2025-07")
         .and_return(evaluation)
 
       allow(Prometheus::Client)
@@ -42,7 +42,7 @@ RSpec.describe "Evaluation tasks" do
 
       allow(Metrics::Evaluation)
         .to receive(:new)
-        .with(registry)
+        .with(registry, :last_month)
         .and_return(metric_evaluation)
     end
 
@@ -55,7 +55,7 @@ RSpec.describe "Evaluation tasks" do
         expect(metric_evaluation)
           .to receive(:record_evaluations)
           .once
-        Rake::Task["evaluation:report_quality_metrics"].invoke("clickstream_01_07")
+        Rake::Task["evaluation:report_quality_metrics"].invoke("clickstream_2025-07")
       end
     end
 

--- a/spec/lib/tasks/evaluation_spec.rb
+++ b/spec/lib/tasks/evaluation_spec.rb
@@ -19,6 +19,10 @@ RSpec.describe "Evaluation tasks" do
   end
 
   describe "report_quality_metrics" do
+    around do |example|
+      Timecop.freeze(2025, 11, 1) { example.call }
+    end
+
     let(:evaluation) { instance_double(DiscoveryEngine::Quality::Evaluation) }
     let(:registry) { double("registry", gauge: nil) }
     let(:push_client) { double("push_client", add: nil) }
@@ -29,7 +33,12 @@ RSpec.describe "Evaluation tasks" do
 
       allow(DiscoveryEngine::Quality::Evaluation)
         .to receive(:new)
-        .with("clickstream_2025-07")
+        .with("clickstream_2025-10")
+        .and_return(evaluation)
+
+      allow(DiscoveryEngine::Quality::Evaluation)
+        .to receive(:new)
+        .with("clickstream_2025-09")
         .and_return(evaluation)
 
       allow(Prometheus::Client)
@@ -44,25 +53,23 @@ RSpec.describe "Evaluation tasks" do
         .to receive(:new)
         .with(registry, :last_month)
         .and_return(metric_evaluation)
+
+      allow(Metrics::Evaluation)
+        .to receive(:new)
+        .with(registry, :month_before_last)
+        .and_return(metric_evaluation)
     end
 
-    it "creates and outputs evaluations" do
+    it "reports quality metrics to prometheus" do
       ClimateControl.modify PROMETHEUS_PUSHGATEWAY_URL: "https://www.something.example.org" do
         expect(evaluation)
           .to receive(:fetch_quality_metrics)
-          .once
+          .twice
 
         expect(metric_evaluation)
           .to receive(:record_evaluations)
-          .once
-        Rake::Task["evaluation:report_quality_metrics"].invoke("clickstream_2025-07")
-      end
-    end
-
-    context "when sample_id is not passed in" do
-      it "raises and error" do
-        expect { Rake::Task["evaluation:report_quality_metrics"].invoke }
-          .to raise_error("sample_set_id is required")
+          .twice
+        Rake::Task["evaluation:report_quality_metrics"].invoke
       end
     end
   end

--- a/spec/services/metrics/evaluation_spec.rb
+++ b/spec/services/metrics/evaluation_spec.rb
@@ -1,7 +1,9 @@
 RSpec.describe Metrics::Evaluation do
-  subject(:evaluation) { described_class.new(registry) }
+  subject(:evaluation) { described_class.new(registry, month) }
 
   let(:registry) { double("registry") }
+  let(:month) { :last_month }
+
   let(:evaluation_response) do
     {
       doc_recall: {
@@ -42,31 +44,31 @@ RSpec.describe Metrics::Evaluation do
   describe "#record_evaluations" do
     it "records the recall, precision and ndcg score" do
       expect(recall_gauge).to receive(:set)
-        .with(0.988, { labels: { top: "1" } })
+        .with(0.988, { labels: { top: "1", month: } })
       expect(recall_gauge).to receive(:set)
-        .with(0.995, { labels: { top: "3" } })
+        .with(0.995, { labels: { top: "3", month: } })
       expect(recall_gauge).to receive(:set)
-        .with(0.998, { labels: { top: "5" } })
+        .with(0.998, { labels: { top: "5", month: } })
       expect(recall_gauge).to receive(:set)
-        .with(0.999, { labels: { top: "10" } })
+        .with(0.999, { labels: { top: "10", month: } })
 
       expect(precision_gauge).to receive(:set)
-        .with(0.988, { labels: { top: "1" } })
+        .with(0.988, { labels: { top: "1", month: } })
       expect(precision_gauge).to receive(:set)
-        .with(0.953, { labels: { top: "3" } })
+        .with(0.953, { labels: { top: "3", month: } })
       expect(precision_gauge).to receive(:set)
-        .with(0.896, { labels: { top: "5" } })
+        .with(0.896, { labels: { top: "5", month: } })
       expect(precision_gauge).to receive(:set)
-        .with(0.752, { labels: { top: "10" } })
+        .with(0.752, { labels: { top: "10", month: } })
 
       expect(ndcg_gauge).to receive(:set)
-        .with(0.988, { labels: { top: "1" } })
+        .with(0.988, { labels: { top: "1", month: } })
       expect(ndcg_gauge).to receive(:set)
-        .with(0.961, { labels: { top: "3" } })
+        .with(0.961, { labels: { top: "3", month: } })
       expect(ndcg_gauge).to receive(:set)
-        .with(0.929, { labels: { top: "5" } })
+        .with(0.929, { labels: { top: "5", month: } })
       expect(ndcg_gauge).to receive(:set)
-        .with(0.887, { labels: { top: "10" } })
+        .with(0.887, { labels: { top: "10", month: } })
 
       evaluation.record_evaluations(evaluation_response)
     end


### PR DESCRIPTION
## What

Update the daily`report_quality_metrics` rake task to fetch and report quality metrics for two sample query sets (last month and month before last)

[Trello](https://trello.com/c/SbbNvfan/844-evaluations-push-sample-query-set-results-to-prometheus)