### PR TITLE
Handle autocomplete timeouts

### DIFF
--- a/app/services/discovery_engine/autocomplete/complete.rb
+++ b/app/services/discovery_engine/autocomplete/complete.rb
@@ -30,7 +30,7 @@ module DiscoveryEngine::Autocomplete
       rescue Google::Cloud::DeadlineExceededError, Google::Cloud::InternalError => e
         Rails.logger.warn("#{self.class.name}: Did not get autocomplete suggestion: '#{e.message}'")
 
-        raise DiscoveryEngine::InternalError
+        []
       end
     end
 

--- a/spec/services/discovery_engine/autocomplete/complete_spec.rb
+++ b/spec/services/discovery_engine/autocomplete/complete_spec.rb
@@ -65,8 +65,8 @@ RSpec.describe DiscoveryEngine::Autocomplete::Complete do
       context "and the error is a Google::Cloud::DeadlineExceededError" do
         let(:error) { Google::Cloud::DeadlineExceededError.new("Deadline error") }
 
-        it "raises an error and logs it to the Rails logger" do
-          expect { completion_result }.to raise_error(DiscoveryEngine::InternalError)
+        it "logs it to the Rails logger and returns an empty array" do
+          expect(completion_result.suggestions).to eq([])
 
           expect(Rails.logger).to have_received(:warn).with(
             "DiscoveryEngine::Autocomplete::Complete: Did not get autocomplete suggestion: 'Deadline error'",
@@ -77,8 +77,8 @@ RSpec.describe DiscoveryEngine::Autocomplete::Complete do
       context "and the error is a Google::Cloud::InternalError" do
         let(:error) { Google::Cloud::InternalError.new("Internal error") }
 
-        it "raises an error and logs it only to the Rails logger" do
-          expect { completion_result }.to raise_error(DiscoveryEngine::InternalError)
+        it "logs it to the Rails logger and returns an empty array" do
+          expect(completion_result.suggestions).to eq([])
 
           expect(Rails.logger).to have_received(:warn).with(
             "DiscoveryEngine::Autocomplete::Complete: Did not get autocomplete suggestion: 'Internal error'",


### PR DESCRIPTION
We should return an empty array of suggestions when the autocomplete client times out or has an internal error to minimise the impact on the end users.

Jira ticket: https://gov-uk.atlassian.net/browse/SCH-2094