### PR TITLE
Make `SampleQuerySet` table ID configurable

### DIFF
--- a/app/services/discovery_engine/quality/sample_query_set.rb
+++ b/app/services/discovery_engine/quality/sample_query_set.rb
@@ -2,9 +2,9 @@ module DiscoveryEngine
   module Quality
     class SampleQuerySet
       BIGQUERY_DATASET_ID = "automated_evaluation_input".freeze
-      BIGQUERY_TABLE_ID = "clickstream".freeze
 
-      def initialize(month_interval)
+      def initialize(table_id, month_interval)
+        @table_id = table_id
         @month_interval = month_interval
       end
 
@@ -14,12 +14,12 @@ module DiscoveryEngine
       end
 
       def id
-        "#{BIGQUERY_TABLE_ID}_#{month_interval}"
+        "#{table_id}_#{month_interval}"
       end
 
     private
 
-      attr_reader :set, :month_interval
+      attr_reader :set, :table_id, :month_interval
 
       def create
         @set = DiscoveryEngine::Clients
@@ -41,7 +41,7 @@ module DiscoveryEngine
             parent: set.name,
             bigquery_source: {
               dataset_id: BIGQUERY_DATASET_ID,
-              table_id: BIGQUERY_TABLE_ID,
+              table_id:,
               project_id: Rails.application.config.google_cloud_project_id,
               partition_date: {
                 year: month_interval.year,
@@ -59,11 +59,11 @@ module DiscoveryEngine
       end
 
       def display_name
-        "#{BIGQUERY_TABLE_ID} #{month_interval}"
+        "#{table_id} #{month_interval}"
       end
 
       def description
-        "Generated from #{month_interval} BigQuery #{BIGQUERY_TABLE_ID} data"
+        "Generated from #{month_interval} BigQuery #{table_id} data"
       end
     end
   end

--- a/lib/tasks/quality.rake
+++ b/lib/tasks/quality.rake
@@ -5,7 +5,7 @@ namespace :quality do
   desc "Create a sample query set for last month's clickstream data and import from BigQuery"
   task setup_sample_query_sets: :environment do
     month_interval = DiscoveryEngine::Quality::MonthInterval.previous_month
-    DiscoveryEngine::Quality::SampleQuerySet.new(month_interval).create_and_import
+    DiscoveryEngine::Quality::SampleQuerySet.new("clickstream", month_interval).create_and_import
   end
 
   desc "Create a sample query set for clickstream data for a given month, and import from BigQuery"
@@ -16,7 +16,7 @@ namespace :quality do
     raise "arguments must be provided in YYYY MM order" if year < month
 
     month_interval = DiscoveryEngine::Quality::MonthInterval.new(year, month)
-    DiscoveryEngine::Quality::SampleQuerySet.new(month_interval).create_and_import
+    DiscoveryEngine::Quality::SampleQuerySet.new("clickstream", month_interval).create_and_import
   end
 
   desc "Create evaluation and push results to Prometheus"
@@ -26,7 +26,7 @@ namespace :quality do
       month_before_last: DiscoveryEngine::Quality::MonthInterval.previous_month(2),
     }
     sample_query_sets = month_intervals.transform_values do |month_interval|
-      DiscoveryEngine::Quality::SampleQuerySet.new(month_interval).id
+      DiscoveryEngine::Quality::SampleQuerySet.new("clickstream", month_interval).id
     end
 
     registry = Prometheus::Client.registry

--- a/spec/lib/tasks/quality_spec.rb
+++ b/spec/lib/tasks/quality_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "Quality tasks" do
 
       allow(DiscoveryEngine::Quality::SampleQuerySet)
       .to receive(:new)
-      .with(expected_month_interval)
+      .with("clickstream", expected_month_interval)
       .and_return(sample_query_set)
     end
 

--- a/spec/services/discovery_engine/quality/sample_query_set_spec.rb
+++ b/spec/services/discovery_engine/quality/sample_query_set_spec.rb
@@ -1,6 +1,7 @@
 RSpec.describe DiscoveryEngine::Quality::SampleQuerySet do
-  subject(:sample_query_set) { described_class.new(month_interval) }
+  subject(:sample_query_set) { described_class.new(table_id, month_interval) }
 
+  let(:table_id) { "clickstream" }
   let(:month_interval) { DiscoveryEngine::Quality::MonthInterval.new(2025, 1) }
 
   let(:operation_object) { double("operation", wait_until_done!: true, error?: false) }


### PR DESCRIPTION
This will allow us to create sample query sets for various different BigQuery table sources in the future.