### PR TITLE
Sch 2142 record number of autocomplete suggestions returned

### DIFF
--- a/app/services/discovery_engine/autocomplete/complete.rb
+++ b/app/services/discovery_engine/autocomplete/complete.rb
@@ -25,13 +25,14 @@ module DiscoveryEngine::Autocomplete
               .completion_service
               .complete_query(complete_query_request)
           end
-
-        response.query_suggestions.map(&:suggestion)
+        suggestions = response.query_suggestions.map(&:suggestion)
       rescue Google::Cloud::DeadlineExceededError, Google::Cloud::InternalError => e
         Rails.logger.warn("#{self.class.name}: Did not get autocomplete suggestion: '#{e.message}'")
-
-        []
+        suggestions = []
       end
+
+      Metrics::Exported.observe_count(:discovery_engine_autocomplete_suggestions_response, suggestions.size)
+      suggestions
     end
 
     def complete_query_request

--- a/app/services/discovery_engine/autocomplete/complete.rb
+++ b/app/services/discovery_engine/autocomplete/complete.rb
@@ -26,6 +26,7 @@ module DiscoveryEngine::Autocomplete
               .complete_query(complete_query_request)
           end
         suggestions = response.query_suggestions.map(&:suggestion)
+        Rails.logger.warn("Completion service did not return any autocomplete suggestions") if suggestions.empty?
       rescue Google::Cloud::DeadlineExceededError, Google::Cloud::InternalError => e
         Rails.logger.warn("#{self.class.name}: Did not get autocomplete suggestion: '#{e.message}'")
         suggestions = []

--- a/app/services/metrics/exported.rb
+++ b/app/services/metrics/exported.rb
@@ -10,7 +10,15 @@ module Metrics
         labels: %i[action],
       ),
     }.freeze
