### PR TITLE
Update naming from Vertex to Agent Search

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # search-api-v2
-API and synchronisation worker for general site search on GOV.UK
+API and synchronisation worker for general site search on GOV.UK.
 
-This application powers the new site search for GOV.UK using Google Cloud Platform (GCP)'s [Vertex
-AI Search][vertex-docs] ("Discovery Engine") product as its underlying search engine. It provides
+This application powers the new site search for GOV.UK using Google Cloud Platform (GCP)'s [Agent
+Search][agent-search-docs] ("Discovery Engine") product as its underlying search engine. It provides
 two core pieces of functionality:
 - An API that is "minimally compatible" with the existing `search-api` REST interface to the extent
   necessary to power the ["site search" (`/search/all`) finder][search-all-finder].
 - A synchonisation worker that receives content updates from the Publishing API message queue and
-  updates the Discovery Engine dataset accordingly
+  updates the Discovery Engine dataset accordingly.
 
 ## Local development
 The official way of running this application locally is through [GOV.UK Docker][govuk-docker], where
@@ -29,7 +29,7 @@ make search-api-v2
 #### Prerequisites
 
 1. You must be a member of the integration gcp access google group: govuk-gcp-access-integration@digital.cabinet-office.gov.uk
-2. You will need the email address of the custom search-api-v2 integration service account. This is the service account used by Search API v2 running in integration to authenticate its requests to Google Vertex AI Search.
+2. You will need the email address of the custom search-api-v2 integration service account. This is the service account used by Search API v2 running in integration to authenticate its requests to Discovery Engine.
 
 The email address can be found under *IAM and admin > Service Accounts* in the __Search API V2 Integration__ project at https://console.cloud.google.com.
 
