### PR TITLE
Add error handling for failed evaluations

### DIFF
--- a/app/services/discovery_engine/quality/evaluations.rb
+++ b/app/services/discovery_engine/quality/evaluations.rb
@@ -19,6 +19,8 @@ module DiscoveryEngine::Quality
         e = DiscoveryEngine::Quality::Evaluation.new(set).fetch_quality_metrics
         Rails.logger.info(e)
         metric_collector.record_evaluations(e, month_label, set.table_id)
+      rescue Google::Cloud::AlreadyExistsError
+        GovukError.notify("No evaluation created for sample query set #{set.name}. Month label: '#{month_label}')")
       end
     end
 


### PR DESCRIPTION
Our daily [report_quality_metrics rake task](https://github.com/alphagov/govuk-helm-charts/blob/main/charts/app-config/values-production.yaml#L2982) should create 4 evaluations:

clickstream - last month and month before last
binary - last month and month before last

The DiscoveryEngine evaluations API works in two steps, first you create an evaluation, which returns an [operation object](https://cloud.google.com/agentspace/agentspace-enterprise/docs/reference/rest/v1alpha/projects.locations.evaluations/create?hl=en). And only once the operation state changes to success can we then fetch the results. The create takes a while, and we continue to poll until we get a success message. 

We recently failed to create one of the four evaluations, as GCP returned an [AlreadyExistsError](https://govuk.sentry.io/issues/6756595901/?referrer=slack&notification_uuid=c6a2d660-26ff-477b-830c-4cb2b95f2e2d&alert_rule_id=14659787&alert_type=issue).

This PR rescues the error, retries three times, and then raises in Sentry so that we know when data is missing, and have the name of both the sample query set and month label needed to recreate the evaluation via a rake task. Will be added in subsequent work.

[Trello](https://trello.com/c/iOFQl2Gy/895-add-error-handling-for-failures-to-create-evaluations)

