### PR TITLE
[SCH-1416] Don't try and send empty metrics to Prometheus

### DIFF
--- a/app/services/metrics/evaluation.rb
+++ b/app/services/metrics/evaluation.rb
@@ -34,8 +34,8 @@ module Metrics
 
     def record_evaluation(key, registry, month, dataset, evaluation_result)
       TOP_K_LEVELS.each do |k|
-        value = evaluation_result[key][:"top_#{k}"]
-        registry.set(value, labels: { top: k, month:, dataset: })
+        value = evaluation_result.dig(key, :"top_#{k}")
+        registry.set(value, labels: { top: k, month:, dataset: }) if value.present?
       end
     end
   end

--- a/spec/services/metrics/evaluation_spec.rb
+++ b/spec/services/metrics/evaluation_spec.rb
@@ -73,5 +73,17 @@ RSpec.describe Metrics::Evaluation do
 
       evaluation.record_evaluations(evaluation_response, month, table_id)
     end
+
+    context "when there are no quality metrics" do
+      let(:evaluation_response) { {} }
+
+      it "does not update prometheus" do
+        expect(recall_gauge).not_to receive(:set)
+        expect(precision_gauge).not_to receive(:set)
+        expect(ndcg_gauge).not_to receive(:set)
+
+        evaluation.record_evaluations(evaluation_response, month, table_id)
+      end
+    end
   end
 end


### PR DESCRIPTION
The evaluations API recently returned empty quality metrics due to a misconfiguration of our sample query sets. Adding a guard clause to prevent the rake task that calls this class from blowing up.

Alternatively we could send 0 if the dig returns nil, see [code](https://github.com/prometheus/client_ruby/blob/5c64546870ef306c34374a813c61188fcc1fa546/lib/prometheus/client/gauge.rb#L16C21-L16C36), but that feels unexpected. Better not to send empty metrics.

[Jira card](https://gov-uk.atlassian.net/browse/SCH-1416)
