### PR TITLE
Ensure queues are durable

### DIFF
--- a/lib/tasks/document_sync_worker.rake
+++ b/lib/tasks/document_sync_worker.rake
@@ -9,7 +9,7 @@ namespace :document_sync_worker do
     bunny = Bunny.new
     channel = bunny.start.create_channel
     exch = Bunny::Exchange.new(channel, :topic, "published_documents")
-    channel.queue(ENV.fetch("PUBLISHED_DOCUMENTS_MESSAGE_QUEUE_NAME")).bind(exch, routing_key: "*.*")
+    channel.queue(ENV.fetch("PUBLISHED_DOCUMENTS_MESSAGE_QUEUE_NAME"), durable: true).bind(exch, routing_key: "*.*")
   end
 
   desc "Listens to and processes messages from the published documents queue"

--- a/spec/lib/tasks/document_sync_worker_spec.rb
+++ b/spec/lib/tasks/document_sync_worker_spec.rb
@@ -100,10 +100,10 @@ RSpec.describe "Document synchronisation tasks" do
           name = ENV.fetch("PUBLISHED_DOCUMENTS_MESSAGE_QUEUE_NAME")
           queue = instance_double(Bunny::Queue, name: name, bind: nil)
 
-          allow(channel).to receive(:queue).with(name).and_return(queue)
+          allow(channel).to receive(:queue).with(name, anything).and_return(queue)
 
           Rake::Task[task_name].invoke
-          expect(channel).to have_received(:queue).with(name)
+          expect(channel).to have_received(:queue).with(name, durable: true)
           expect(queue).to have_received(:bind).with(exchange, routing_key: "*.*")
         end
       end


### PR DESCRIPTION
Modern versions of RabbitMQ do not allow queues that are not durable and not exclusive. This change ensures that the queues we define are now all durable to fix this issue.

We also ensure we only create each queue once and then bind two exchanges

This fixes an error when make-ing the search-api-v2 in govuk-docker