### PR TITLE
SCH-1405 Log VAIS search and autocomplete request durations

### DIFF
--- a/app/services/discovery_engine/autocomplete/complete.rb
+++ b/app/services/discovery_engine/autocomplete/complete.rb
@@ -18,14 +18,20 @@ module DiscoveryEngine::Autocomplete
       # Discovery Engine returns an error on an empty query, so we need to handle it ourselves
       return [] if query.blank?
 
-      DiscoveryEngine::Clients.completion_service
-        .complete_query(complete_query_request)
-        .query_suggestions
-        .map(&:suggestion)
-    rescue Google::Cloud::DeadlineExceededError, Google::Cloud::InternalError => e
-      Rails.logger.warn("#{self.class.name}: Did not get autocomplete suggestion: '#{e.message}'")
+      begin
+        response =
+          Metrics::Exported.observe_duration(:vertex_autocomplete_request_duration) do
+            DiscoveryEngine::Clients
+              .completion_service
+              .complete_query(complete_query_request)
+          end
 
-      raise DiscoveryEngine::InternalError
+        response.query_suggestions.map(&:suggestion)
+      rescue Google::Cloud::DeadlineExceededError, Google::Cloud::InternalError => e
+        Rails.logger.warn("#{self.class.name}: Did not get autocomplete suggestion: '#{e.message}'")
+
+        raise DiscoveryEngine::InternalError
+      end
     end
 
     def complete_query_request

--- a/app/services/metrics/exported.rb
+++ b/app/services/metrics/exported.rb
@@ -25,6 +25,12 @@ module Metrics
         "total time taken for google vertex to respond to a search request (seconds)",
         buckets: [0.1, 0.5, 1, 2, 5],
       ),
+      vertex_autocomplete_request_duration: CLIENT.register(
+        :histogram,
+        "search_api_v2_vertex_autocomplete_request_duration",
+        "total time taken for google vertex to respond to an autocomplete request (seconds)",
+        buckets: [0.1, 0.5, 1, 2, 5],
+      ),
     }.freeze
 
     def self.increment_counter(counter, labels = {})

--- a/app/services/metrics/exported.rb
+++ b/app/services/metrics/exported.rb
@@ -18,6 +18,13 @@ module Metrics
         "total time taken to process an incoming message from Publishing API (seconds)",
         buckets: [0.1, 0.5, 1, 2, 5],
       ),
+      ### VAIS response duration histograms
+      vertex_search_request_duration: CLIENT.register(
+        :histogram,
+        "search_api_v2_vertex_search_request_duration",
+        "total time taken for google vertex to respond to a search request (seconds)",
+        buckets: [0.1, 0.5, 1, 2, 5],
+      ),
     }.freeze
 
     def self.increment_counter(counter, labels = {})

--- a/spec/services/discovery_engine/autocomplete/complete_spec.rb
+++ b/spec/services/discovery_engine/autocomplete/complete_spec.rb
@@ -5,6 +5,9 @@ RSpec.describe DiscoveryEngine::Autocomplete::Complete do
 
   before do
     allow(DiscoveryEngine::Clients).to receive(:completion_service).and_return(client)
+    allow(Metrics::Exported)
+      .to receive(:observe_duration)
+      .and_call_original
   end
 
   describe "#completion_result" do
@@ -26,6 +29,14 @@ RSpec.describe DiscoveryEngine::Autocomplete::Complete do
         query:,
         query_model: "user-event",
       )
+    end
+
+    it "logs the request duration" do
+      completion_result
+
+      expect(Metrics::Exported)
+        .to have_received(:observe_duration)
+        .with(:vertex_autocomplete_request_duration)
     end
 
     context "when the query is empty" do

--- a/spec/services/discovery_engine/query/search_spec.rb
+++ b/spec/services/discovery_engine/query/search_spec.rb
@@ -27,6 +27,9 @@ RSpec.describe DiscoveryEngine::Query::Search do
           consumer: "test-consumer", consumer_group: "test-group",
         ),
       )
+    allow(Metrics::Exported)
+      .to receive(:observe_duration)
+      .and_call_original
   end
 
   around do |example|
@@ -76,6 +79,12 @@ RSpec.describe DiscoveryEngine::Query::Search do
           "Louth Garden Centre",
           "Cleethorpes Garden Centre",
         ])
+      end
+
+      it "logs the request duration" do
+        expect(Metrics::Exported)
+          .to have_received(:observe_duration)
+          .with(:vertex_search_request_duration)
       end
 
       context "when start and count are specified" do


### PR DESCRIPTION
Add prometheus logging for the time it takes Google VAIS to respond to search and autocomplete requests.

[Example integration grafana panel](https://grafana.eks.integration.govuk.digital/d/govuk-search/gov-uk-search?orgId=1&from=now-30m&to=now&timezone=browser):
[
<img width="501" height="466" alt="Screenshot 2025-08-12 at 19 24 29" src="https://github.com/user-attachments/assets/fea72b50-4ea1-4843-a3df-6847aef38421" />
](url)