### PR TITLE
[SCH-2054] Add metric for search_controller#show

### DIFF
--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -2,7 +2,9 @@ class SearchesController < ApplicationController
   before_action :validate_query_params, only: :show
 
   def show
-    render json: DiscoveryEngine::Query::Search.new(query_params, user_agent: request.user_agent).result_set
+    Metrics::Exported.observe_duration(:search_controller_request_duration) do
+      render json: DiscoveryEngine::Query::Search.new(query_params, user_agent: request.user_agent).result_set
+    end
   end
 
 private

--- a/app/services/metrics/exported.rb
+++ b/app/services/metrics/exported.rb
@@ -31,6 +31,12 @@ module Metrics
         "total time taken for google vertex to respond to an autocomplete request (seconds)",
         buckets: [0.1, 0.5, 1, 2, 5],
       ),
+      search_controller_request_duration: CLIENT.register(
+        :histogram,
+        "search_api_v2_search_controller_request_duration",
+        "total time taken for the show action of the search controller (seconds)",
+        buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 15, 25, 50],
+      ),
     }.freeze
 
     def self.increment_counter(counter, labels = {})

--- a/spec/requests/search_request_spec.rb
+++ b/spec/requests/search_request_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe "Making a search request" do
   let(:results) { [Result.new(content_id: "123"), Result.new(content_id: "456")] }
 
   before do
+    allow(Metrics::Exported).to receive(:observe_duration).and_call_original
     allow(DiscoveryEngine::Query::Search).to receive(:new).and_return(search_service)
   end
 
@@ -43,6 +44,14 @@ RSpec.describe "Making a search request" do
 
       expect(response).to have_http_status(:bad_request)
       expect(JSON.parse(response.body)).to eq("error" => "Invalid query parameter")
+    end
+
+    it "logs the request duration" do
+      get "/search.json"
+
+      expect(Metrics::Exported)
+        .to have_received(:observe_duration)
+        .with(:search_controller_request_duration)
     end
 
     context "when search returns a DiscoveryEngine::InternalError" do


### PR DESCRIPTION
Add bespoke metric for whole of #show method. 

Duration should equal http_request_duration that we get from [prometheus/client_ruby](https://github.com/prometheus/client_ruby/blob/main/lib/prometheus/middleware/collector.rb#L50) via [govuk_app_config](https://github.com/alphagov/govuk_app_config/blob/main/lib/govuk_app_config/govuk_prometheus_exporter.rb)

Deployed branch to `integration`, and confirmed that the new metric is coming through:
<img width="1909" height="833" alt="Screenshot 2026-04-27 at 12 12 53" src="https://github.com/user-attachments/assets/2356c1ce-e090-4468-9bbb-f958f111a4d7" />

