### PR TITLE
Refactor Evaluations, and add support for Binary datasets

### DIFF
--- a/app/services/discovery_engine/quality/evaluations.rb
+++ b/app/services/discovery_engine/quality/evaluations.rb
@@ -1,0 +1,36 @@
+module DiscoveryEngine::Quality
+  class Evaluations
+    def initialize(month_label, metric_collector)
+      @month_label = month_label
+      @metric_collector = metric_collector
+    end
+
+    attr_reader :metric_collector
+
+    def collect_all_quality_metrics
+      all_sample_query_sets.each do |set|
+        e = DiscoveryEngine::Quality::Evaluation.new(set).fetch_quality_metrics
+        Rails.logger.info(e)
+        metric_collector.record_evaluations(e, month_label)
+      end
+    end
+
+  private
+
+    attr_reader :month_label
+
+    def month_interval
+      case month_label
+
+      when :last_month
+        DiscoveryEngine::Quality::MonthInterval.previous_month
+      when :month_before_last
+        DiscoveryEngine::Quality::MonthInterval.previous_month(2)
+      end
+    end
+
+    def all_sample_query_sets
+      DiscoveryEngine::Quality::SampleQuerySets.new(month_interval).all
+    end
+  end
+end

--- a/app/services/discovery_engine/quality/evaluations.rb
+++ b/app/services/discovery_engine/quality/evaluations.rb
@@ -1,36 +1,29 @@
 module DiscoveryEngine::Quality
   class Evaluations
-    def initialize(month_label, metric_collector)
-      @month_label = month_label
+    MONTH_LABELS = %i[last_month month_before_last].freeze
+
+    def initialize(metric_collector)
       @metric_collector = metric_collector
     end
 
+    def collect_all_quality_metrics
+      MONTH_LABELS.each { |month_label| collect_quality_metrics(month_label) }
+    end
+
+  private
+
     attr_reader :metric_collector
 
-    def collect_all_quality_metrics
-      all_sample_query_sets.each do |set|
+    def collect_quality_metrics(month_label)
+      all_sample_query_sets(month_label).each do |set|
         e = DiscoveryEngine::Quality::Evaluation.new(set).fetch_quality_metrics
         Rails.logger.info(e)
         metric_collector.record_evaluations(e, month_label)
       end
     end
 
-  private
-
-    attr_reader :month_label
-
-    def month_interval
-      case month_label
-
-      when :last_month
-        DiscoveryEngine::Quality::MonthInterval.previous_month
-      when :month_before_last
-        DiscoveryEngine::Quality::MonthInterval.previous_month(2)
-      end
-    end
-
-    def all_sample_query_sets
-      DiscoveryEngine::Quality::SampleQuerySets.new(month_interval).all
+    def all_sample_query_sets(month_label)
+      DiscoveryEngine::Quality::SampleQuerySets.new(month_label).all
     end
   end
 end

--- a/app/services/discovery_engine/quality/sample_query_set.rb
+++ b/app/services/discovery_engine/quality/sample_query_set.rb
@@ -2,10 +2,10 @@ module DiscoveryEngine
   module Quality
     class SampleQuerySet
       BIGQUERY_DATASET_ID = "automated_evaluation_input".freeze
-      BIGQUERY_TABLE_ID = "clickstream".freeze
 
-      def initialize(month_interval)
+      def initialize(month_interval, table_id)
         @month_interval = month_interval
+        @table_id = table_id
       end
 
       def create_and_import
@@ -19,7 +19,7 @@ module DiscoveryEngine
 
     private
 
-      attr_reader :month_interval
+      attr_reader :month_interval, :table_id
 
       def create
         DiscoveryEngine::Clients
