### PR TITLE
Add a 10 second wait between evaluation requests

### DIFF
--- a/app/services/discovery_engine/quality/evaluations_runner.rb
+++ b/app/services/discovery_engine/quality/evaluations_runner.rb
@@ -10,6 +10,8 @@ module DiscoveryEngine::Quality
       evaluations.each do |e|
         send_to_bucket(e)
         send_to_prometheus(e)
+        # space out our calls to the evaluations API, as it is unable to handle concurrent requests
+        Kernel.sleep(10)
       end
     end
 

--- a/spec/services/discovery_engine/quality/evaluations_runner_spec.rb
+++ b/spec/services/discovery_engine/quality/evaluations_runner_spec.rb
@@ -71,6 +71,8 @@ RSpec.describe DiscoveryEngine::Quality::EvaluationsRunner do
       .to receive(:send)
       .with(anything, anything, anything)
       .and_return(true)
+
+    allow(Kernel).to receive(:sleep).with(10).and_return(true)
   end
 
   describe "#upload_and_report_metrics" do


### PR DESCRIPTION
The evaluations API can only handle one evaluation create request at a time. Whilst an evaluation is being created, the api returns a Google::Cloud::AlreadyExistsError if another create request is received.

Our code in the Evaluation class checks that the evaluation has a state of :SUCCEEDED before a fresh evaluation request is sent. However we are still seeing this error returned from the client.

Adding a sleep of 10 seconds is a pragmatic attempt to work around this, given our limited visibility of what is causing the AlreadyExistsError to be returned.

Logs from production indicate that the error is being returned between evaluations of the same table id, eg after binary 09 and before binary 10