### PR TITLE
Best bets for JSA and ESA

### DIFF
--- a/config/best_bets.yml
+++ b/config/best_bets.yml
@@ -36,6 +36,8 @@ shared:
   "plan for change": /missions
   "eta": /eta
   "paying hmrc": /government/collections/paying-hmrc-detailed-information
+  "new style jsa": /jobseekers-allowance
+  "new style esa": /employment-support-allowance
 
 test:
   "i want to test a single best bet": /here/you/go


### PR DESCRIPTION
Boost the mainstream guides for 'new style jsa' and 'new style esa'.

https://govuk.zendesk.com/agent/tickets/6175335

[Trello](https://trello.com/c/4Mx740TM/898-zendesk-issue-best-bets-for-new-style-jsa-and-new-style-esa)