### PR TITLE
Add min and max start for search request

### DIFF
--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -16,6 +16,12 @@ private
 
   def validate_query_params
     raise ActionController::BadRequest, "Invalid query parameter" unless params.fetch(:q, "").is_a?(String)
+
+    max_start = DiscoveryEngine::Query::Search::MAX_RESULTS_VALUE
+    start = params.fetch(:start, 0).to_i
+    if start.negative? || start > max_start
+      raise ActionController::BadRequest, "Invalid start value"
+    end
   end
 
   def render_internal_error

--- a/app/services/discovery_engine/query/search.rb
+++ b/app/services/discovery_engine/query/search.rb
@@ -3,6 +3,7 @@ module DiscoveryEngine::Query
     DEFAULT_PAGE_SIZE = 10
     DEFAULT_OFFSET = 0
     DEFAULT_ORDER_BY = nil # not specifying an order_by means the results are ordered by relevance
+    MAX_RESULTS_VALUE = 2_147_483_647
 
     def initialize(
       query_params,

--- a/spec/requests/search_request_spec.rb
+++ b/spec/requests/search_request_spec.rb
@@ -46,6 +46,20 @@ RSpec.describe "Making a search request" do
       expect(JSON.parse(response.body)).to eq("error" => "Invalid query parameter")
     end
 
+    it "returns a bad request if the start parameter is negative" do
+      get "/search.json?start=-1"
+
+      expect(response).to have_http_status(:bad_request)
+      expect(JSON.parse(response.body)).to eq("error" => "Invalid start value")
+    end
+
+    it "returns a bad request if the start parameter is too large" do
+      get "/search.json?start=2_147_483_648"
+
+      expect(response).to have_http_status(:bad_request)
+      expect(JSON.parse(response.body)).to eq("error" => "Invalid start value")
+    end
+
     it "logs the request duration" do
       get "/search.json"
 


### PR DESCRIPTION
Discovery Engine requires the "offset" parameter in the search request to be between 0 and 2,147,483,647 (max signed int 32). If it is more than this, Discovery Engine returns a RangeError. If it is less than this, Discovery Engine returns an INVALID_ARGUMENT error [1].

This change adds validation to the "start" parameter in the request (which is later translated to the "offset" field for Discovery Engine), to check it is within the valid range. If not, we return a BadRequest.

[1] https://docs.cloud.google.com/ruby/docs/reference/google-cloud-discovery_engine-v1/latest/Google-Cloud-DiscoveryEngine-V1-SearchRequest#Google__Cloud__DiscoveryEngine__V1__SearchRequest_offset_instance_