### PR TITLE
Add /sign-in to the unignore list

### DIFF
--- a/config/document_type_ignorelist_path_overrides.yml
+++ b/config/document_type_ignorelist_path_overrides.yml
@@ -11,6 +11,7 @@ shared:
 - /help/cookies # special_route
 - /find-local-council # special_route
 - /contact # special_route
+- /sign-in # special_route
 
 test:
 - /test_ignored_path_override


### PR DESCRIPTION
The  “Sign in to a service” route is a special_route and is therefore not indexed in the Vertex store. This commit ensures it is indexed so /sign_in can be found using search

Jira: https://gov-uk.atlassian.net/browse/SCH-1425