-    HISTOGRAMS = {
+    COUNTER_HISTOGRAMS = {
+      discovery_engine_autocomplete_suggestions_response: CLIENT.register(
+        :histogram,
+        "search_api_v2_discovery_engine_autocomplete_suggestions_response",
+        "number of autocomplete suggestions returned by discovery engine",
+        buckets: [0, 1, 2, 3, 4, 5],
+      ),
+    }.freeze
+    DURATION_HISTOGRAMS = {
       ### Syncing histograms
       total_processing_duration: CLIENT.register(
         :histogram,
@@ -47,8 +55,16 @@ module Metrics
       # Metrics are best effort only, don't raise if they fail
     end
 
+    def self.observe_count(histogram, count, labels = {})
+      Rails.logger.warn("Unknown histogram: #{histogram}") and return unless COUNTER_HISTOGRAMS.key?(histogram)
+
+      COUNTER_HISTOGRAMS[histogram].observe(count, labels)
+    rescue StandardError
+      # Metrics are best effort only, don't raise if they fail
+    end
+
     def self.observe_duration(histogram, labels = {}, &block)
-      unless HISTOGRAMS.key?(histogram)
+      unless DURATION_HISTOGRAMS.key?(histogram)
         Rails.logger.warn("Unknown histogram: #{histogram}")
         return block.call
       end
@@ -59,7 +75,7 @@ module Metrics
       end
 
       begin
-        HISTOGRAMS[histogram].observe(duration, labels)
+        DURATION_HISTOGRAMS[histogram].observe(duration, labels)
       rescue StandardError
         # Metrics are best effort only, don't raise if they fail
       end

--- a/spec/services/discovery_engine/autocomplete/complete_spec.rb
+++ b/spec/services/discovery_engine/autocomplete/complete_spec.rb
@@ -8,6 +8,9 @@ RSpec.describe DiscoveryEngine::Autocomplete::Complete do
     allow(Metrics::Exported)
       .to receive(:observe_duration)
       .and_call_original
+    allow(Metrics::Exported)
+      .to receive(:observe_count)
+      .and_call_original
   end
 
   describe "#completion_result" do
@@ -39,12 +42,26 @@ RSpec.describe DiscoveryEngine::Autocomplete::Complete do
         .with(:vertex_autocomplete_request_duration)
     end
 
+    it "logs the number of autocomplete suggestions" do
+      completion_result
+
+      expect(Metrics::Exported)
+        .to have_received(:observe_count)
+        .with(:discovery_engine_autocomplete_suggestions_response, 3)
+    end
+
     context "when the query is empty" do
       let(:query) { "" }
 
       it "returns an empty array and does not make a request" do
         expect(completion_result.suggestions).to eq([])
         expect(client).not_to have_received(:complete_query)
+      end
+
+      it "doesn't log the number of autocomplete suggestions" do
+        completion_result
+
+        expect(Metrics::Exported).not_to have_received(:observe_count)
       end
     end
 
@@ -72,6 +89,14 @@ RSpec.describe DiscoveryEngine::Autocomplete::Complete do
             "DiscoveryEngine::Autocomplete::Complete: Did not get autocomplete suggestion: 'Deadline error'",
           )
         end
+
+        it "logs that zero autocomplete suggestions were returned" do
+          completion_result
+
+          expect(Metrics::Exported)
+            .to have_received(:observe_count)
+            .with(:discovery_engine_autocomplete_suggestions_response, 0)
+        end
       end
 
       context "and the error is a Google::Cloud::InternalError" do
@@ -83,6 +108,14 @@ RSpec.describe DiscoveryEngine::Autocomplete::Complete do
           expect(Rails.logger).to have_received(:warn).with(
             "DiscoveryEngine::Autocomplete::Complete: Did not get autocomplete suggestion: 'Internal error'",
           )
+        end
+
+        it "logs that zero autocomplete suggestions were returned" do
+          completion_result
+
+          expect(Metrics::Exported)
+            .to have_received(:observe_count)
+            .with(:discovery_engine_autocomplete_suggestions_response, 0)
         end
       end
     end

--- a/spec/services/metrics/exported_spec.rb
+++ b/spec/services/metrics/exported_spec.rb
@@ -23,11 +23,36 @@ RSpec.describe Metrics::Exported do
     end
   end
 
+  describe ".observe_count" do
+    let(:histogram) { double(observe: nil) }
+    let(:count) { 3 }
+
+    before do
+      stub_const("Metrics::Exported::COUNTER_HISTOGRAMS", { foo: histogram })
+    end
+
+    it "observes the passed in count for the given histogram with the given labels" do
+      described_class.observe_count(:foo, :count, bar: "baz")
+
+      expect(histogram).to have_received(:observe).with(:count, bar: "baz")
+    end
+
+    it "fails gracefully if the histogram does not exist" do
+      expect { described_class.observe_count(:bar, :count) }.not_to raise_error
+    end
+
+    it "fails gracefully if the operation raises an error" do
+      allow(histogram).to receive(:observe).and_raise("boom")
+
+      expect { described_class.observe_count(:foo, :count) }.not_to raise_error
+    end
+  end
+
   describe ".observe_duration" do
     let(:histogram) { double(observe: nil) }
 
     before do
-      stub_const("Metrics::Exported::HISTOGRAMS", { foo: histogram })
+      stub_const("Metrics::Exported::DURATION_HISTOGRAMS", { foo: histogram })
     end
 
     it "observes the duration of the given block for the given histogram with the given labels" do

--- a/spec/services/metrics/exported_spec.rb
+++ b/spec/services/metrics/exported_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe Metrics::Exported do
     it "fails gracefully if the operation raises an error" do
       allow(histogram).to receive(:observe).and_raise("boom")
 
-      expect(described_class.observe_duration(:bar) { "result" }).to eq("result")
+      expect(described_class.observe_duration(:foo) { "result" }).to eq("result")
     end
   end
 end


### PR DESCRIPTION
We want to add a histogram metric in Prometheus that records the number of autocomplete suggestions returned by GCP, so that we can create an alert when this number drops to zero.

Jira ticket: https://gov-uk.atlassian.net/browse/SCH-2142