### PR TITLE
Move rescue_from DiscoveryEngine::InternalError

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,12 +1,7 @@
 class ApplicationController < ActionController::API
-  rescue_from DiscoveryEngine::InternalError, with: :render_internal_error
   rescue_from ActionController::BadRequest, with: :render_bad_request
 
 private
-
-  def render_internal_error
-    render json: { "error": "Internal server error" }, status: :internal_server_error
-  end
 
   def render_bad_request(exception)
     render json: { "error": exception.message }, status: :bad_request

--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -1,4 +1,5 @@
 class SearchesController < ApplicationController
+  rescue_from DiscoveryEngine::InternalError, with: :render_internal_error
   before_action :validate_query_params, only: :show
 
   def show
@@ -15,5 +16,9 @@ private
 
   def validate_query_params
     raise ActionController::BadRequest, "Invalid query parameter" unless params.fetch(:q, "").is_a?(String)
+  end
+
+  def render_internal_error
+    render json: { "error": "Internal server error" }, status: :internal_server_error
   end
 end

--- a/spec/requests/autocomplete_request_spec.rb
+++ b/spec/requests/autocomplete_request_spec.rb
@@ -33,16 +33,16 @@ RSpec.describe "Making an autocomplete request" do
     end
   end
 
-  context "when autocomplete returns a DiscoveryEngine::InternalError" do
-    before do
-      allow(DiscoveryEngine::Autocomplete::Complete).to receive(:new)
-        .and_raise(DiscoveryEngine::InternalError)
-    end
+  context "when autocomplete returns zero suggestions" do
+    let(:completion_result) { CompletionResult.new(suggestions: []) }
 
-    it "returns a 500 response" do
+    it "returns empty suggestions" do
       get "/autocomplete.json?q=foo"
 
-      expect(response).to have_http_status(:internal_server_error)
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body)).to eq({
+        "suggestions" => [],
+      })
     end
   end
 end


### PR DESCRIPTION
Move rescue_from DiscoveryEngine::InternalError from the application controller to the searches controller. Now that autocomplete will no longer raise DiscoveryEngine::InternalError when the autocomplete request to GCP times out or errors [1], this error handling is no longer required in the autocomplete controller.

[1] https://github.com/alphagov/search-api-v2/pull/677