### PR TITLE
Rake task to create a sample query set for a given month

### DIFF
--- a/app/services/discovery_engine/quality/sample_query_set.rb
+++ b/app/services/discovery_engine/quality/sample_query_set.rb
@@ -3,6 +3,11 @@ module DiscoveryEngine
     class SampleQuerySet
       include SampleQuerySetFields
 
+      def initialize(year = nil, month = nil)
+        @year = year&.to_i
+        @month = month&.to_i
+      end
+
       def create_and_import
         create
         import
@@ -10,17 +15,17 @@ module DiscoveryEngine
 
     private
 
-      attr_reader :set
+      attr_reader :set, :year, :month
 
       def create
         @set = DiscoveryEngine::Clients
           .sample_query_set_service
           .create_sample_query_set(
             sample_query_set: {
-              display_name: display_name(last_month),
-              description: description(last_month),
+              display_name: display_name(date),
+              description: description(date),
             },
-            sample_query_set_id: sample_query_set_id(last_month),
+            sample_query_set_id: sample_query_set_id(date),
             parent: Rails.application.config.discovery_engine_default_location_name,
           )
       end
@@ -35,8 +40,8 @@ module DiscoveryEngine
               table_id: BIGQUERY_TABLE_ID,
               project_id: Rails.application.config.google_cloud_project_id,
               partition_date: {
-                year: last_month.year,
-                month: last_month.month,
+                year: date.year,
+                month: date.month,
                 # Partition date needs to be a full date not just year-month
                 day: 1,
               },
@@ -49,8 +54,10 @@ module DiscoveryEngine
         Rails.logger.info("Successfully imported sample queries into: #{set.name}")
       end
 
-      def last_month
-        Time.zone.now.prev_month
+      def date
+        return Time.zone.now.prev_month if year.nil? || month.nil?
+
+        Date.new(year, month, 1)
       end
     end
   end

--- a/lib/tasks/quality.rake
+++ b/lib/tasks/quality.rake
@@ -7,6 +7,18 @@ namespace :quality do
     DiscoveryEngine::Quality::SampleQuerySet.new.create_and_import
   end
 
+  desc "Create a sample query set for clickstream data for a given month, and import from BigQuery"
+  task :setup_sample_query_set, %i[year month] => :environment do |_, args|
+    raise "year and month are required arguments" unless args[:year] && args[:month]
+
+    raise "arguments must be provided in YYYY M order" if args[:year].to_i < args[:month].to_i
+
+    year = args[:year]
+    month = args[:month]
+
+    DiscoveryEngine::Quality::SampleQuerySet.new(year, month).create_and_import
+  end
+
   desc "Create evaluation and push results to Prometheus"
   task report_quality_metrics: :environment do
     fields = DiscoveryEngine::Quality::SampleQuerySetFields

--- a/spec/lib/tasks/quality_spec.rb
+++ b/spec/lib/tasks/quality_spec.rb
@@ -18,6 +18,26 @@ RSpec.describe "Quality tasks" do
     end
   end
 
+  describe "setup_sample_query_set" do
+    let(:sample_query_set) { instance_double(DiscoveryEngine::Quality::SampleQuerySet) }
+
+    before do
+      Rake::Task["quality:setup_sample_query_set"].reenable
+
+      allow(DiscoveryEngine::Quality::SampleQuerySet)
+      .to receive(:new)
+      .with("2025", "1")
+      .and_return(sample_query_set)
+    end
+
+    it "creates and imports a sample set" do
+      expect(sample_query_set)
+        .to receive(:create_and_import)
+        .once
+      Rake::Task["quality:setup_sample_query_set"].invoke("2025", "1")
+    end
+  end
+
   describe "report_quality_metrics" do
     around do |example|
       Timecop.freeze(2025, 11, 1) { example.call }


### PR DESCRIPTION
To be used as part of our quality monitoring. 

The default rake task `quality:setup_sample_query_sets` is hardcoded to create sample query sets for last month and the month before last. 

This task will allow us to create a sample query set for a given month. 