### PR TITLE
Bug fix: Only instantiate Evaluations::Metrics object once

### DIFF
--- a/app/services/metrics/evaluation.rb
+++ b/app/services/metrics/evaluation.rb
@@ -2,7 +2,7 @@ module Metrics
   class Evaluation
     TOP_K_LEVELS = %w[1 3 5 10].freeze
 
-    def initialize(registry, month)
+    def initialize(registry)
       @doc_recall = registry.gauge(
         :search_api_v2_evaluation_monitoring_recall,
         docstring: "Vertex AI search evaluation recall",
@@ -18,16 +18,15 @@ module Metrics
         docstring: "Vertex AI search evaluation ndcg",
         labels: %i[top month],
       )
-      @month = month
     end
 
-    def record_evaluations(evaluation_result)
+    def record_evaluations(evaluation_result, month)
       metrics.each { |key, registry| record_evaluation(key, registry, month, evaluation_result) }
     end
 
   private
 
-    attr_reader :doc_recall, :doc_precision, :doc_ndcg, :month
+    attr_reader :doc_recall, :doc_precision, :doc_ndcg
 
     def metrics
       { doc_recall:, doc_precision:, doc_ndcg: }

--- a/lib/tasks/quality.rake
+++ b/lib/tasks/quality.rake
@@ -17,13 +17,14 @@ namespace :quality do
     }
 
     registry = Prometheus::Client.registry
+    metric_evaluation = Metrics::Evaluation.new(registry)
 
     sample_query_sets.each do |month_label, id|
       e = DiscoveryEngine::Quality::Evaluation.new(id).fetch_quality_metrics
 
       Rails.logger.info(e)
 
-      Metrics::Evaluation.new(registry, month_label).record_evaluations(e)
+      metric_evaluation.record_evaluations(e, month_label)
 
       Prometheus::Client::Push.new(
         job: "evaluation_report_quality_metrics",

--- a/spec/services/metrics/evaluation_spec.rb
+++ b/spec/services/metrics/evaluation_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Metrics::Evaluation do
-  subject(:evaluation) { described_class.new(registry, month) }
+  subject(:evaluation) { described_class.new(registry) }
 
   let(:registry) { double("registry") }
   let(:month) { :last_month }
@@ -70,7 +70,7 @@ RSpec.describe Metrics::Evaluation do
       expect(ndcg_gauge).to receive(:set)
         .with(0.887, { labels: { top: "10", month: } })
 
-      evaluation.record_evaluations(evaluation_response)
+      evaluation.record_evaluations(evaluation_response, month)
     end
   end
 end


### PR DESCRIPTION
Previous configuration resulted in the following error

`Prometheus::Client::Registry::AlreadyRegisteredError:search_api_v2_evaluation_monitoring_recall has already been registered (Prometheus::Client::Registry::AlreadyRegisteredError)`

