### PR TITLE
[SCH-2077] Add best bets for GOV.UK chat

### DIFF
--- a/config/best_bets.yml
+++ b/config/best_bets.yml
@@ -39,6 +39,8 @@ shared:
   "evacuation": /government/news/foreign-office-travel-advice-updates
   "middle east": /government/news/foreign-office-travel-advice-updates
   "doha": /foreign-travel-advice/qatar
+  "chat": /guidance/download-the-govuk-app
+  "gov.uk chat": /guidance/download-the-govuk-app
 
 test:
   "i want to test a single best bet": /here/you/go


### PR DESCRIPTION
There is expected to be press on Monday regarding GOV.UK chat. Adding two best bets so that users are offered the GOV.UK app as a search result.

Additionally, Simon Hughesdon has let us know that Martin Lewis may talk about GOV.UK chat in the GOV.UK app on his next show (Tuesday 12th May) which may drive people to search for GOV.UK chat on site search. 

Previously, searches for ‘chat’ and ‘gov.uk chat' did not bring up the [GOV.UK app page](https://www.gov.uk/guidance/download-the-govuk-app). This is probably because this page did not mention GOV.UK chat.

The chat team have now updated the GOV.UK app page to include information about GOV.UK chat. Now searching for `GOV.UK chat` or `gov.uk chat` returns the GOV.UK app page on page 2 of results. For `"chat"` or `"Chat"` it's page 77 or 78. But for `chat` without quotes it's not in the first 500 results. So it's likely that the page is not being retrieved for plain `chat` queries. 

See [Jira ticket SCH-2077](https://gov-uk.atlassian.net/browse/SCH-2077).