### PR TITLE
Temporarily pin versions of Discovery engine api gems 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,9 @@ updates:
     directory: /
     schedule:
       interval: daily
+    ignore:
+      - dependency-name: google-cloud-discovery_engine
+      - dependency-name: google-cloud-discovery_engine-*
   - package-ecosystem: docker
     directory: /
     schedule:

--- a/Gemfile
+++ b/Gemfile
@@ -10,8 +10,8 @@ gem "railties", RAILS_GEMS_VERSION
 gem "bootsnap", require: false
 gem "connection_pool"
 gem "csv"
-gem "google-cloud-discovery_engine"
-gem "google-cloud-discovery_engine-v1beta"
+gem "google-cloud-discovery_engine", "<= 2.2.0"
+gem "google-cloud-discovery_engine-v1beta", "<= 0.20.1"
 gem "govuk_app_config"
 gem "govuk_message_queue_consumer"
 gem "jsonpath"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -612,8 +612,8 @@ DEPENDENCIES
   connection_pool
   csv
   debug
-  google-cloud-discovery_engine
-  google-cloud-discovery_engine-v1beta
+  google-cloud-discovery_engine (<= 2.2.0)
+  google-cloud-discovery_engine-v1beta (<= 0.20.1)
   govuk_app_config
   govuk_message_queue_consumer
   govuk_test


### PR DESCRIPTION
Temporarily pin versions of discovery engine api client gems

We recently bumped [google-cloud-discovery_engine](https://github.com/alphagov/search-api-v2/pull/518) to 2.3.0

And [google-cloud-discovery_engine-v1beta](https://github.com/alphagov/search-api-v2/pull/517) to 0.21.0

This resulted in a high number of errors and a [search outage](https://docs.google.com/document/d/1K0G02cjckgr1TZ1Bt8t-Utifg0jXN2Uk_UDlw2Pa0Sk/edit?tab=t.0#heading=h.p99426yo0rbv) 

Whilst we await clarity on the cause of these issues, let's pin the versions and prevent dependabot from re-opening PR's to bump them.