### PR TITLE
Add dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,13 +4,22 @@ updates:
     directory: /
     schedule:
       interval: daily
+    cooldown:
+      default-days: 3
+      exclude:
+        - govuk_app_config
+        - govuk_message_queue_consumer
   - package-ecosystem: docker
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 3
     ignore:
       - dependency-name: ruby
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: daily
+    cooldown:
+      default-days: 3


### PR DESCRIPTION
Setting to 3 days as per the [suggested configuration](https://docs.publishing.service.gov.uk/manual/manage-dependencies.html#schedule-and-cooldown)

Excluding internal dependencies, as they will have their own cooldown configured.

https://gov-uk.atlassian.net/browse/SCH-2043