### PR TITLE
Remove retry when google returns an error

### DIFF
--- a/app/services/discovery_engine/quality/evaluation.rb
+++ b/app/services/discovery_engine/quality/evaluation.rb
@@ -1,11 +1,7 @@
 module DiscoveryEngine::Quality
   class Evaluation
-    MAX_RETRIES_ON_ERROR = 3
-    WAIT_ON_ERROR = 3
-
     def initialize(sample_set)
       @sample_set = sample_set
-      @attempt = 1
     end
 
     def quality_metrics
@@ -45,14 +41,8 @@ module DiscoveryEngine::Quality
 
       Rails.logger.info("Successfully created evaluation: #{sample_set.display_name}")
     rescue Google::Cloud::AlreadyExistsError => e
-      if @attempt < MAX_RETRIES_ON_ERROR
-        Rails.logger.warn("Failed to create evaluation: #{sample_set.display_name} (#{e.message}). Retrying...")
-        @attempt += 1
-        Kernel.sleep(WAIT_ON_ERROR)
-        retry
-      else
-        raise e
-      end
+      Rails.logger.warn("Failed to create an evaluation of sample set #{sample_set.display_name} (#{e.message})")
+      raise e
     end
 
     def get_evaluation_with_wait

--- a/app/services/discovery_engine/quality/evaluation.rb
+++ b/app/services/discovery_engine/quality/evaluation.rb
@@ -39,7 +39,7 @@ module DiscoveryEngine::Quality
 
       @result = operation.results
 
-      Rails.logger.info("Successfully created evaluation: #{sample_set.display_name}")
+      Rails.logger.info("Successfully created an evaluation of sample set #{sample_set.display_name}")
     rescue Google::Cloud::AlreadyExistsError => e
       Rails.logger.warn("Failed to create an evaluation of sample set #{sample_set.display_name} (#{e.message})")
       raise e

--- a/spec/services/discovery_engine/quality/evaluation_spec.rb
+++ b/spec/services/discovery_engine/quality/evaluation_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe DiscoveryEngine::Quality::Evaluation do
         )
 
         expect(Rails.logger).to have_received(:info)
-          .with("Successfully created evaluation: clickstream 2025-10")
+          .with("Successfully created an evaluation of sample set clickstream 2025-10")
       end
 
       it "fetches quality metrics" do

--- a/spec/services/discovery_engine/quality/evaluation_spec.rb
+++ b/spec/services/discovery_engine/quality/evaluation_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe DiscoveryEngine::Quality::Evaluation do
       end
     end
 
-    context "when GCP returns an error" do
+    context "when GCP returns an AlreadyExistsError" do
       let(:erroring_service) { double("evaluation") }
 
       before do
@@ -57,15 +57,15 @@ RSpec.describe DiscoveryEngine::Quality::Evaluation do
           .with(anything)
           .and_raise(Google::Cloud::AlreadyExistsError)
 
-        allow(Kernel).to receive(:sleep).with(3).and_return(true)
-        allow(Rails.logger).to receive(:warn)
+        allow(Rails.logger)
+          .to receive(:warn)
       end
 
-      it "retries 3 times and then raises an error" do
+      it "logs then raises the error" do
         expect { evaluation.quality_metrics }.to raise_error(Google::Cloud::AlreadyExistsError)
-        expect(erroring_service).to have_received(:create_evaluation).exactly(3).times
-        expect(Rails.logger).to have_received(:warn).exactly(2).times
-          .with("Failed to create evaluation: clickstream 2025-10 (Google::Cloud::AlreadyExistsError). Retrying...")
+
+        expect(Rails.logger).to have_received(:warn)
+          .with("Failed to create an evaluation of sample set clickstream 2025-10 (Google::Cloud::AlreadyExistsError)")
       end
     end
 


### PR DESCRIPTION
Remove retry when google returns an error
The retry was added in https://github.com/alphagov/search-api-v2/pull/515

Vertex allows only one evaluation to be run at a time per project. This code
is retrying a creation request when google is already actively working on a
different one.

Evaluations can take up to an hour to complete, so retrying after 3 seconds is just
using up our daily quota of evaluation requests and is highly unlikely to succeed.

We could set the retry period to 30 minutes, but that feels like a bad plan as
then we're queuing requests on a bit of an opaque schedule.

So it's probably just easier to remove the retry and let the task fail, with documentation to
explain that in this situation the task should be run at a later time. We could also consider
a task that polls vertex to see if there are active evaluations running.

```
{"@timestamp":"2025-09-02T12:00:02.167Z","message":"Getting ready to fetch quality metrics for binary datasets","level":"INFO","tags":["rails"]}
{"@timestamp":"2025-09-02T12:00:03.840Z","message":"Failed to create evaluation: binary 2025-08 (6:Active evaluation on project 780375417592 already exists. Please wait until evaluation finishes.. debug_error_string:{UNKNOWN:Error received from peer ipv4:74.125.193.95:443 {grpc_status:6, grpc_message:\"Active evaluation on project 780375417592 already exists. Please wait until evaluation finishes.\"}}). Retrying...","level":"WARN","tags":["rails"]}
{"@timestamp":"2025-09-02T12:00:09.321Z","message":"Failed to create evaluation: binary 2025-08 (6:Active evaluation on project 780375417592 already exists. Please wait until evaluation finishes.. debug_error_string:{UNKNOWN:Error received from peer ipv4:74.125.193.95:443 {grpc_message:\"Active evaluation on project 780375417592 already exists. Please wait until evaluation finishes.\", grpc_status:6}}). Retrying...","level":"WARN","tags":["rails"]}
{"@timestamp":"2025-09-02T12:00:13.230Z","message":"Failed to create evaluation: binary 2025-07 (6:Active evaluation on project 780375417592 already exists. Please wait until evaluation finishes.. debug_error_string:{UNKNOWN:Error received from peer ipv4:74.125.193.95:443 {grpc_message:\"Active evaluation on project 780375417592 already exists. Please wait until evaluation finishes.\", grpc_status:6}}). Retrying...","level":"WARN","tags":["rails"]}
{"@timestamp":"2025-09-02T12:00:16.713Z","message":"Failed to create evaluation: binary 2025-07 (6:Active evaluation on project 780375417592 already exists. Please wait until evaluation finishes.. debug_error_string:{UNKNOWN:Error received from peer ipv4:74.125.193.95:443 {grpc_status:6, grpc_message:\"Active evaluation on project 780375417592 already exists. Please wait until evaluation finishes.\"}}). Retrying...","level":"WARN","tags":["rails"]}
```