### PR TITLE
Exclude documents with a type of content_block_*

### DIFF
--- a/config/document_type_ignorelist.yml
+++ b/config/document_type_ignorelist.yml
@@ -6,6 +6,7 @@
 shared:
   - !ruby/regexp /^placeholder/ # any placeholder type
   - completed_transaction
+  - !ruby/regexp /^content_block/
   - email_alert_signup
   - embassies_index
   - facet


### PR DESCRIPTION
content_block_* document types, such as content_block_tax, content_block_contact are currently being added to discovery engine and surfacing in search results. However these pieces of content do not have a rendering application, so clicking on the search result raises a 404.

https://www.gov.uk/api/content/content-blocks/content_block_contact/universal-credit-helpline https://www.gov.uk/content-blocks/content_block_contact/universal-credit-helpline

Jira: https://gov-uk.atlassian.net/browse/SCH-2150