### PR TITLE
Remove logging for empty autocomplete response

### DIFF
--- a/app/services/discovery_engine/autocomplete/complete.rb
+++ b/app/services/discovery_engine/autocomplete/complete.rb
@@ -26,7 +26,6 @@ module DiscoveryEngine::Autocomplete
               .complete_query(complete_query_request)
           end
         suggestions = response.query_suggestions.map(&:suggestion)
-        Rails.logger.warn("Completion service did not return any autocomplete suggestions") if suggestions.empty?
       rescue Google::Cloud::DeadlineExceededError, Google::Cloud::InternalError => e
         Rails.logger.warn("#{self.class.name}: Did not get autocomplete suggestion: '#{e.message}'")
         suggestions = []


### PR DESCRIPTION
Reverts https://github.com/alphagov/search-api-v2/commit/f68f2122f15020b92a3212edc1c99750a8f3fe88

Even when the service is healthy, this line is logging ~1500 lines every minute, making it both expensive and unhelpful in the event of an issue.