### PR TITLE
Handle invalid query parameters

### DIFF
--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -1,4 +1,6 @@
 class SearchesController < ApplicationController
+  rescue_from ArgumentError, with: :render_argument_error
+
   def show
     render json: DiscoveryEngine::Query::Search.new(query_params, user_agent: request.user_agent).result_set
   end
@@ -7,5 +9,9 @@ private
 
   def query_params
     params.permit!
+  end
+
+  def render_argument_error(exception)
+    render json: { "error": exception.message }, status: :unprocessable_content
   end
 end

--- a/app/services/discovery_engine/query/search.rb
+++ b/app/services/discovery_engine/query/search.rb
@@ -11,6 +11,8 @@ module DiscoveryEngine::Query
       @query_params = query_params
       @user_agent = user_agent
 
+      validate_query_params!
+
       Rails.logger.debug { "Instantiated #{self.class.name}: Query: #{discovery_engine_params}" }
     end
 
@@ -40,6 +42,10 @@ module DiscoveryEngine::Query
         Rails.logger.warn("#{self.class.name}: Did not get search results: '#{e.message}'")
         raise DiscoveryEngine::InternalError
       end
+    end
+
+    def validate_query_params!
+      raise ArgumentError, "Invalid query parameter" unless query_params.fetch(:q, "").is_a?(String)
     end
 
     def discovery_engine_params

--- a/spec/requests/search_request_spec.rb
+++ b/spec/requests/search_request_spec.rb
@@ -38,6 +38,15 @@ RSpec.describe "Making a search request" do
       )
     end
 
+    it "reports an ArgumentError" do
+      allow(DiscoveryEngine::Query::Search).to receive(:new).and_raise(ArgumentError, "invalid query parameter")
+
+      get "/search.json?q[]=foo"
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(JSON.parse(response.body)).to eq("error" => "invalid query parameter")
+    end
+
     context "when search returns a DiscoveryEngine::InternalError" do
       before do
         allow(search_service)

--- a/spec/services/discovery_engine/query/search_spec.rb
+++ b/spec/services/discovery_engine/query/search_spec.rb
@@ -2,6 +2,7 @@ RSpec.describe DiscoveryEngine::Query::Search do
   subject(:search) { described_class.new(query_params, user_agent: "test-user-agent") }
 
   let(:client) { double("SearchService::Client", search: search_return_value) }
+  let(:search_return_value) { double }
   let(:filters) { double(filter_expression: "filter-expression") }
 
   let(:query_params) { { q: "garden centres" } }
@@ -249,8 +250,6 @@ RSpec.describe DiscoveryEngine::Query::Search do
     end
 
     context "when search fails" do
-      let(:search_return_value) { double }
-
       before do
         allow(search_return_value)
           .to receive(:response)
@@ -287,6 +286,18 @@ RSpec.describe DiscoveryEngine::Query::Search do
           expect(Rails.logger).to have_received(:warn).with(
             "DiscoveryEngine::Query::Search: Did not get search results: 'Internal error'",
           )
+        end
+      end
+    end
+
+    context "when supplying invalid parameters" do
+      context "and the error is the user supplying an invalid query parameter" do
+        let(:query_params) { { q: [] } }
+
+        it "raises an ArgumentError because the query parameter is not a string" do
+          expect {
+            search
+          }.to raise_error(ArgumentError, "Invalid query parameter")
         end
       end
     end


### PR DESCRIPTION
Ensure that searching with a 'q' parameter that is not a String (e.g. an Array or a Hash) is handled gracefully. Previously, this case was unhandled and caused errors to be reported in Sentry.

Jira: https://gov-uk.atlassian.net/browse/SCH-1389