@@ -41,7 +41,7 @@ module DiscoveryEngine
             parent: name,
             bigquery_source: {
               dataset_id: BIGQUERY_DATASET_ID,
-              table_id: BIGQUERY_TABLE_ID,
+              table_id:,
               project_id: Rails.application.config.google_cloud_project_id,
               partition_date: {
                 year: month_interval.year,
@@ -59,11 +59,11 @@ module DiscoveryEngine
       end
 
       def display_name
-        "#{BIGQUERY_TABLE_ID} #{month_interval}"
+        "#{table_id} #{month_interval}"
       end
 
       def description
-        "Generated from #{month_interval} BigQuery #{BIGQUERY_TABLE_ID} data"
+        "Generated from #{month_interval} BigQuery #{table_id} data"
       end
 
       def id

--- a/app/services/discovery_engine/quality/sample_query_sets.rb
+++ b/app/services/discovery_engine/quality/sample_query_sets.rb
@@ -14,6 +14,10 @@ module DiscoveryEngine
           SampleQuerySet.new(month_interval, table_id)
         end
       end
+
+      def create_and_import_all
+        all.each(&:create_and_import)
+      end
     end
   end
 end

--- a/app/services/discovery_engine/quality/sample_query_sets.rb
+++ b/app/services/discovery_engine/quality/sample_query_sets.rb
@@ -1,7 +1,7 @@
 module DiscoveryEngine
   module Quality
     class SampleQuerySets
-      BIGQUERY_TABLE_IDS = %w[clickstream].freeze
+      BIGQUERY_TABLE_IDS = %w[clickstream binary].freeze
 
       attr_reader :month_label
 

--- a/app/services/discovery_engine/quality/sample_query_sets.rb
+++ b/app/services/discovery_engine/quality/sample_query_sets.rb
@@ -3,15 +3,15 @@ module DiscoveryEngine
     class SampleQuerySets
       BIGQUERY_TABLE_IDS = %w[clickstream].freeze
 
-      attr_reader :month_interval
+      attr_reader :month_label
 
-      def initialize(month_interval)
-        @month_interval = month_interval
+      def initialize(month_label)
+        @month_label = month_label
       end
 
       def all
         @all ||= BIGQUERY_TABLE_IDS.map do |table_id|
-          SampleQuerySet.new(month_interval, table_id)
+          SampleQuerySet.new(table_id:, month_label:)
         end
       end
 

--- a/app/services/discovery_engine/quality/sample_query_sets.rb
+++ b/app/services/discovery_engine/quality/sample_query_sets.rb
@@ -1,0 +1,19 @@
+module DiscoveryEngine
+  module Quality
+    class SampleQuerySets
+      BIGQUERY_TABLE_IDS = %w[clickstream].freeze
+
+      attr_reader :month_interval
+
+      def initialize(month_interval)
+        @month_interval = month_interval
+      end
+
+      def all
+        @all ||= BIGQUERY_TABLE_IDS.map do |table_id|
+          SampleQuerySet.new(month_interval, table_id)
+        end
+      end
+    end
+  end
+end

--- a/lib/tasks/quality.rake
+++ b/lib/tasks/quality.rake
@@ -7,14 +7,17 @@ namespace :quality do
     DiscoveryEngine::Quality::SampleQuerySets.new(:last_month).create_and_import_all
   end
 
-  desc "Create a sample query set for clickstream data for a given month, and import from BigQuery"
-  task :setup_sample_query_set, %i[year month] => :environment do |_, args|
+  desc "Create a sample query set for a given month, and import from BigQuery"
+  task :setup_sample_query_set, %i[year month table_id] => :environment do |_, args|
     year = args[:year]&.to_i
     month = args[:month]&.to_i
+    table_id = args[:table_id]
+
     raise "year and month are required arguments" unless year.positive? && month.positive?
+    raise "table id is a required argument" if table_id.blank?
     raise "arguments must be provided in YYYY MM order" if year < month
 
-    DiscoveryEngine::Quality::SampleQuerySet.new(month:, year:, table_id: "clickstream").create_and_import
+    DiscoveryEngine::Quality::SampleQuerySet.new(month:, year:, table_id:).create_and_import
   end
 
   desc "Create evaluation and push results to Prometheus"

--- a/lib/tasks/quality.rake
+++ b/lib/tasks/quality.rake
@@ -5,8 +5,7 @@ namespace :quality do
   desc "Create a sample query set for last month's clickstream data and import from BigQuery"
   task setup_sample_query_sets: :environment do
     month_interval = DiscoveryEngine::Quality::MonthInterval.previous_month
-    array_of_sets = DiscoveryEngine::Quality::SampleQuerySets.new(month_interval).all
-    array_of_sets.each(&:create_and_import)
+    DiscoveryEngine::Quality::SampleQuerySets.new(month_interval).create_and_import_all
   end
 
   desc "Create a sample query set for clickstream data for a given month, and import from BigQuery"

--- a/lib/tasks/quality.rake
+++ b/lib/tasks/quality.rake
@@ -4,8 +4,7 @@ require "prometheus/client/push"
 namespace :quality do
   desc "Create a sample query set for last month's clickstream data and import from BigQuery"
   task setup_sample_query_sets: :environment do
-    month_interval = DiscoveryEngine::Quality::MonthInterval.previous_month
-    DiscoveryEngine::Quality::SampleQuerySets.new(month_interval).create_and_import_all
+    DiscoveryEngine::Quality::SampleQuerySets.new(:last_month).create_and_import_all
   end
 
   desc "Create a sample query set for clickstream data for a given month, and import from BigQuery"
@@ -15,8 +14,7 @@ namespace :quality do
     raise "year and month are required arguments" unless year.positive? && month.positive?
     raise "arguments must be provided in YYYY MM order" if year < month
 
-    month_interval = DiscoveryEngine::Quality::MonthInterval.new(year, month)
-    DiscoveryEngine::Quality::SampleQuerySet.new(month_interval, "clickstream").create_and_import
+    DiscoveryEngine::Quality::SampleQuerySet.new(month:, year:, table_id: "clickstream").create_and_import
   end
 
   desc "Create evaluation and push results to Prometheus"

--- a/lib/tasks/quality.rake
+++ b/lib/tasks/quality.rake
@@ -22,11 +22,8 @@ namespace :quality do
     registry = Prometheus::Client.registry
     metric_collector = Metrics::Evaluation.new(registry)
 
-    %i[last_month month_before_last].each do |month_label|
-      DiscoveryEngine::Quality::Evaluations.new(
-        month_label, metric_collector
-      ).collect_all_quality_metrics
-    end
+    DiscoveryEngine::Quality::Evaluations.new(metric_collector)
+      .collect_all_quality_metrics
 
     Prometheus::Client::Push.new(
       job: "evaluation_report_quality_metrics",

--- a/spec/lib/tasks/quality_spec.rb
+++ b/spec/lib/tasks/quality_spec.rb
@@ -52,14 +52,9 @@ RSpec.describe "Quality tasks" do
       Rake::Task["quality:report_quality_metrics"].reenable
 
       allow(DiscoveryEngine::Quality::Evaluations)
-      .to receive(:new)
-      .with(:last_month, metric_collector)
-      .and_return(evaluations)
-
-      allow(DiscoveryEngine::Quality::Evaluations)
-      .to receive(:new)
-      .with(:month_before_last, metric_collector)
-      .and_return(evaluations)
+        .to receive(:new)
+        .with(metric_collector)
+        .and_return(evaluations)
 
       allow(Prometheus::Client)
         .to receive(:registry)
@@ -79,7 +74,7 @@ RSpec.describe "Quality tasks" do
       ClimateControl.modify PROMETHEUS_PUSHGATEWAY_URL: "https://www.something.example.org" do
         expect(evaluations)
           .to receive(:collect_all_quality_metrics)
-          .twice
+          .once
         Rake::Task["quality:report_quality_metrics"].invoke
       end
     end

--- a/spec/lib/tasks/quality_spec.rb
+++ b/spec/lib/tasks/quality_spec.rb
@@ -3,18 +3,12 @@ RSpec.describe "Quality tasks" do
   let(:sample_query_sets) { instance_double(DiscoveryEngine::Quality::SampleQuerySets) }
 
   describe "setup_sample_query_sets" do
-    around do |example|
-      Timecop.freeze(2025, 11, 1) { example.call }
-    end
-
-    let(:expected_month_interval) { DiscoveryEngine::Quality::MonthInterval.new(2025, 10) }
-
     before do
       Rake::Task["quality:setup_sample_query_sets"].reenable
 
       allow(DiscoveryEngine::Quality::SampleQuerySets)
       .to receive(:new)
-      .with(expected_month_interval)
+      .with(:last_month)
       .and_return(sample_query_sets)
 
       allow(sample_query_sets)
@@ -30,14 +24,12 @@ RSpec.describe "Quality tasks" do
   end
 
   describe "setup_sample_query_set" do
-    let(:expected_month_interval) { DiscoveryEngine::Quality::MonthInterval.new(2025, 1) }
-
     before do
       Rake::Task["quality:setup_sample_query_set"].reenable
 
       allow(DiscoveryEngine::Quality::SampleQuerySet)
       .to receive(:new)
-      .with(expected_month_interval, "clickstream")
+      .with(month: 1, year: 2025, table_id: "clickstream")
       .and_return(sample_query_set)
     end
 
@@ -50,10 +42,6 @@ RSpec.describe "Quality tasks" do
   end
 
   describe "report_quality_metrics" do
-    around do |example|
-      Timecop.freeze(2025, 11, 1) { example.call }
-    end
-
     let(:evaluations) { instance_double(DiscoveryEngine::Quality::Evaluations) }
     let(:evaluation_response) { double }
     let(:registry) { double("registry", gauge: nil) }

--- a/spec/lib/tasks/quality_spec.rb
+++ b/spec/lib/tasks/quality_spec.rb
@@ -18,13 +18,12 @@ RSpec.describe "Quality tasks" do
       .and_return(sample_query_sets)
 
       allow(sample_query_sets)
-      .to receive(:all)
-      .and_return([sample_query_set])
+      .to receive(:create_and_import_all)
     end
 
     it "creates and imports a sample set" do
-      expect(sample_query_set)
-        .to receive(:create_and_import)
+      expect(sample_query_sets)
+        .to receive(:create_and_import_all)
         .once
       Rake::Task["quality:setup_sample_query_sets"].invoke
     end

--- a/spec/lib/tasks/quality_spec.rb
+++ b/spec/lib/tasks/quality_spec.rb
@@ -37,7 +37,28 @@ RSpec.describe "Quality tasks" do
       expect(sample_query_set)
         .to receive(:create_and_import)
         .once
-      Rake::Task["quality:setup_sample_query_set"].invoke("2025", "1")
+      Rake::Task["quality:setup_sample_query_set"].invoke("2025", "1", "clickstream")
+    end
+
+    it "raises an error unless table_id is provided" do
+      message = "table id is a required argument"
+      expect {
+        Rake::Task["quality:setup_sample_query_set"].invoke("2025", "1")
+      }.to raise_error(message)
+    end
+
+    it "raises an error unless year and month are provided" do
+      message = "year and month are required arguments"
+      expect {
+        Rake::Task["quality:setup_sample_query_set"].invoke("clickstream")
+      }.to raise_error(message)
+    end
+
+    it "raises an error if year and month are not provided in YYYY MM order" do
+      message = "arguments must be provided in YYYY MM order"
+      expect {
+        Rake::Task["quality:setup_sample_query_set"].invoke("05", "2025", "clickstream")
+      }.to raise_error(message)
     end
   end
 

--- a/spec/services/discovery_engine/quality/evaluations_spec.rb
+++ b/spec/services/discovery_engine/quality/evaluations_spec.rb
@@ -1,7 +1,6 @@
 RSpec.describe DiscoveryEngine::Quality::Evaluations do
-  subject(:evaluations) { described_class.new(month_label, metric_collector) }
+  subject(:evaluations) { described_class.new(metric_collector) }
 
-  let(:month_label) { :last_month }
   let(:metric_collector) { double("metric_collector") }
   let(:evaluation) { double("evaluation") }
   let(:evaluation_response) { "amything" }
@@ -20,7 +19,11 @@ RSpec.describe DiscoveryEngine::Quality::Evaluations do
 
     allow(metric_collector)
       .to receive(:record_evaluations)
-      .with(evaluation_response, month_label)
+      .with(evaluation_response, :last_month)
+
+    allow(metric_collector)
+      .to receive(:record_evaluations)
+      .with(evaluation_response, :month_before_last)
 
     allow(DiscoveryEngine::Quality::SampleQuerySets)
       .to receive(:new)
@@ -29,7 +32,7 @@ RSpec.describe DiscoveryEngine::Quality::Evaluations do
 
     allow(sample_query_sets)
       .to receive(:all)
-      .and_return([sample_query_set, sample_query_set])
+      .and_return([sample_query_set])
   end
 
   describe "#collect_all_quality_metrics" do

--- a/spec/services/discovery_engine/quality/evaluations_spec.rb
+++ b/spec/services/discovery_engine/quality/evaluations_spec.rb
@@ -1,0 +1,44 @@
+RSpec.describe DiscoveryEngine::Quality::Evaluations do
+  subject(:evaluations) { described_class.new(month_label, metric_collector) }
+
+  let(:month_label) { :last_month }
+  let(:metric_collector) { double("metric_collector") }
+  let(:evaluation) { double("evaluation") }
+  let(:evaluation_response) { "amything" }
+  let(:sample_query_sets) { double("sample_query_sets") }
+  let(:sample_query_set) { double("sample_query_set") }
+
+  before do
+    allow(DiscoveryEngine::Quality::Evaluation)
+      .to receive(:new)
+      .with(sample_query_set)
+      .and_return(evaluation)
+
+    allow(evaluation)
+      .to receive(:fetch_quality_metrics)
+      .and_return(evaluation_response)
+
+    allow(metric_collector)
+      .to receive(:record_evaluations)
+      .with(evaluation_response, month_label)
+
+    allow(DiscoveryEngine::Quality::SampleQuerySets)
+      .to receive(:new)
+      .with(anything)
+      .and_return(sample_query_sets)
+
+    allow(sample_query_sets)
+      .to receive(:all)
+      .and_return([sample_query_set, sample_query_set])
+  end
+
+  describe "#collect_all_quality_metrics" do
+    it "sends #fetch_quality_metrics to the Evaluation class for all sample query sets" do
+      evaluations.collect_all_quality_metrics
+
+      expect(evaluation)
+        .to have_received(:fetch_quality_metrics)
+        .twice
+    end
+  end
+end

--- a/spec/services/discovery_engine/quality/sample_query_set_spec.rb
+++ b/spec/services/discovery_engine/quality/sample_query_set_spec.rb
@@ -1,58 +1,102 @@
 RSpec.describe DiscoveryEngine::Quality::SampleQuerySet do
-  subject(:sample_query_set) { described_class.new(month_interval, table_id) }
-
-  let(:month_interval) { DiscoveryEngine::Quality::MonthInterval.new(2025, 1) }
-
-  let(:operation_object) { double("operation", wait_until_done!: true, error?: false) }
-  let(:sample_query_set_service_stub) { double("sample_query_set_service", create_sample_query_set: nil) }
-  let(:sample_query_service_stub) { double("sample_query_service", import_sample_queries: operation_object) }
-  let(:table_id) { "clickstream" }
+  around do |example|
+    Timecop.freeze(2025, 11, 1) { example.call }
+  end
 
   before do
     allow(DiscoveryEngine::Clients).to receive_messages(sample_query_set_service: sample_query_set_service_stub, sample_query_service: sample_query_service_stub)
   end
 
+  let(:sample_query_set_service_stub) { double("sample_query_set_service", create_sample_query_set: nil) }
+  let(:sample_query_service_stub) { double("sample_query_service", import_sample_queries: operation_object) }
+  let(:operation_object) { double("operation", wait_until_done!: true, error?: false) }
+  let(:table_id) { "clickstream" }
+
   describe "#create_and_import" do
-    it "creates a sample query set for the given month interval" do
-      sample_query_set.create_and_import
+    context "when the month label ':last_month' is provided" do
+      subject(:sample_query_set) { described_class.new(month_label:, table_id:) }
 
-      expect(sample_query_set_service_stub).to have_received(:create_sample_query_set).with(
-        sample_query_set: {
-          display_name: "clickstream 2025-01",
-          description: "Generated from 2025-01 BigQuery clickstream data",
-        },
-        sample_query_set_id: "clickstream_2025-01",
-        parent: Rails.application.config.discovery_engine_default_location_name,
-      )
+      let(:month_label) { :last_month }
 
-      expect(sample_query_service_stub).to have_received(:import_sample_queries).with(
-        parent: "[location]/sampleQuerySets/clickstream_2025-01",
-        bigquery_source: {
-          dataset_id: "automated_evaluation_input",
-          table_id: "clickstream",
-          project_id: Rails.application.config.google_cloud_project_id,
-          partition_date: {
-            year: 2025,
-            month: 1,
-            day: 1,
+      it "creates a sample query set for last month" do
+        sample_query_set.create_and_import
+
+        expect(sample_query_set_service_stub).to have_received(:create_sample_query_set).with(
+          sample_query_set: {
+            display_name: "clickstream 2025-10",
+            description: "Generated from 2025-10 BigQuery clickstream data",
           },
-        },
-      )
+          sample_query_set_id: "clickstream_2025-10",
+          parent: Rails.application.config.discovery_engine_default_location_name,
+        )
+
+        expect(sample_query_service_stub).to have_received(:import_sample_queries).with(
+          parent: "[location]/sampleQuerySets/clickstream_2025-10",
+          bigquery_source: {
+            dataset_id: "automated_evaluation_input",
+            table_id: "clickstream",
+            project_id: Rails.application.config.google_cloud_project_id,
+            partition_date: {
+              year: 2025,
+              month: 10,
+              day: 1,
+            },
+          },
+        )
+      end
+
+      context "when operation does not complete" do
+        let(:error_stub) { double("error", message: "An error message") }
+        let(:operation_object) { double("operation", wait_until_done!: true, error?: true, error: error_stub) }
+
+        it "raises an error" do
+          expect { sample_query_set.create_and_import }.to raise_error("An error message")
+        end
+      end
     end
 
-    context "when operation does not complete" do
-      let(:error_stub) { double("error", message: "An error message") }
-      let(:operation_object) { double("operation", wait_until_done!: true, error?: true, error: error_stub) }
+    context "when a year and month are provided" do
+      subject(:sample_query_set) { described_class.new(month:, year:, table_id:) }
 
-      it "raises an error" do
-        expect { sample_query_set.create_and_import }.to raise_error("An error message")
+      let(:year) { 2025 }
+      let(:month) { 9 }
+
+      it "creates a sample query set for the year and month provided" do
+        sample_query_set.create_and_import
+
+        expect(sample_query_set_service_stub).to have_received(:create_sample_query_set).with(
+          sample_query_set: {
+            display_name: "clickstream 2025-09",
+            description: "Generated from 2025-09 BigQuery clickstream data",
+          },
+          sample_query_set_id: "clickstream_2025-09",
+          parent: Rails.application.config.discovery_engine_default_location_name,
+        )
+
+        expect(sample_query_service_stub).to have_received(:import_sample_queries).with(
+          parent: "[location]/sampleQuerySets/clickstream_2025-09",
+          bigquery_source: {
+            dataset_id: "automated_evaluation_input",
+            table_id: "clickstream",
+            project_id: Rails.application.config.google_cloud_project_id,
+            partition_date: {
+              year: 2025,
+              month: 9,
+              day: 1,
+            },
+          },
+        )
       end
     end
   end
 
   describe "#name" do
+    subject(:sample_query_set) { described_class.new(month_label:, table_id:) }
+
+    let(:month_label) { :last_month }
+
     it "returns the fully qualified GCP name of the sample query set" do
-      expect(sample_query_set.name).to eq("[location]/sampleQuerySets/clickstream_2025-01")
+      expect(sample_query_set.name).to eq("[location]/sampleQuerySets/clickstream_2025-10")
     end
   end
 end

--- a/spec/services/discovery_engine/quality/sample_query_set_spec.rb
+++ b/spec/services/discovery_engine/quality/sample_query_set_spec.rb
@@ -1,11 +1,12 @@
 RSpec.describe DiscoveryEngine::Quality::SampleQuerySet do
-  subject(:sample_query_set) { described_class.new(month_interval) }
+  subject(:sample_query_set) { described_class.new(month_interval, table_id) }
 
   let(:month_interval) { DiscoveryEngine::Quality::MonthInterval.new(2025, 1) }
 
   let(:operation_object) { double("operation", wait_until_done!: true, error?: false) }
   let(:sample_query_set_service_stub) { double("sample_query_set_service", create_sample_query_set: nil) }
   let(:sample_query_service_stub) { double("sample_query_service", import_sample_queries: operation_object) }
+  let(:table_id) { "clickstream" }
 
   before do
     allow(DiscoveryEngine::Clients).to receive_messages(sample_query_set_service: sample_query_set_service_stub, sample_query_service: sample_query_service_stub)

--- a/spec/services/discovery_engine/quality/sample_query_sets_spec.rb
+++ b/spec/services/discovery_engine/quality/sample_query_sets_spec.rb
@@ -1,0 +1,19 @@
+RSpec.describe DiscoveryEngine::Quality::SampleQuerySets do
+  subject(:sample_query_sets) { described_class.new(month_interval) }
+
+  let(:month_interval) { DiscoveryEngine::Quality::MonthInterval.new(2025, 1) }
+
+  describe "#all" do
+    it "returns SampleQuerySet objects" do
+      expect(sample_query_sets.all.count).to eq(1)
+    end
+
+    it "creates a SampleQuerySet object for each table name" do
+      expect(DiscoveryEngine::Quality::SampleQuerySet)
+        .to receive(:new)
+        .with(month_interval, "clickstream")
+
+      sample_query_sets.all
+    end
+  end
+end

--- a/spec/services/discovery_engine/quality/sample_query_sets_spec.rb
+++ b/spec/services/discovery_engine/quality/sample_query_sets_spec.rb
@@ -1,11 +1,12 @@
 RSpec.describe DiscoveryEngine::Quality::SampleQuerySets do
   subject(:sample_query_sets) { described_class.new(:last_month) }
+
   let(:sample_query_set) { instance_double(DiscoveryEngine::Quality::SampleQuerySet) }
   let(:month_label) { :last_month }
 
   describe "#all" do
     it "returns SampleQuerySet objects" do
-      expect(sample_query_sets.all.count).to eq(1)
+      expect(sample_query_sets.all.count).to eq(2)
     end
 
     it "creates a SampleQuerySet object for each table name" do
@@ -13,17 +14,31 @@ RSpec.describe DiscoveryEngine::Quality::SampleQuerySets do
         .to receive(:new)
         .with(table_id: "clickstream", month_label:)
 
+      expect(DiscoveryEngine::Quality::SampleQuerySet)
+        .to receive(:new)
+        .with(table_id: "binary", month_label:)
+
       sample_query_sets.all
     end
   end
 
   describe "#create_and_import_all" do
-    it "calls create_and_import on each SampleQuerySet" do
-      allow(DiscoveryEngine::Quality::SampleQuerySet)
-      .to receive(:new)
-      .and_return(sample_query_set)
+    let(:sample_query_set_clickstream) { instance_double(DiscoveryEngine::Quality::SampleQuerySet) }
+    let(:sample_query_set_binary) { instance_double(DiscoveryEngine::Quality::SampleQuerySet) }
 
-      expect([sample_query_set]).to all(receive(:create_and_import))
+    it "calls create_and_import on each SampleQuerySet instance" do
+      allow(DiscoveryEngine::Quality::SampleQuerySet)
+        .to receive(:new)
+        .with(table_id: "clickstream", month_label: month_label)
+        .and_return(sample_query_set_clickstream)
+
+      allow(DiscoveryEngine::Quality::SampleQuerySet)
+        .to receive(:new)
+        .with(table_id: "binary", month_label: month_label)
+        .and_return(sample_query_set_binary)
+
+      expect(sample_query_set_clickstream).to receive(:create_and_import)
+      expect(sample_query_set_binary).to receive(:create_and_import)
 
       sample_query_sets.create_and_import_all
     end

--- a/spec/services/discovery_engine/quality/sample_query_sets_spec.rb
+++ b/spec/services/discovery_engine/quality/sample_query_sets_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe DiscoveryEngine::Quality::SampleQuerySets do
-  subject(:sample_query_sets) { described_class.new(month_interval) }
+  subject(:sample_query_sets) { described_class.new(:last_month) }
   let(:sample_query_set) { instance_double(DiscoveryEngine::Quality::SampleQuerySet) }
-  let(:month_interval) { DiscoveryEngine::Quality::MonthInterval.new(2025, 1) }
+  let(:month_label) { :last_month }
 
   describe "#all" do
     it "returns SampleQuerySet objects" do
@@ -11,7 +11,7 @@ RSpec.describe DiscoveryEngine::Quality::SampleQuerySets do
     it "creates a SampleQuerySet object for each table name" do
       expect(DiscoveryEngine::Quality::SampleQuerySet)
         .to receive(:new)
-        .with(month_interval, "clickstream")
+        .with(table_id: "clickstream", month_label:)
 
       sample_query_sets.all
     end

--- a/spec/services/discovery_engine/quality/sample_query_sets_spec.rb
+++ b/spec/services/discovery_engine/quality/sample_query_sets_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe DiscoveryEngine::Quality::SampleQuerySets do
   subject(:sample_query_sets) { described_class.new(month_interval) }
-
+  let(:sample_query_set) { instance_double(DiscoveryEngine::Quality::SampleQuerySet) }
   let(:month_interval) { DiscoveryEngine::Quality::MonthInterval.new(2025, 1) }
 
   describe "#all" do
@@ -14,6 +14,18 @@ RSpec.describe DiscoveryEngine::Quality::SampleQuerySets do
         .with(month_interval, "clickstream")
 
       sample_query_sets.all
+    end
+  end
+
+  describe "#create_and_import_all" do
+    it "calls create_and_import on each SampleQuerySet" do
+      allow(DiscoveryEngine::Quality::SampleQuerySet)
+      .to receive(:new)
+      .and_return(sample_query_set)
+
+      expect([sample_query_set]).to all(receive(:create_and_import))
+
+      sample_query_sets.create_and_import_all
     end
   end
 end


### PR DESCRIPTION
## What
Refactor our Evaluations and SampleQuerySet logic
Add support for Binary datasets

## How

- Create two new wrapper classes, Evaluations and SampleQuerySets
- In everywhere except the SampleQuerySet class, pass in the label ( `:last_month`, or :`month_before_last` instead) of passing in a `MonthInterval` object
- Store the available month labels in the Evaluations class.  Fly in the ointment here, is that the SampleQuerySet class needs to know what the options are for its case statement. 
- Simplify rake task by moving logic into the wrapper classes

## Why
We want to start fetching metrics for the Binary datasets, and the original implementation was for clickstream dataset only.