### PR TITLE
Refactor `SampleQuerySet` name management

### DIFF
--- a/app/services/discovery_engine/quality/evaluation.rb
+++ b/app/services/discovery_engine/quality/evaluation.rb
@@ -1,9 +1,7 @@
 module DiscoveryEngine::Quality
   class Evaluation
-    attr_reader :sample_set_id
-
-    def initialize(sample_set_id)
-      @sample_set_id = sample_set_id
+    def initialize(sample_set)
+      @sample_set = sample_set
     end
 
     def fetch_quality_metrics
@@ -13,7 +11,7 @@ module DiscoveryEngine::Quality
 
   private
 
-    attr_reader :result
+    attr_reader :sample_set, :result
 
     def create
       operation = DiscoveryEngine::Clients
@@ -23,7 +21,7 @@ module DiscoveryEngine::Quality
           evaluation: {
             evaluation_spec: {
               query_set_spec: {
-                sample_query_set: sample_set_name,
+                sample_query_set: sample_set.name,
               },
               search_request: {
                 serving_config: ServingConfig.default.name,
@@ -43,10 +41,6 @@ module DiscoveryEngine::Quality
     def fetch
       Rails.logger.info("Fetching evaluations...")
       fetch_with_wait.quality_metrics.to_h
-    end
-
-    def sample_set_name
-      "#{Rails.application.config.discovery_engine_default_location_name}/sampleQuerySets/#{sample_set_id}"
     end
 
     def fetch_with_wait

--- a/app/services/discovery_engine/quality/sample_query_set.rb
+++ b/app/services/discovery_engine/quality/sample_query_set.rb
@@ -17,12 +17,16 @@ module DiscoveryEngine
         "#{BIGQUERY_TABLE_ID}_#{month_interval}"
       end
 
+      def name
+        "#{Rails.application.config.discovery_engine_default_location_name}/sampleQuerySets/#{id}"
+      end
+
     private
 
-      attr_reader :set, :month_interval
+      attr_reader :month_interval
 
       def create
-        @set = DiscoveryEngine::Clients
+        DiscoveryEngine::Clients
           .sample_query_set_service
           .create_sample_query_set(
             sample_query_set: {
@@ -38,7 +42,7 @@ module DiscoveryEngine
         operation = DiscoveryEngine::Clients
           .sample_query_service
           .import_sample_queries(
-            parent: set.name,
+            parent: name,
             bigquery_source: {
               dataset_id: BIGQUERY_DATASET_ID,
               table_id: BIGQUERY_TABLE_ID,
@@ -55,7 +59,7 @@ module DiscoveryEngine
 
         raise operation.error.message if operation.error?
 
-        Rails.logger.info("Successfully imported sample queries into: #{set.name}")
+        Rails.logger.info("Successfully imported sample queries into: #{name}")
       end
 
       def display_name

--- a/lib/tasks/quality.rake
+++ b/lib/tasks/quality.rake
@@ -26,14 +26,14 @@ namespace :quality do
       month_before_last: DiscoveryEngine::Quality::MonthInterval.previous_month(2),
     }
     sample_query_sets = month_intervals.transform_values do |month_interval|
-      DiscoveryEngine::Quality::SampleQuerySet.new(month_interval).id
+      DiscoveryEngine::Quality::SampleQuerySet.new(month_interval)
     end
 
     registry = Prometheus::Client.registry
     metric_evaluation = Metrics::Evaluation.new(registry)
 
-    sample_query_sets.each do |month_label, id|
-      e = DiscoveryEngine::Quality::Evaluation.new(id).fetch_quality_metrics
+    sample_query_sets.each do |month_label, set|
+      e = DiscoveryEngine::Quality::Evaluation.new(set).fetch_quality_metrics
 
       Rails.logger.info(e)
 

--- a/spec/lib/tasks/quality_spec.rb
+++ b/spec/lib/tasks/quality_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe "Quality tasks" do
-  describe "setup_sample_query_sets" do
-    let(:sample_query_set) { instance_double(DiscoveryEngine::Quality::SampleQuerySet) }
+  let(:sample_query_set) { instance_double(DiscoveryEngine::Quality::SampleQuerySet) }
 
+  describe "setup_sample_query_sets" do
     before do
       Rake::Task["quality:setup_sample_query_sets"].reenable
 
@@ -19,7 +19,6 @@ RSpec.describe "Quality tasks" do
   end
 
   describe "setup_sample_query_set" do
-    let(:sample_query_set) { instance_double(DiscoveryEngine::Quality::SampleQuerySet) }
     let(:expected_month_interval) { DiscoveryEngine::Quality::MonthInterval.new(2025, 1) }
 
     before do
@@ -49,18 +48,23 @@ RSpec.describe "Quality tasks" do
     let(:registry) { double("registry", gauge: nil) }
     let(:push_client) { double("push_client", add: nil) }
     let(:metric_evaluation) { instance_double(Metrics::Evaluation) }
+    let(:sample_query_set_last_month) { instance_double(DiscoveryEngine::Quality::SampleQuerySet) }
 
     before do
       Rake::Task["quality:report_quality_metrics"].reenable
 
+      allow(DiscoveryEngine::Quality::SampleQuerySet)
+      .to receive(:new)
+      .and_return(sample_query_set, sample_query_set_last_month)
+
       allow(DiscoveryEngine::Quality::Evaluation)
         .to receive(:new)
-        .with("clickstream_2025-10")
+        .with(sample_query_set)
         .and_return(evaluation)
 
       allow(DiscoveryEngine::Quality::Evaluation)
         .to receive(:new)
-        .with("clickstream_2025-09")
+        .with(sample_query_set_last_month)
         .and_return(evaluation)
 
       allow(Prometheus::Client)

--- a/spec/services/discovery_engine/quality/evaluation_spec.rb
+++ b/spec/services/discovery_engine/quality/evaluation_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe DiscoveryEngine::Quality::Evaluation do
-  let(:sample_set_id) { "clickstream_01_02" }
-  let(:evaluation) { described_class.new(sample_set_id) }
+  let(:sample_set) { instance_double(DiscoveryEngine::Quality::SampleQuerySet, name: "/set") }
+  let(:evaluation) { described_class.new(sample_set) }
 
   describe "#fetch" do
     let(:quality_metrics) { double("quality_metrics", to_h: "some output") }
@@ -39,7 +39,7 @@ RSpec.describe DiscoveryEngine::Quality::Evaluation do
           evaluation: {
             evaluation_spec: {
               query_set_spec: {
-                sample_query_set: "#{Rails.application.config.discovery_engine_default_location_name}/sampleQuerySets/#{sample_set_id}",
+                sample_query_set: "/set",
               },
               search_request: {
                 serving_config: ServingConfig.default.name,

--- a/spec/services/discovery_engine/quality/sample_query_set_spec.rb
+++ b/spec/services/discovery_engine/quality/sample_query_set_spec.rb
@@ -4,8 +4,7 @@ RSpec.describe DiscoveryEngine::Quality::SampleQuerySet do
   let(:month_interval) { DiscoveryEngine::Quality::MonthInterval.new(2025, 1) }
 
   let(:operation_object) { double("operation", wait_until_done!: true, error?: false) }
-  let(:response_object) { double("response", name: "/sample_query_set/1") }
-  let(:sample_query_set_service_stub) { double("sample_query_set_service", create_sample_query_set: response_object) }
+  let(:sample_query_set_service_stub) { double("sample_query_set_service", create_sample_query_set: nil) }
   let(:sample_query_service_stub) { double("sample_query_service", import_sample_queries: operation_object) }
 
   before do
@@ -26,7 +25,7 @@ RSpec.describe DiscoveryEngine::Quality::SampleQuerySet do
       )
 
       expect(sample_query_service_stub).to have_received(:import_sample_queries).with(
-        parent: response_object.name,
+        parent: "[location]/sampleQuerySets/clickstream_2025-01",
         bigquery_source: {
           dataset_id: "automated_evaluation_input",
           table_id: "clickstream",
@@ -53,6 +52,12 @@ RSpec.describe DiscoveryEngine::Quality::SampleQuerySet do
   describe "#id" do
     it "returns the sample query set ID based on the month interval" do
       expect(sample_query_set.id).to eq("clickstream_2025-01")
+    end
+  end
+
+  describe "#name" do
+    it "returns the fully qualified GCP name of the sample query set" do
+      expect(sample_query_set.name).to eq("[location]/sampleQuerySets/clickstream_2025-01")
     end
   end
 end


### PR DESCRIPTION
The name of a sample query set should be the responsibility of the sample query set, not the evaluation. This also allows us to stop keeping track of a response value when creating a sample query set.