### PR TITLE
Pin Github actions to SHA

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -6,7 +6,7 @@ jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           show-progress: false
       - uses: alphagov/govuk-infrastructure/.github/actions/actionlint@main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,11 +51,11 @@ jobs:
       # Redis running through govuk-infrastructure action
       REDIS_URL: redis://localhost:6379
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.ref || github.ref }}
           show-progress: false
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@0cb964fd540e0a24c900370abf38a33466142735 # v1.305.0
         with:
           bundler-cache: true
       - name: Setup Redis


### PR DESCRIPTION
Pinning to SHAs which are immutable protects us from supply chain risks where existing release tags are applied to malicious code.

This is in line with our [defensive practices](https://docs.publishing.service.gov.uk/manual/manage-dependencies.html#defensive-practices) and the [gds-way instructions](https://github.com/alphagov/gds-way/blob/08f316a234a4c48e03e3b7c02dfba303cea3e704/source/standards/source-code/using-github-actions.html.md.erb#L33-L37)

Dependabot should keep these up to date, so long as the version comment is in line. I'm interested to see how these work in practice though.

[Platform Engineering do this already](https://github.com/alphagov/govuk-infrastructure/blob/a220775d1f16deea28d0f3c73ee4956439866223/.github/workflows/codeql-analysis.yml#L20), but they use Renovate.

It's not possible for us to pin our internal workflows, because they're not released in the same way.