### PR TITLE
Sch 1457 evaluations add serving configuration name to the detailed metrics json

### DIFF
--- a/app/services/discovery_engine/quality/evaluation.rb
+++ b/app/services/discovery_engine/quality/evaluation.rb
@@ -13,7 +13,11 @@ module DiscoveryEngine::Quality
     # evaluation_name and api_response.name are equivalent, but calling api_response
     # ensures that we have fetched an evaluation before we ask for list_results.
     def list_evaluation_results
-      ListEvaluationResults.new(api_response.name, sample_set.display_name).formatted_json
+      ListEvaluationResults.new(
+        api_response.name,
+        sample_set.display_name,
+        serving_config,
+      ).formatted_json
     end
 
     def formatted_create_time

--- a/app/services/discovery_engine/quality/evaluation.rb
+++ b/app/services/discovery_engine/quality/evaluation.rb
@@ -30,6 +30,12 @@ module DiscoveryEngine::Quality
 
     attr_reader :evaluation_name
 
+    def serving_config
+      raise "Error: cannot provide serving config of an evaluation unless one exists" if @api_response.blank?
+
+      @api_response.evaluation_spec.search_request.serving_config
+    end
+
     def api_response
       @api_response ||= fetch_api_response
     end

--- a/app/services/discovery_engine/quality/list_evaluation_results.rb
+++ b/app/services/discovery_engine/quality/list_evaluation_results.rb
@@ -1,8 +1,9 @@
 module DiscoveryEngine::Quality
   class ListEvaluationResults
-    def initialize(evaluation_name, sample_query_set_name)
+    def initialize(evaluation_name, sample_query_set_name, serving_config)
       @evaluation_name = evaluation_name
       @sample_query_set_name = sample_query_set_name
+      @serving_config = serving_config
     end
 
     def formatted_json
@@ -10,6 +11,7 @@ module DiscoveryEngine::Quality
       parsed = JSON.parse(json)
       with_required_keys = {
         "evaluation_name" => evaluation_name,
+        "serving_configuration_name" => serving_config_display_name,
         "evaluation_results" => parsed,
       }
       with_required_keys.to_json
@@ -17,7 +19,7 @@ module DiscoveryEngine::Quality
 
   private
 
-    attr_reader :evaluation_name, :sample_query_set_name
+    attr_reader :evaluation_name, :sample_query_set_name, :serving_config
 
     def raw_api_response
       results = DiscoveryEngine::Clients
@@ -28,6 +30,10 @@ module DiscoveryEngine::Quality
         )
       Rails.logger.info("Successfully fetched detailed metrics for evaluation #{evaluation_name} of sample query set #{sample_query_set_name}")
       results
+    end
+
+    def serving_config_display_name
+      serving_config.split("/")[-1]
     end
   end
 end

--- a/spec/services/discovery_engine/quality/evaluation_spec.rb
+++ b/spec/services/discovery_engine/quality/evaluation_spec.rb
@@ -11,12 +11,21 @@ RSpec.describe DiscoveryEngine::Quality::Evaluation do
   let(:operation) { double("operation", error?: false, wait_until_done!: true, results: response) }
   let(:response) { double("response", name: "/evaluations/1") }
   let(:google_time_stamp) { double("google_time_stamp", nanos: 812_173_000, seconds: 1_753_600_645) }
+  let(:search_request) do
+    double("search_request",
+           serving_config: "projects/780375417592/locations/global/collections/default_collection/engines/govuk_global/servingConfigs/default")
+  end
+  let(:evaluation_spec) do
+    double("evaluation_spec",
+           search_request: search_request)
+  end
   let(:evaluation_success) do
     double("evaluation",
            state: :SUCCEEDED,
            quality_metrics: quality_metrics_response,
            name: "/evaluations/1",
-           create_time: google_time_stamp)
+           create_time: google_time_stamp,
+           evaluation_spec: evaluation_spec)
   end
   let(:evaluation_pending) { double("evaluation", state: :PENDING) }
 
@@ -174,7 +183,7 @@ RSpec.describe DiscoveryEngine::Quality::Evaluation do
 
       allow(DiscoveryEngine::Quality::ListEvaluationResults)
         .to receive(:new)
-        .with(anything, anything)
+        .with(anything, anything, anything)
         .and_return(list_evaluation_results)
 
       allow(list_evaluation_results)

--- a/spec/services/discovery_engine/quality/list_evaluation_results_spec.rb
+++ b/spec/services/discovery_engine/quality/list_evaluation_results_spec.rb
@@ -1,8 +1,10 @@
 RSpec.describe DiscoveryEngine::Quality::ListEvaluationResults do
-  subject(:list_results) { described_class.new(evaluation_name, sample_query_set_name) }
+  subject(:list_results) { described_class.new(evaluation_name, sample_query_set_name, serving_config) }
 
   let(:evaluation_name) { "projects/780375417592/locations/global/evaluations/2b53e0c6" }
   let(:sample_query_set_name) { "clickstream_09-2025" }
+  let(:serving_config) { "projects/780375417592/locations/global/collections/default_collection/engines/govuk_global/servingConfigs/default" }
+  let(:serving_config_display_name) { "default" }
   let(:evaluation_service) { double("evaluation_service", list_evaluation_results: raw_api_response) }
   let(:raw_api_response) { double("raw_api_resonse", to_json: response.to_json) }
   let(:response) do
@@ -65,6 +67,7 @@ RSpec.describe DiscoveryEngine::Quality::ListEvaluationResults do
     it "formats the response" do
       formatted_results = {
         "evaluation_name" => evaluation_name,
+        "serving_configuration_name" => serving_config_display_name,
         "evaluation_results" => response,
       }
       expect(list_results.formatted_json).to eq(formatted_results.to_json)


### PR DESCRIPTION
This PR adds the serving config name to the evaluation results json that get pushed to our GCP bucket, so that we will be able to easily check which serving config an evaluation has been run with in GCP.

The serving config is being read directly from the api response of GCP's "get_evaluation" method on the EvaluationService Client, because this approach is more reliable than reusing an attribute for the value that was used to create an evaluation.

Jira ticket: https://gov-uk.atlassian.net/browse/SCH-1457

See GCP REST docs on Evaluation Response: https://cloud.google.com/agentspace/docs/reference/rest/v1beta/projects.locations.evaluations#resource:-evaluation

See GCP Ruby Client docs on Evaluation:
https://cloud.google.com/ruby/docs/reference/google-cloud-discovery_engine-v1beta/latest/Google-Cloud-DiscoveryEngine-V1beta-Evaluation
