### PR TITLE
Add `MonthInterval` to represent month

### DIFF
--- a/app/services/discovery_engine/quality/month_interval.rb
+++ b/app/services/discovery_engine/quality/month_interval.rb
@@ -1,0 +1,12 @@
+module DiscoveryEngine::Quality
+  MonthInterval = Data.define(:year, :month) do
+    def self.previous_month(months_ago = 1)
+      date = Time.zone.now.prev_month(months_ago)
+      new(date.year, date.month)
+    end
+
+    def to_s
+      Date.new(year, month, 1).strftime("%Y-%m")
+    end
+  end
+end

--- a/app/services/discovery_engine/quality/sample_query_set_fields.rb
+++ b/app/services/discovery_engine/quality/sample_query_set_fields.rb
@@ -5,20 +5,16 @@ module DiscoveryEngine
 
   module_function
 
-    def display_name(date)
-      "#{BIGQUERY_TABLE_ID} #{formatted_date(date)}"
+    def display_name(month_interval)
+      "#{BIGQUERY_TABLE_ID} #{month_interval}"
     end
 
-    def description(date)
-      "Generated from #{formatted_date(date)} BigQuery #{BIGQUERY_TABLE_ID} data"
+    def description(month_interval)
+      "Generated from #{month_interval} BigQuery #{BIGQUERY_TABLE_ID} data"
     end
 
-    def sample_query_set_id(date)
-      "#{BIGQUERY_TABLE_ID}_#{formatted_date(date)}"
-    end
-
-    def formatted_date(date)
-      date.strftime("%Y-%m")
+    def sample_query_set_id(month_interval)
+      "#{BIGQUERY_TABLE_ID}_#{month_interval}"
     end
   end
 end

--- a/spec/lib/tasks/quality_spec.rb
+++ b/spec/lib/tasks/quality_spec.rb
@@ -20,13 +20,14 @@ RSpec.describe "Quality tasks" do
 
   describe "setup_sample_query_set" do
     let(:sample_query_set) { instance_double(DiscoveryEngine::Quality::SampleQuerySet) }
+    let(:expected_month_interval) { DiscoveryEngine::Quality::MonthInterval.new(2025, 1) }
 
     before do
       Rake::Task["quality:setup_sample_query_set"].reenable
 
       allow(DiscoveryEngine::Quality::SampleQuerySet)
       .to receive(:new)
-      .with("2025", "1")
+      .with(expected_month_interval)
       .and_return(sample_query_set)
     end
 

--- a/spec/services/discovery_engine/quality/month_interval_spec.rb
+++ b/spec/services/discovery_engine/quality/month_interval_spec.rb
@@ -1,0 +1,42 @@
+RSpec.describe DiscoveryEngine::Quality::MonthInterval do
+  subject(:month_interval) { described_class.new(year, month) }
+
+  let(:year) { 1989 }
+  let(:month) { 12 }
+
+  describe ".previous_month" do
+    around do |example|
+      Timecop.freeze(1987, 7, 21) { example.call }
+    end
+
+    context "without an argument" do
+      it "returns a month interval for one month ago" do
+        expect(described_class.previous_month).to eq(described_class.new(1987, 6))
+      end
+    end
+
+    context "with an argument" do
+      it "returns a month interval for the specified number of months ago" do
+        expect(described_class.previous_month(11)).to eq(described_class.new(1986, 8))
+      end
+    end
+  end
+
+  describe "#year" do
+    it "returns the year" do
+      expect(month_interval.year).to eq(1989)
+    end
+  end
+
+  describe "#month" do
+    it "returns the month" do
+      expect(month_interval.month).to eq(12)
+    end
+  end
+
+  describe "#to_s" do
+    it "returns the formatted string representation of the month interval" do
+      expect(month_interval.to_s).to eq("1989-12")
+    end
+  end
+end

--- a/spec/services/discovery_engine/quality/sample_query_set_spec.rb
+++ b/spec/services/discovery_engine/quality/sample_query_set_spec.rb
@@ -1,5 +1,7 @@
 RSpec.describe DiscoveryEngine::Quality::SampleQuerySet do
-  subject(:sample_query_set) { described_class.new }
+  subject(:sample_query_set) { described_class.new(month_interval) }
+
+  let(:month_interval) { DiscoveryEngine::Quality::MonthInterval.new(2025, 1) }
 
   let(:operation_object) { double("operation", wait_until_done!: true, error?: false) }
   let(:response_object) { double("response", name: "/sample_query_set/1") }
@@ -11,109 +13,39 @@ RSpec.describe DiscoveryEngine::Quality::SampleQuerySet do
   end
 
   describe "#create_and_import" do
-    context "when it's January" do
-      around do |example|
-        Timecop.freeze(2025, 1, 31) { example.call }
-      end
+    it "creates a sample query set for the given month interval" do
+      sample_query_set.create_and_import
 
