### PR TITLE
Sch 2054 align histogram buckets

### DIFF
--- a/app/services/discovery_engine/autocomplete/complete.rb
+++ b/app/services/discovery_engine/autocomplete/complete.rb
@@ -20,7 +20,7 @@ module DiscoveryEngine::Autocomplete
 
       begin
         response =
-          Metrics::Exported.observe_duration(:vertex_autocomplete_request_duration) do
+          Metrics::Exported.observe_duration(:discovery_engine_autocomplete_request_duration) do
             DiscoveryEngine::Clients
               .completion_service
               .complete_query(complete_query_request)

--- a/app/services/discovery_engine/query/search.rb
+++ b/app/services/discovery_engine/query/search.rb
@@ -31,7 +31,7 @@ module DiscoveryEngine::Query
     def response
       @response ||= begin
         search_result =
-          Metrics::Exported.observe_duration(:vertex_search_request_duration) do
+          Metrics::Exported.observe_duration(:discovery_engine_search_request_duration) do
             DiscoveryEngine::Clients.search_service.search(discovery_engine_params)
           end
 

--- a/app/services/metrics/exported.rb
+++ b/app/services/metrics/exported.rb
@@ -26,12 +26,11 @@ module Metrics
         "total time taken to process an incoming message from Publishing API (seconds)",
         buckets: [0.1, 0.5, 1, 2, 5],
       ),
-      ### Discovery Engine (perviously marketed as "Vertex AI Search") response duration histograms
-      vertex_search_request_duration: CLIENT.register(
+      ### Discovery Engine response duration histograms
+      discovery_engine_search_request_duration: CLIENT.register(
         :histogram,
-        "search_api_v2_vertex_search_request_duration",
+        "search_api_v2_discovery_engine_search_request_duration",
         "total time taken for google cloud discovery engine to respond to a search request (seconds)",
-        buckets: [0.1, 0.5, 1, 2, 5],
       ),
       vertex_autocomplete_request_duration: CLIENT.register(
         :histogram,

--- a/app/services/metrics/exported.rb
+++ b/app/services/metrics/exported.rb
@@ -32,11 +32,10 @@ module Metrics
         "search_api_v2_discovery_engine_search_request_duration",
         "total time taken for google cloud discovery engine to respond to a search request (seconds)",
       ),
-      vertex_autocomplete_request_duration: CLIENT.register(
+      discovery_engine_autocomplete_request_duration: CLIENT.register(
         :histogram,
-        "search_api_v2_vertex_autocomplete_request_duration",
+        "search_api_v2_discovery_engine_autocomplete_request_duration",
         "total time taken for google cloud discovery engine to respond to an autocomplete request (seconds)",
-        buckets: [0.1, 0.5, 1, 2, 5],
       ),
       search_controller_request_duration: CLIENT.register(
         :histogram,

--- a/spec/services/discovery_engine/autocomplete/complete_spec.rb
+++ b/spec/services/discovery_engine/autocomplete/complete_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe DiscoveryEngine::Autocomplete::Complete do
 
       expect(Metrics::Exported)
         .to have_received(:observe_duration)
-        .with(:vertex_autocomplete_request_duration)
+        .with(:discovery_engine_autocomplete_request_duration)
     end
 
     it "logs the number of autocomplete suggestions" do

--- a/spec/services/discovery_engine/query/search_spec.rb
+++ b/spec/services/discovery_engine/query/search_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe DiscoveryEngine::Query::Search do
       it "logs the request duration" do
         expect(Metrics::Exported)
           .to have_received(:observe_duration)
-          .with(:vertex_search_request_duration)
+          .with(:discovery_engine_search_request_duration)
       end
 
       context "when start and count are specified" do


### PR DESCRIPTION
Updates search and autocomplete request duration metrics

Removes specified buckets so that we use the [default set in govuk_app_config](https://github.com/alphagov/govuk_app_config/blob/main/lib/govuk_app_config/govuk_prometheus_exporter.rb#L38). This is so that the buckets are the same as those used to record `http_request_duration_seconds_bucket` so we can do an apples-to-apples comparison between them.

We also update the name of the metrics to refer to Discovery Engine instead of Vertex, since Vertex has been rebranded to Agent Search. We use the name Discovery Engine because this is the name for the API, which historically changes less frequently.

Jira ticket: https://gov-uk.atlassian.net/browse/SCH-2054