### PR TITLE
Add retry policy to Discovery Engine search client

### DIFF
--- a/app/services/discovery_engine/clients.rb
+++ b/app/services/discovery_engine/clients.rb
@@ -14,7 +14,14 @@ module DiscoveryEngine
 
     def search_service
       @search_service ||= Google::Cloud::DiscoveryEngine.search_service(version: :v1) do |config|
-        config.timeout = 4
+        config.timeout = 2.0
+        config.retry_policy = {
+          initial_delay: 1.0, # Seconds to wait before the first retry
+          max_delay: 2.0, # Maximum delay between retries
+          multiplier: 1.5, # Factor to increase delay by for each attempt
+          # https://grpc.io/docs/guides/status-codes/
+          retry_codes: %w[UNAVAILABLE DEADLINE_EXCEEDED INTERNAL],
+        }
       end
     end
 

--- a/spec/services/discovery_engine/clients_spec.rb
+++ b/spec/services/discovery_engine/clients_spec.rb
@@ -4,12 +4,13 @@ RSpec.describe DiscoveryEngine::Clients do
     described_class.instance_variable_set(:@search_service, nil)
   end
 
-  shared_examples "a client with timeout configured" do |service_name, timeout|
+  shared_examples "a client with custom configuration" do |service_name, timeout|
     let(:config) { double("config") }
     let(:client) { double("client") }
 
     before do
       allow(config).to receive(:timeout=)
+      allow(config).to receive(:retry_policy=)
       allow(Google::Cloud::DiscoveryEngine).to receive(service_name) do |**_kwargs, &block|
         block.call(config) if block
         client
@@ -17,25 +18,38 @@ RSpec.describe DiscoveryEngine::Clients do
     end
 
     it "initialises the client with the v1 API version" do
-      subject
+      service
       expect(Google::Cloud::DiscoveryEngine).to have_received(service_name).with(version: :v1)
     end
 
     it "configures the client with a timeout" do
-      subject
+      service
       expect(config).to have_received(:timeout=).with(timeout)
     end
   end
 
-  describe ".search_service with 3 second timeout" do
-    subject { described_class.search_service }
+  describe ".search_service with four second timeout and retry policy" do
+    let(:service) { described_class.search_service }
 
-    include_examples "a client with timeout configured", :search_service, 4
+    include_examples "a client with custom configuration", :search_service, 2
+
+    it "configures the client with a retry_policy" do
+      service
+
+      expect(config).to have_received(:retry_policy=).with(
+        {
+          initial_delay: 1.0,
+          max_delay: 2.0,
+          multiplier: 1.5,
+          retry_codes: %w[UNAVAILABLE DEADLINE_EXCEEDED INTERNAL],
+        },
+      )
+    end
   end
 
   describe ".completion_service with one second timeout" do
-    subject { described_class.completion_service }
+    let(:service) { described_class.completion_service }
 
-    include_examples "a client with timeout configured", :completion_service, 1
+    include_examples "a client with custom configuration", :completion_service, 1
   end
 end


### PR DESCRIPTION
Attempt to add a retry policy that breaks down as follows:

Assuming that the timeout is **per request** this config means:

0s - make a request (wait 2 seconds and timeout)
Wait 1s
Retry 1 of request (wait 2 seconds and timeout)
Wait 1.5s
Retry 2 of request (wait 2 seconds and timeout)
Wait 2s ( 1.5 x 1.5 is 2.25, but we have a max wait of 2 )
Retry 3 of request (wait 2 seconds and timeout)
Wait 2s
Retry 4 of request (wait 2 seconds and timeout)
Wait 2s
Retry 5 of request (wait 2 seconds and timeout)

https://docs.cloud.google.com/ruby/docs/reference/google-cloud-discovery_engine-v1/latest/Google-Cloud-DiscoveryEngine-V1-SearchService-Client-Configuration#Google__Cloud__DiscoveryEngine__V1__SearchService__Client__Configuration_retry_policy__instance_