-      it "calls the sample_query_set and import_sample_query set endpoints" do
-        sample_query_set.create_and_import
+      expect(sample_query_set_service_stub).to have_received(:create_sample_query_set).with(
+        sample_query_set: {
+          display_name: "clickstream 2025-01",
+          description: "Generated from 2025-01 BigQuery clickstream data",
+        },
+        sample_query_set_id: "clickstream_2025-01",
+        parent: Rails.application.config.discovery_engine_default_location_name,
+      )
 
-        expect(sample_query_set_service_stub).to have_received(:create_sample_query_set).with(
-          sample_query_set: {
-            display_name: "clickstream 2024-12",
-            description: "Generated from 2024-12 BigQuery clickstream data",
+      expect(sample_query_service_stub).to have_received(:import_sample_queries).with(
+        parent: response_object.name,
+        bigquery_source: {
+          dataset_id: "automated_evaluation_input",
+          table_id: "clickstream",
+          project_id: Rails.application.config.google_cloud_project_id,
+          partition_date: {
+            year: 2025,
+            month: 1,
+            day: 1,
           },
-          sample_query_set_id: "clickstream_2024-12",
-          parent: Rails.application.config.discovery_engine_default_location_name,
-        )
-
-        expect(sample_query_service_stub).to have_received(:import_sample_queries).with(
-          parent: response_object.name,
-          bigquery_source: {
-            dataset_id: "automated_evaluation_input",
-            table_id: "clickstream",
-            project_id: Rails.application.config.google_cloud_project_id,
-            partition_date: {
-              year: 2024,
-              month: 12,
-              day: 1,
-            },
-          },
-        )
-      end
+        },
+      )
     end
 
-    context "when it's the middle of the year" do
-      around do |example|
-        Timecop.freeze(2025, 6, 12) { example.call }
-      end
+    context "when operation does not complete" do
+      let(:error_stub) { double("error", message: "An error message") }
+      let(:operation_object) { double("operation", wait_until_done!: true, error?: true, error: error_stub) }
 
-      it "calls the sample_query_set and import_sample_query set endpoints" do
-        sample_query_set.create_and_import
-
-        expect(sample_query_set_service_stub).to have_received(:create_sample_query_set).with(
-          sample_query_set: {
-            display_name: "clickstream 2025-05",
-            description: "Generated from 2025-05 BigQuery clickstream data",
-          },
-          sample_query_set_id: "clickstream_2025-05",
-          parent: Rails.application.config.discovery_engine_default_location_name,
-        )
-
-        expect(sample_query_service_stub).to have_received(:import_sample_queries).with(
-          parent: response_object.name,
-          bigquery_source: {
-            dataset_id: "automated_evaluation_input",
-            table_id: "clickstream",
-            project_id: Rails.application.config.google_cloud_project_id,
-            partition_date: {
-              year: 2025,
-              month: 5,
-              day: 1,
-            },
-          },
-        )
-      end
-
-      context "when a custom date is passed in" do
-        subject(:sample_query_set) { described_class.new(2025, 1) }
-
-        it "creates a sample query set for the given month" do
-          sample_query_set.create_and_import
-
-          expect(sample_query_set_service_stub).to have_received(:create_sample_query_set).with(
-            sample_query_set: {
-              display_name: "clickstream 2025-01",
-              description: "Generated from 2025-01 BigQuery clickstream data",
-            },
-            sample_query_set_id: "clickstream_2025-01",
-            parent: Rails.application.config.discovery_engine_default_location_name,
-          )
-
-          expect(sample_query_service_stub).to have_received(:import_sample_queries).with(
-            parent: response_object.name,
-            bigquery_source: {
-              dataset_id: "automated_evaluation_input",
-              table_id: "clickstream",
-              project_id: Rails.application.config.google_cloud_project_id,
-              partition_date: {
-                year: 2025,
-                month: 1,
-                day: 1,
-              },
-            },
-          )
-        end
-      end
-
-      context "when operation does not complete" do
-        let(:error_stub) { double("error", message: "An error message") }
-        let(:operation_object) { double("operation", wait_until_done!: true, error?: true, error: error_stub) }
-
-        it "raises an error" do
-          expect { sample_query_set.create_and_import }.to raise_error("An error message")
-        end
+      it "raises an error" do
+        expect { sample_query_set.create_and_import }.to raise_error("An error message")
       end
     end
   end


### PR DESCRIPTION
This adds a new `MonthInterval` class that represents the time span of
one calendar month that we want to create sample query sets for (for
example, July 2025).

This is a better representation than a "standard" Ruby date object, as it purely refers to a given month and year. It also offers a convenient factory method to get a previous month's interval.

We then refactor `SampleQuerySet` and the quality Rake tasks to use the new `MonthInterval` domain class instead of handling their own date logic.

In particular, this allows us to remove a lot of the logic and testing from `SampleQuerySet` around date logic.
