### PR TITLE
Evaluations: Fetch evaluations of explicit datasets 

### DIFF
--- a/app/services/discovery_engine/quality/sample_query_sets.rb
+++ b/app/services/discovery_engine/quality/sample_query_sets.rb
@@ -1,7 +1,7 @@
 module DiscoveryEngine
   module Quality
     class SampleQuerySets
-      BIGQUERY_TABLE_IDS = %w[clickstream binary].freeze
+      BIGQUERY_TABLE_IDS = %w[clickstream binary explicit].freeze
 
       attr_reader :month_label
 

--- a/spec/services/discovery_engine/quality/sample_query_sets_spec.rb
+++ b/spec/services/discovery_engine/quality/sample_query_sets_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe DiscoveryEngine::Quality::SampleQuerySets do
 
   describe "#all" do
     it "returns SampleQuerySet objects" do
-      expect(sample_query_sets.all.count).to eq(2)
+      expect(sample_query_sets.all.count).to eq(3)
     end
 
     it "creates a SampleQuerySet object for each table name" do
@@ -18,6 +18,10 @@ RSpec.describe DiscoveryEngine::Quality::SampleQuerySets do
         .to receive(:new)
         .with(table_id: "binary", month_label:)
 
+      expect(DiscoveryEngine::Quality::SampleQuerySet)
+        .to receive(:new)
+        .with(table_id: "explicit", month_label:)
+
       sample_query_sets.all
     end
   end
@@ -25,6 +29,7 @@ RSpec.describe DiscoveryEngine::Quality::SampleQuerySets do
   describe "#create_and_import_all" do
     let(:sample_query_set_clickstream) { instance_double(DiscoveryEngine::Quality::SampleQuerySet) }
     let(:sample_query_set_binary) { instance_double(DiscoveryEngine::Quality::SampleQuerySet) }
+    let(:sample_query_set_explicit) { instance_double(DiscoveryEngine::Quality::SampleQuerySet) }
 
     it "calls create_and_import_queries on each SampleQuerySet instance" do
       allow(DiscoveryEngine::Quality::SampleQuerySet)
@@ -37,8 +42,14 @@ RSpec.describe DiscoveryEngine::Quality::SampleQuerySets do
         .with(table_id: "binary", month_label: month_label)
         .and_return(sample_query_set_binary)
 
+      allow(DiscoveryEngine::Quality::SampleQuerySet)
+        .to receive(:new)
+        .with(table_id: "explicit", month_label: month_label)
+        .and_return(sample_query_set_explicit)
+
       expect(sample_query_set_clickstream).to receive(:create_and_import_queries)
       expect(sample_query_set_binary).to receive(:create_and_import_queries)
+      expect(sample_query_set_explicit).to receive(:create_and_import_queries)
 
       sample_query_sets.create_and_import_all
     end


### PR DESCRIPTION
We want to run evaluations of explicit datasets as well as clickstream and binary.

Currently we will only fetch aggregate metrics for prometheus via the existing [report_qualiy_metrics](https://github.com/alphagov/search-api-v2/blob/main/lib/tasks/quality.rake#L26) task