@@ -101,14 +101,14 @@ time being, it is intentionally not a complete replacement for [Search API][sear
 See [Search API compatibility](docs/search_api_compatibility.md) for more information about our
 compatibility design choices.
 
-## "Vertex" vs "Discovery Engine"
-The marketing name of the search product we use (_Google Vertex AI Search and Conversation_) has
-undergone several changes while this application was first developed, and some concepts have
-different naming in the Google Cloud Platform UI compared to the actual underlying APIs themselves.
+## "Agent Search" vs "Discovery Engine"
+The marketing name of the search product we use (_Google Cloud Agent Search_) has
+undergone several changes since this application was first developed, and some concepts have
+different naming in the Google Cloud Platform UI compared to the actual underlying APIs.
 
-We have chosen to exclusively use the more stable API naming (_Discovery Engine_, _engine_ instead
+We prefer to use the more stable API naming (_Discovery Engine_, _engine_ instead
 of _app_, etc.) throughout the codebase and documentation to avoid having to rename things as the
-product reached general availability, but you may see the terms "Vertex" or "Vertex Search" as well
+product reached general availability, but you may see the terms "Agent Search" as well
 as some other marketing terms used in some project artefacts.
 
 ## Related projects
@@ -121,7 +121,7 @@ as some other marketing terms used in some project artefacts.
       Engine including cloud resources and event ingestion for continuous training of the search
       engine
 
-[vertex-docs]: https://cloud.google.com/generative-ai-app-builder/docs/introduction
+[agent-search-docs]: https://cloud.google.com/generative-ai-app-builder/docs/introduction
 [search-all-finder]: https://www.gov.uk/search/all
 [govuk-docker]: https://github.com/alphagov/govuk-docker
 [env]: https://github.com/alphagov/govuk-docker/blob/main/projects/search-api-v2/docker-compose.yml

--- a/app/models/concerns/publishing_api/metadata.rb
+++ b/app/models/concerns/publishing_api/metadata.rb
@@ -40,7 +40,7 @@ module PublishingApi
         document_type: document_hash[:document_type],
         content_purpose_supergroup: document_hash[:content_purpose_supergroup],
         part_of_taxonomy_tree:,
-        # Vertex can only currently boost on numeric fields, not booleans
+        # Discovery Engine can only currently boost on numeric fields, not booleans
         is_historic: historic? ? 1 : 0,
         government_name:,
         organisation_state:,

--- a/app/services/discovery_engine/query/search.rb
+++ b/app/services/discovery_engine/query/search.rb
@@ -90,7 +90,7 @@ module DiscoveryEngine::Query
         DEFAULT_ORDER_BY
       else
         # This helps us spot clients that are sending unexpected values and probably should continue
-        # to use the previoius search-api instead of this API.
+        # to use the previous search-api instead of this API.
         Rails.logger.warn("Unexpected order_by value: #{query_params[:order].inspect}")
         DEFAULT_ORDER_BY
       end
@@ -110,7 +110,7 @@ module DiscoveryEngine::Query
     end
 
     def news_recency_boost_specs
-      # Since we first created `NewsRecencyBoost`, Vertex AI Search has gained the equivalent
+      # Since we first created `NewsRecencyBoost`, Discovery Engine has gained the equivalent
       # functionality natively. As of Mar 2025, we are AB testing this new feature on the `variant`
       # serving configuration, so we do not want to apply our custom boost if that is the serving
       # config used for the current search, as it would cause content to be boosted twice.

--- a/app/services/metrics/exported.rb
+++ b/app/services/metrics/exported.rb
@@ -18,17 +18,17 @@ module Metrics
         "total time taken to process an incoming message from Publishing API (seconds)",
         buckets: [0.1, 0.5, 1, 2, 5],
       ),
-      ### VAIS response duration histograms
+      ### Discovery Engine (perviously marketed as "Vertex AI Search") response duration histograms
       vertex_search_request_duration: CLIENT.register(
         :histogram,
         "search_api_v2_vertex_search_request_duration",
-        "total time taken for google vertex to respond to a search request (seconds)",
+        "total time taken for google cloud discovery engine to respond to a search request (seconds)",
         buckets: [0.1, 0.5, 1, 2, 5],
       ),
       vertex_autocomplete_request_duration: CLIENT.register(
         :histogram,
         "search_api_v2_vertex_autocomplete_request_duration",
-        "total time taken for google vertex to respond to an autocomplete request (seconds)",
+        "total time taken for google cloud discovery engine to respond to an autocomplete request (seconds)",
         buckets: [0.1, 0.5, 1, 2, 5],
       ),
       search_controller_request_duration: CLIENT.register(

--- a/docs/openapi/specification.yml
+++ b/docs/openapi/specification.yml
@@ -475,7 +475,7 @@ components:
             The suggested query text with highlighting.
 
             Note that this is always just the entire `text` property wrapped in `<mark>` tags as
-            Vertex AI Search does not provide highlighting for individual parts of the query.
+            Discovery Engine does not provide highlighting for individual parts of the query.
           example: "<mark>driving test</mark>"
 
     AutocompleteResponse:

--- a/docs/search_autocomplete.md
+++ b/docs/search_autocomplete.md
@@ -1,5 +1,5 @@
 # Search autocomplete
-We use Vertex AI Search's [built-in autocomplete functionality][vais-ac] to provide our users with
+We use Discovery Engine's [built-in autocomplete functionality][discovery-engine-ac] to provide our users with
 helpful suggestions to complete their query as they type in search fields.
 
 Search API v2 provides an API to return suggestions, which the [`search_with_autocomplete`
@@ -31,6 +31,6 @@ This will cause an empty array of suggestions to be returned to all clients (web
 
 [component]: https://components.publishing.service.gov.uk/component-guide/search_with_autocomplete
 [ff-proxy]: https://github.com/alphagov/finder-frontend/blob/main/app/controllers/api/autocompletes_controller.rb
-[vais-ac]: https://cloud.google.com/generative-ai-app-builder/docs/configure-autocomplete
+[discovery-engine-ac]: https://cloud.google.com/generative-ai-app-builder/docs/configure-autocomplete
 [values-production.yaml]: https://github.com/alphagov/govuk-helm-charts/blob/main/charts/app-config/values-production.yaml
 [search-admin-denylist]: https://search-admin.publishing.service.gov.uk/completion_denylist_entries


### PR DESCRIPTION
Google have rebranded Vertex AI Search to Agent Search, so we need to update the marketing name in the docs.

We are also changing some of the internal documentation to use "Discovery Engine", which is the more stable API name, to avoid future re-namings and because it should be a more familiar name for developers.

Jira ticket: https://gov-uk.atlassian.net/browse/SCH-2050